### PR TITLE
Add :auto_increment to MySQL

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -761,8 +761,12 @@ if Code.ensure_loaded?(Mariaex) do
     defp column_options(opts) do
       default = Keyword.fetch(opts, :default)
       null    = Keyword.get(opts, :null)
-      [default_expr(default), null_expr(null)]
+      auto_increment = Keyword.get(opts, :auto_increment)
+      [default_expr(default), null_expr(null), auto_increment_expr(auto_increment)]
     end
+
+    defp auto_increment_expr(true), do: " auto_increment"
+    defp auto_increment_expr(_), do: []
 
     defp null_expr(false), do: " NOT NULL"
     defp null_expr(true), do: " NULL"

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -831,6 +831,13 @@ defmodule Ecto.Adapters.MySQLTest do
            [~s|CREATE TABLE `posts` (`id` bigint unsigned not null auto_increment, PRIMARY KEY (`id`)) ENGINE = MYISAM|]
   end
 
+  test "create table with a auto_increment column" do
+    create = {:create, table(:posts, primary_key: false),
+               [{:add, :id, :id, [null: false, auto_increment: true, primary_key: true]}]}
+    assert execute_ddl(create) ==
+           [~s|CREATE TABLE `posts` (`id` integer NOT NULL auto_increment, PRIMARY KEY (`id`)) ENGINE = INNODB|]
+  end
+
   test "create table with references" do
     create = {:create, table(:posts),
                [{:add, :id, :serial, [primary_key: true]},


### PR DESCRIPTION
I have to deal with old-style schema, which uses `integer not null auto_increment` column for primary key. Couldn't find a way to do this.

For new project, better to use `:serial` or `:bigserial` though.