### PR TITLE
Correct @spec in Mix.EctoSQL

### DIFF
--- a/lib/mix/ecto_sql.ex
+++ b/lib/mix/ecto_sql.ex
@@ -39,7 +39,7 @@ defmodule Mix.EctoSQL do
   @doc """
   Ensures the given repository's migrations path exists on the file system.
   """
-  @spec ensure_migrations_path(Ecto.Repo.t) :: Ecto.Repo.t
+  @spec ensure_migrations_path(Ecto.Repo.t) :: String.t
   def ensure_migrations_path(repo) do
     path = Path.join(source_repo_priv(repo), "migrations")
 


### PR DESCRIPTION
https://github.com/elixir-ecto/ecto_sql/commit/5d49262aa1c5a9d5cba70fc7a3cc241001f6ccf7 changed the value returned by `Mix.EctoSQL.ensure_migrations_path/1`. It now returns the migrations path instead of the repo.

cc @josevalim 