### PR TITLE
Remove duplicate space between the module name and do

### DIFF
--- a/lib/ecto/adapter/structure.ex
+++ b/lib/ecto/adapter/structure.ex
@@ -1,4 +1,4 @@
-defmodule Ecto.Adapter.Structure  do
+defmodule Ecto.Adapter.Structure do
   @moduledoc """
   Specifies the adapter structure (dump/load) API.
   """


### PR DESCRIPTION
I usually look for modules using Ctrl + p and write: `ModuleName of` and I spent some time looking for` Structure`, this PR corrects duplicate space. :+1: 