### PR TITLE
Support Ecto.Query in insert_all values

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -183,6 +183,7 @@ if Code.ensure_loaded?(Mariaex) do
     end
 
     defp insert_all_value(nil), do: "DEFAULT"
+    defp insert_all_value({%Ecto.Query{} = query, _params}), do: [?(, all(query), ?)]
     defp insert_all_value(_),   do: '?'
 
     @impl true

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -183,7 +183,7 @@ if Code.ensure_loaded?(Mariaex) do
     end
 
     defp insert_all_value(nil), do: "DEFAULT"
-    defp insert_all_value({%Ecto.Query{} = query, _params}), do: [?(, all(query), ?)]
+    defp insert_all_value({%Ecto.Query{} = query, _params_counter}), do: [?(, all(query), ?)]
     defp insert_all_value(_),   do: '?'
 
     @impl true

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -207,8 +207,8 @@ if Code.ensure_loaded?(Postgrex) do
         nil, counter ->
           {"DEFAULT", counter}
 
-        {%Ecto.Query{} = query, params}, counter ->
-          {[?(, all(query), ?)], counter + length(params)}
+        {%Ecto.Query{} = query, params_counter}, counter ->
+          {[?(, all(query), ?)], counter + params_counter}
 
         _, counter ->
           {[?$ | Integer.to_string(counter)], counter + 1}

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -206,6 +206,10 @@ if Code.ensure_loaded?(Postgrex) do
       intersperse_reduce(values, ?,, counter, fn
         nil, counter ->
           {"DEFAULT", counter}
+
+        {%Ecto.Query{} = query, params}, counter ->
+          {[?(, all(query), ?)], counter + length(params)}
+
         _, counter ->
           {[?$ | Integer.to_string(counter)], counter + 1}
       end)

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -510,7 +510,12 @@ defmodule Ecto.Adapters.SQL do
     Enum.map_reduce rows, [], fn fields, params ->
       Enum.map_reduce header, params, fn key, acc ->
         case :lists.keyfind(key, 1, fields) do
-          {^key, value} -> {key, [value|acc]}
+          {^key, {%Ecto.Query{} = query, query_params}} ->
+            {{query, query_params}, Enum.reverse(query_params) ++ acc}
+
+          {^key, value} ->
+            {key, [value | acc]}
+
           false -> {nil, acc}
         end
       end

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -511,7 +511,7 @@ defmodule Ecto.Adapters.SQL do
       Enum.map_reduce header, params, fn key, acc ->
         case :lists.keyfind(key, 1, fields) do
           {^key, {%Ecto.Query{} = query, query_params}} ->
-            {{query, query_params}, Enum.reverse(query_params) ++ acc}
+            {{query, length(query_params)}, Enum.reverse(query_params) ++ acc}
 
           {^key, value} ->
             {key, [value | acc]}

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -756,6 +756,12 @@ defmodule Ecto.Adapters.MySQLTest do
     end
   end
 
+  test "insert with query" do
+    select_query = from("schema", select: [:id]) |> plan(:all)
+    query = insert(nil, "schema", [:x, :y, :z], [[:x, {select_query, 2}, :z], [nil, nil, {select_query, 1}]], {:raise, [], []}, [])
+    assert query == ~s{INSERT INTO `schema` (`x`,`y`,`z`) VALUES (?,(SELECT s0.`id` FROM `schema` AS s0),?),(DEFAULT,DEFAULT,(SELECT s0.`id` FROM `schema` AS s0))}
+  end
+
   test "update" do
     query = update(nil, "schema", [:id], [x: 1, y: 2], [])
     assert query == ~s{UPDATE `schema` SET `id` = ? WHERE `x` = ? AND `y` = ?}

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -922,6 +922,13 @@ defmodule Ecto.Adapters.PostgresTest do
     assert query == ~s{INSERT INTO "schema" ("x","y") VALUES ($1,$2) ON CONFLICT (\"id\") DO UPDATE SET "x" = EXCLUDED."x","y" = EXCLUDED."y"}
   end
 
+  test "insert with query" do
+    query = from("schema", select: [:id]) |> plan(:all)
+    query = insert(nil, "schema", [:x, :y, :z], [[:x, {query, 3}, :z], [nil, {query, 2}, :z]], {:raise, [], []}, [:id])
+
+    assert query == ~s{INSERT INTO "schema" ("x","y","z") VALUES ($1,(SELECT s0."id" FROM "schema" AS s0),$5),(DEFAULT,(SELECT s0."id" FROM "schema" AS s0),$8) RETURNING "id"}
+  end
+
   test "update" do
     query = update(nil, "schema", [:x, :y], [id: 1], [])
     assert query == ~s{UPDATE "schema" SET "x" = $1, "y" = $2 WHERE "id" = $3}


### PR DESCRIPTION
I would like to propose the feature to support select query as a value in `insert_all` (and maybe `update_all` later), which is supported by PostgreSQL. For example:

```ex
user_id_query = from(u in User, where: u.username == "bob", select: u.id)
Repo.insert_all(Comment, [[text: "Yo!", user_id: user_id_query]])
```

I was able to come up with a quick and dirty prototype to make this feature work. I can continue polishing this PR up  if this is accepted. Also some works would need to be done on `ecto` as well.

Thank you.