### PR TITLE
feat(Ecto.Migration.Runner): Support drop_if_exists for Ecto.Migratio…

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -689,6 +689,9 @@ if Code.ensure_loaded?(Mariaex) do
     def execute_ddl({:drop, %Constraint{}}),
       do: error!(nil, "MySQL adapter does not support constraints")
 
+    def execute_ddl({:drop_if_exists, %Constraint{}}),
+      do: error!(nil, "MySQL adapter does not support constraints")
+
     def execute_ddl({:drop_if_exists, %Index{}}),
       do: error!(nil, "MySQL adapter does not support drop if exists for index")
 

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -774,6 +774,11 @@ if Code.ensure_loaded?(Postgrex) do
         " DROP CONSTRAINT ", quote_name(constraint.name)]]
     end
 
+    def execute_ddl({:drop_if_exists, %Constraint{} = constraint}) do
+      [["ALTER TABLE ", quote_table(constraint.prefix, constraint.table),
+        " DROP CONSTRAINT IF EXISTS ", quote_name(constraint.name)]]
+    end
+
     def execute_ddl(string) when is_binary(string), do: [string]
 
     def execute_ddl(keyword) when is_list(keyword),

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -318,6 +318,8 @@ defmodule Ecto.Migration.Runner do
     do: "create exclude constraint #{constraint.name} on table #{quote_name(constraint.prefix, constraint.table)}"
   defp command({:drop, %Constraint{} = constraint}),
     do: "drop constraint #{constraint.name} from table #{quote_name(constraint.prefix, constraint.table)}"
+  defp command({:drop_if_exists, %Constraint{} = constraint}),
+    do: "drop constraint if exists #{constraint.name} from table #{quote_name(constraint.prefix, constraint.table)}"
 
   defp quote_name(nil, name), do: quote_name(name)
   defp quote_name(prefix, name), do: quote_name(prefix) <> "." <> quote_name(name)

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -998,6 +998,18 @@ defmodule Ecto.Adapters.MySQLTest do
     assert execute_ddl(drop) == [~s|DROP TABLE `foo`.`posts`|]
   end
 
+  test "drop constraint" do
+    assert_raise ArgumentError, ~r/MySQL adapter does not support constraints/, fn ->
+      execute_ddl({:drop, constraint(:products, "price_must_be_positive", prefix: :foo)})
+    end
+  end
+
+  test "drop_if_exists constraint" do
+    assert_raise ArgumentError, ~r/MySQL adapter does not support constraints/, fn ->
+      execute_ddl({:drop_if_exists, constraint(:products, "price_must_be_positive", prefix: :foo)})
+    end
+  end
+
   test "alter table" do
     alter = {:alter, table(:posts),
                [{:add, :title, :string, [default: "Untitled", size: 100, null: false]},

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1427,6 +1427,16 @@ defmodule Ecto.Adapters.PostgresTest do
       [~s|ALTER TABLE "foo"."products" DROP CONSTRAINT "price_must_be_positive"|]
   end
 
+  test "drop_if_exists constraint" do
+    drop = {:drop_if_exists, constraint(:products, "price_must_be_positive")}
+    assert execute_ddl(drop) ==
+      [~s|ALTER TABLE "products" DROP CONSTRAINT IF EXISTS "price_must_be_positive"|]
+
+    drop = {:drop_if_exists, constraint(:products, "price_must_be_positive", prefix: "foo")}
+    assert execute_ddl(drop) ==
+      [~s|ALTER TABLE "foo"."products" DROP CONSTRAINT IF EXISTS "price_must_be_positive"|]
+  end
+
   test "rename table" do
     rename = {:rename, table(:posts), table(:new_posts)}
     assert execute_ddl(rename) == [~s|ALTER TABLE "posts" RENAME TO "new_posts"|]

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -351,6 +351,12 @@ defmodule Ecto.MigrationTest do
     assert {:drop, %Constraint{}} = last_command()
   end
 
+  test "forward: drops a constraint if constraint exists" do
+    drop_if_exists constraint(:posts, :price)
+    flush()
+    assert {:drop_if_exists, %Constraint{}} = last_command()
+  end
+
   test "forward: renames a table" do
     result = rename(table(:posts), to: table(:new_posts))
     flush()
@@ -393,7 +399,7 @@ defmodule Ecto.MigrationTest do
 
     {_, table, _} = last_command()
     assert table.prefix == "foo"
-  end  
+  end
 
   @tag repo_config: [migration_default_prefix: "baz"]
   test "forward: create a table with prefix from configuration" do
@@ -663,6 +669,13 @@ defmodule Ecto.MigrationTest do
     drop index(:posts, [:title])
     flush()
     assert {:create, %Index{}} = last_command()
+  end
+
+  test "backward: drops a constraint" do
+    assert_raise Ecto.MigrationError, ~r/cannot reverse migration command/, fn ->
+      drop_if_exists constraint(:posts, :price)
+      flush()
+    end
   end
 
   test "backward: renames a table" do


### PR DESCRIPTION
…n.Constaints

@josevalim Adds support for dropping constraints if they exist. 

https://www.postgresql.org/docs/9.6/sql-altertable.html