### PR TITLE
feat: after_begin and before_commit migration callbacks

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -34,6 +34,29 @@ defmodule Ecto.Adapters.SQL do
   test in a transaction, making sure the tests are isolated and can
   run concurrently. See `Ecto.Adapters.SQL.Sandbox` for more information.
 
+  ## Transaction Callbacks
+
+  There are use cases that dictate adding some common behavior after beginning a
+  migration transaction, or before commiting that transaction. For instance, one
+  might desire to set a `lock_timeout` for each lock in the transaction.
+
+  Another way these might be leveraged is by defining a custom migration module
+  so that these callbacks will run for *all* of your migrations, if you have special
+  requirements.
+
+      defmodule MyApp.Migration do
+        defmacro __using__(_) do
+          use Ecto.Migration
+
+          def after_begin() do
+            execute "SET lock_timeout TO '5s'", "SET lock_timeout TO '10s'"
+          end
+        end
+      end
+
+  Then in your migrations you can `use MyApp.Migration` to share this behavior
+  among all your migrations.
+
   ## Structure load and dumping
 
   If you have an existing database, you may want to dump its existing

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -194,8 +194,9 @@ defmodule Ecto.Migration do
 
   """
 
-  @optional_callback after_begin() :: term
-  @optional_callback before_commit() :: term
+  @callback after_begin() :: term
+  @callback before_commit() :: term
+  @optional_callbacks after_begin: 0, before_commit: 0
 
   defmodule Index do
     @moduledoc """

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -194,6 +194,9 @@ defmodule Ecto.Migration do
 
   """
 
+  @callback after_begin() :: term
+  @callback before_commit() :: term
+
   defmodule Index do
     @moduledoc """
     Used internally by adapters.
@@ -278,6 +281,12 @@ defmodule Ecto.Migration do
       import Ecto.Migration
       @disable_ddl_transaction false
       @before_compile Ecto.Migration
+
+      def after_begin(), do: :ok
+
+      def before_commit(), do: :ok
+
+      defoverridable after_begin: 0, before_commit: 0
     end
   end
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -194,8 +194,8 @@ defmodule Ecto.Migration do
 
   """
 
-  @callback after_begin() :: term
-  @callback before_commit() :: term
+  @optional_callback after_begin() :: term
+  @optional_callback before_commit() :: term
 
   defmodule Index do
     @moduledoc """
@@ -281,12 +281,6 @@ defmodule Ecto.Migration do
       import Ecto.Migration
       @disable_ddl_transaction false
       @before_compile Ecto.Migration
