### PR TITLE
Parens not added when joining on CTE

### DIFF
--- a/integration_test/cases/joins.exs
+++ b/integration_test/cases/joins.exs
@@ -77,6 +77,26 @@ defmodule Ecto.Integration.JoinsTest do
     assert [{^p1, ^c1}, {^p2, ^c1}] = TestRepo.all(query)
   end
 
+  test "join with cte" do
+    p1 = TestRepo.insert!(%Post{title: "1"})
+    p2 = TestRepo.insert!(%Post{title: "2"})
+
+    p1_id = p1.id
+
+    query =
+      from(p in Post,
+        join:
+          c in fragment(
+            "WITH bogus AS (SELECT ? as temp) SELECT temp as post_id FROM bogus",
+            ^p1_id
+          ),
+        on: c.post_id == p.id,
+        select: {p}
+      )
+
+    assert [{^p1}] = TestRepo.all(query)
+  end
+
   test "named joins" do
     _p = TestRepo.insert!(%Post{title: "1"})
     p2 = TestRepo.insert!(%Post{title: "2"})

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -413,7 +413,7 @@ if Code.ensure_loaded?(Mariaex) do
     defp operator_to_boolean(:or), do: " OR "
 
     defp parens_for_select([first_expr | _] = expr) do
-      if is_binary(first_expr) and String.starts_with?(first_expr, ["SELECT", "select"]) do
+      if is_binary(first_expr) and String.starts_with?(first_expr, ["SELECT", "select", "WITH", "with"]) do
         [?(, expr, ?)]
       else
         expr

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -457,7 +457,7 @@ if Code.ensure_loaded?(Postgrex) do
     defp operator_to_boolean(:or), do: " OR "
 
     defp parens_for_select([first_expr | _] = expr) do
-      if is_binary(first_expr) and String.starts_with?(first_expr, ["SELECT", "select"]) do
+      if is_binary(first_expr) and String.starts_with?(first_expr, ["SELECT", "select", "WITH", "with"]) do
         [?(, expr, ?)]
       else
         expr


### PR DESCRIPTION
I tried out Ecto 3, a test in the app failed on a join with a Common Table Expression. When joining on a CTE, parens were not added, triggering an error from mariadb

> ** (Mariaex.Error) (1064): You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'bogus AS (SELECT ? as temp) SELECT temp as post_id FROM bogus AS f1 ON f1.`post_' at line 1

This used to work on Ecto 2. See this PR for a reproduction.

I've added a possible fix by adding parens when the join expressions starts with the words `with` or `WITH`. 

Of course this can also be fixed by adding the parens around the CTE like 
```
fragment("(WITH bogus AS (SELECT ? as temp) SELECT temp as post_id FROM bogus)", ^p1_id)
```

The mysql test fails on mysql 5.6 not supporting CTE's. Mariadb does since 10.2