### PR TITLE
Expose repo to migrations

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -658,6 +658,13 @@ defmodule Ecto.Migration do
   end
 
   @doc """
+  Gets the migrator repo.
+  """
+  def repo do
+    Runner.repo
+  end
+
+  @doc """
   Gets the migrator prefix.
   """
   def prefix do

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -78,6 +78,13 @@ defmodule Ecto.Migration.Runner do
   end
 
   @doc """
+  Gets the repo for this migration
+  """
+  def repo do
+    Agent.get(runner(), & &1.repo)
+  end
+
+  @doc """
   Gets the prefix for this migration
   """
   def prefix do

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -31,6 +31,10 @@ defmodule Ecto.MigrationTest do
     assert direction() == :up
   end
 
+  test "allows repo to be retrieved" do
+    assert repo() == TestRepo
+  end
+
   @tag prefix: "foo"
   test "allows prefix to be retrieved" do
     assert prefix() == "foo"


### PR DESCRIPTION
I'm likely in the minority that would need or use this, but it seems logical to have access to the repo during migrations and I didn't see an obvious way to get to it already.  If nothing else, this may save others from digging for it.