### PR TITLE
Raise MySQL specific error instead of a FunctionClauseError

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -127,7 +127,7 @@ if Code.ensure_loaded?(Mariaex) do
     end
 
     @impl true
-    def delete_all(%{select: nil} = query) do
+    def delete_all(query) do
       if query.select do
         error!(nil, ":select is not supported in delete_all by MySQL")
       end

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -474,6 +474,11 @@ defmodule Ecto.Adapters.MySQLTest do
     assert update_all(query) ==
            ~s{UPDATE `schema` AS s0, `schema2` AS s1 } <>
            ~s{SET s0.`x` = 0 WHERE (s0.`x` = s1.`z`) AND (s0.`x` = 123)}
+
+    assert_raise ArgumentError, ":select is not supported in update_all by MySQL", fn ->
+      query = from(e in Schema, where: e.x == 123, select: e.x)
+      update_all(query)
+    end
   end
 
   test "update all with prefix" do
@@ -500,6 +505,11 @@ defmodule Ecto.Adapters.MySQLTest do
     assert delete_all(query) ==
            ~s{DELETE s0.* FROM `schema` AS s0 } <>
            ~s{INNER JOIN `schema2` AS s1 ON s0.`x` = s1.`z` WHERE (s0.`x` = 123)}
+
+    assert_raise ArgumentError, ":select is not supported in delete_all by MySQL", fn ->
+      query = from(e in Schema, where: e.x == 123, select: e.x)
+      delete_all(query)
+    end
   end
 
   test "delete all with prefix" do
@@ -733,6 +743,10 @@ defmodule Ecto.Adapters.MySQLTest do
 
     query = insert("prefix", "schema", [], [[]], {:raise, [], []}, [])
     assert query == ~s{INSERT INTO `prefix`.`schema` () VALUES ()}
+
+    assert_raise ArgumentError, ":returning is not supported in insert/insert_all by MySQL", fn ->
+      insert(nil, "schema", [:x, :y], [[:x, :y]], {:raise, [], []}, [:x, :y])
+    end
   end
 
   test "insert with on duplicate key" do


### PR DESCRIPTION
delete_all/1 should raise the MySQL specific error when called with a non nil select clause.