-
-      def after_begin(), do: :ok
-
-      def before_commit(), do: :ok
-
-      defoverridable after_begin: 0, before_commit: 0
     end
   end
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -194,7 +194,20 @@ defmodule Ecto.Migration do
 
   """
 
+  @doc """
+  Migration code to run immediately after the transaction is opened.
+
+  Keep in mind that it is treated like any normal migration code, and should
+  consider both the up *and* down cases of the migration.
+  """
   @callback after_begin() :: term
+
+  @doc """
+  Migration code to run immediately before the transaction is closed.
+
+  Keep in mind that it is treated like any normal migration code, and should
+  consider both the up *and* down cases of the migration.
+  """
   @callback before_commit() :: term
   @optional_callbacks after_begin: 0, before_commit: 0
 

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -23,7 +23,9 @@ defmodule Ecto.Migration.Runner do
     metadata(runner, opts)
 
     log(level, "== Running #{version} #{inspect module}.#{operation}/0 #{direction}")
-    {time1, _} = :timer.tc(module, operation, [])
+    {time1, _} = :timer.tc(fn ->
+      perform_operation(module, operation)
+    end)
     {time2, _} = :timer.tc(&flush/0, [])
     time = time1 + time2
     log(level, "== Migrated #{version} in #{inspect(div(time, 100_000) / 10)}s")
@@ -263,6 +265,19 @@ defmodule Ecto.Migration.Runner do
   end
 
   ## Helpers
+
+  defp perform_operation(module, operation) do
+    if module.__migration__[:disable_ddl_transaction] do
+      apply(module, operation, [])
+    else
+      try do
+        module.after_begin()
+        apply(module, operation, [])
+      after
+        module.before_commit()
+      end
+    end
+  end
 
   defp runner do
     case Process.get(:ecto_migration) do

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -23,9 +23,7 @@ defmodule Ecto.Migration.Runner do
     metadata(runner, opts)
 
     log(level, "== Running #{version} #{inspect module}.#{operation}/0 #{direction}")
-    {time1, _} = :timer.tc(fn ->
-      perform_operation(module, operation)
-    end)
+    {time1, _} = :timer.tc(module, operation, [])
     {time2, _} = :timer.tc(&flush/0, [])
     time = time1 + time2
     log(level, "== Migrated #{version} in #{inspect(div(time, 100_000) / 10)}s")
@@ -265,24 +263,6 @@ defmodule Ecto.Migration.Runner do
   end
 
   ## Helpers
-
-  defp perform_operation(module, operation) do
-    if module.__migration__[:disable_ddl_transaction] do
-      apply(module, operation, [])
-    else
-      if function_exported?(module, :after_begin, 0) do
-        module.after_begin()
-      end
-
-      result = apply(module, operation, [])
-
-      if function_exported?(module, :before_commit, 0) do
-        module.before_commit()
-      end
-
-      result
-    end
-  end
 
   defp runner do
     case Process.get(:ecto_migration) do

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -270,12 +270,17 @@ defmodule Ecto.Migration.Runner do
     if module.__migration__[:disable_ddl_transaction] do
       apply(module, operation, [])
     else
-      try do
+      if function_exported?(module, :after_begin, 0) do
         module.after_begin()
-        apply(module, operation, [])
-      after
+      end
+
+      result = apply(module, operation, [])
+
+      if function_exported?(module, :before_commit, 0) do
         module.before_commit()
       end
+
+      result
     end
   end
 

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -267,15 +267,7 @@ defmodule Ecto.Migration.Runner do
   ## Helpers
 
   defp perform_operation(repo, module, operation) do
-    # TODO: Test adapter can never trigger this case, so how do we test it?
-    in_transaction? =
-      try do
-        repo.in_transaction?()
-      rescue
-        _ -> false
-      end
-
-    if in_transaction? do
+    if repo.in_transaction?() do
       if function_exported?(module, :after_begin, 0) do
         module.after_begin()
       end

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -23,9 +23,7 @@ defmodule Ecto.Migration.Runner do
     metadata(runner, opts)
 
     log(level, "== Running #{version} #{inspect module}.#{operation}/0 #{direction}")
-    {time1, _} = :timer.tc(fn ->
-      perform_operation(repo, module, operation)
-    end)
+    {time1, _} = :timer.tc(fn -> perform_operation(repo, module, operation) end)
     {time2, _} = :timer.tc(&flush/0, [])
     time = time1 + time2
     log(level, "== Migrated #{version} in #{inspect(div(time, 100_000) / 10)}s")

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -191,17 +191,7 @@ defmodule Ecto.Migrator do
       {:ok, result} =
         repo.transaction(
           fn ->
-            if function_exported?(module, :after_begin, 0) do
-              module.after_begin()
-            end
-
-            result = send_and_receive(parent, ref, fun.())
-
-            if function_exported?(module, :before_commit, 0) do
-              module.before_commit()
-            end
-
-            result
+            send_and_receive(parent, ref, fun.())
           end,
           log: false, timeout: :infinity
         )

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -189,7 +189,8 @@ defmodule Ecto.Migrator do
       send_and_receive(parent, ref, fun.())
     else
       {:ok, result} =
-        repo.transaction(fn -> send_and_receive(parent, ref, fun.()) end,
+        repo.transaction(
+          fn -> send_and_receive(parent, ref, fun.()) end,
           log: false, timeout: :infinity
         )
 

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -190,7 +190,19 @@ defmodule Ecto.Migrator do
     else
       {:ok, result} =
         repo.transaction(
-          fn -> send_and_receive(parent, ref, fun.()) end,
+          fn ->
+            if function_exported?(module, :after_begin, 0) do
+              module.after_begin()
+            end
+
+            result = send_and_receive(parent, ref, fun.())
+
+            if function_exported?(module, :before_commit, 0) do
+              module.before_commit()
+            end
+
+            result
+          end,
           log: false, timeout: :infinity
         )
 

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -189,10 +189,7 @@ defmodule Ecto.Migrator do
       send_and_receive(parent, ref, fun.())
     else
       {:ok, result} =
-        repo.transaction(
-          fn ->
-            send_and_receive(parent, ref, fun.())
-          end,
+        repo.transaction(fn -> send_and_receive(parent, ref, fun.()) end,
           log: false, timeout: :infinity
         )
 

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -487,7 +487,7 @@ defmodule Ecto.MigratorTest do
       assert log =~ "before_commit_down"
     end
 
-    test "are not run when the migration is disabled" do
+    test "are not run when the transaction is disabled" do
       log = capture_log(fn ->
         assert up(TestRepo, 10, MigrationWithCallbacksAndNoTransaction) == :ok
       end)

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -476,7 +476,7 @@ defmodule Ecto.MigratorTest do
       assert log =~ "before_commit"
     end
 
-    test "they are both run in a transaction going down" do
+    test "are both run in a transaction going down" do
       assert up(TestRepo, 10, MigrationWithCallbacks, log: false) == :ok
 
       log = capture_log(fn ->
@@ -487,7 +487,7 @@ defmodule Ecto.MigratorTest do
       assert log =~ "before_commit_down"
     end
 
-    test "they are not run when the migration is disabled" do
+    test "are not run when the migration is disabled" do
       log = capture_log(fn ->
         assert up(TestRepo, 10, MigrationWithCallbacksAndNoTransaction) == :ok
       end)

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -67,6 +67,40 @@ defmodule Ecto.MigratorTest do
     end
   end
 
+  defmodule MigrationWithCallbacks do
+    use Ecto.Migration
+
+    def after_begin() do
+      execute "after_begin", "after_begin_down"
+    end
+
+    def before_commit() do
+      execute "before_commit", "before_commit_down"
+    end
+
+    def change do
+      create index(:posts, [:foo])
+    end
+  end
+
+  defmodule MigrationWithCallbacksAndNoTransaction do
+    use Ecto.Migration
+
+    @disable_ddl_transaction true
+
+    def after_begin() do
+      execute "after_begin", "after_begin_down"
+    end
+
+    def before_commit() do
+      execute "before_commit", "before_commit_down"
+    end
+
+    def change do
+      create index(:posts, [:foo])
+    end
+  end
+
   defmodule InvalidMigration do
     use Ecto.Migration
   end
@@ -429,6 +463,37 @@ defmodule Ecto.MigratorTest do
 
     test "version migrations stop even if asked to exceed available" do
       assert run(TestRepo, [{13, ChangeMigration}, {14, UpDownMigration}], :up, to: 15, log: false) == [13, 14]
+    end
+  end
+
+  describe "migration callbacks" do
+    test "both run when in a transaction going up" do
+      log = capture_log(fn ->
+        assert up(TestRepo, 10, MigrationWithCallbacks) == :ok
+      end)
+
+      assert log =~ "after_begin"
+      assert log =~ "before_commit"
+    end
+
+    test "they are both run in a transaction going down" do
+      assert up(TestRepo, 10, MigrationWithCallbacks, log: false) == :ok
+
+      log = capture_log(fn ->
+        assert down(TestRepo, 10, MigrationWithCallbacks) == :ok
+      end)
+
+      assert log =~ "after_begin_down"
+      assert log =~ "before_commit_down"
+    end
+
+    test "they are not run when the migration is disabled" do
+      log = capture_log(fn ->
+        assert up(TestRepo, 10, MigrationWithCallbacksAndNoTransaction) == :ok
+      end)
+
+      refute log =~ "after_begin"
+      refute log =~ "before_commit"
     end
   end
 end

--- a/test/test_repo.exs
+++ b/test/test_repo.exs
@@ -14,7 +14,6 @@ defmodule EctoSQL.TestAdapter do
 
   def checkout(_, _, _), do: raise "not implemented"
   def delete(_, _, _, _), do: raise "not implemented"
-  def in_transaction?(_), do: raise "not implemented"
   def insert_all(_, _, _, _, _, _, _), do: raise "not implemented"
   def rollback(_, _), do: raise "not implemented"
   def stream(_, _, _, _, _), do: raise "not implemented"
@@ -47,9 +46,15 @@ defmodule EctoSQL.TestAdapter do
     {:ok, []}
   end
 
+  def in_transaction?(_), do: Process.get(:in_transaction?) || false
+
   def transaction(_mod, _opts, fun) do
+    Process.put(:in_transaction?, true)
     send test_process(), {:transaction, fun}
+
     {:ok, fun.()}
+  after
+    Process.put(:in_transaction?, false)
   end
 
   ## Migrations


### PR DESCRIPTION
This should cover the use case discussed in #31. For more information, see the issue.

I have added tests, but I still need to add documentation which I will do this evening. Using these callbacks, you can write standard migration code. However, I'm struggling to figure out how to make working with up/down play nicely. Given this migration:

```
defmodule MyMigration do
  ...

  def after_begin() do
    execute "some_sql"
  end

  def change() do
    ...
  end
end
```

If you roll it back, you will get an error that `execute "some_sql"` cannot be rolled back. It seems to me like we need some way to differentiate between up and down. Either `after_begin_up` and `after_begin_down`, or `after_begin(:up)`? I'm unsure.