### PR TITLE
Fix removing an reference column

### DIFF
--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -762,6 +762,10 @@ if Code.ensure_loaded?(Mariaex) do
     end
 
     defp column_change(_table, {:remove, name}), do: ["DROP ", quote_name(name)]
+    defp column_change(table, {:remove, name, %Reference{} = ref, _opts}) do
+      [drop_constraint_expr(ref, table, name), "DROP ", quote_name(name)]
+    end
+    defp column_change(_table, {:remove, name, _type, _opts}), do: ["DROP ", quote_name(name)]
 
     defp column_options(opts) do
       default = Keyword.fetch(opts, :default)

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -880,6 +880,10 @@ if Code.ensure_loaded?(Postgrex) do
     end
 
     defp column_change(_table, {:remove, name}), do: ["DROP COLUMN ", quote_name(name)]
+    defp column_change(table, {:remove, name, %Reference{} = ref, _opts}) do
+      [drop_constraint_expr(ref, table, name), "DROP COLUMN ", quote_name(name)]
+    end
+    defp column_change(_table, {:remove, name, _type, _opts}), do: ["DROP COLUMN ", quote_name(name)]
 
     defp modify_null(name, opts) do
       case Keyword.get(opts, :null) do

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -872,6 +872,7 @@ defmodule Ecto.Migration do
 
   """
   def remove(column, type, opts \\ []) when is_atom(column) do
+    validate_type!(type)
     Runner.subcommand {:remove, column, type, opts}
   end
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -862,7 +862,9 @@ defmodule Ecto.Migration do
   Removes a column in a reversible way when altering a table.
 
   `type` and `opts` are exactly the same as in `add/3`, and
-  they are only used when the command is reversed.
+  they are used when the command is reversed.
+
+  If the `type` value is a `%Reference{}`, it is used to remove the constraint.
 
   ## Examples
 

--- a/test/ecto/adapters/mysql_test.exs
+++ b/test/ecto/adapters/mysql_test.exs
@@ -1042,7 +1042,9 @@ defmodule Ecto.Adapters.MySQLTest do
                 {:modify, :status, :string, from: :integer},
                 {:modify, :user_id, :integer, from: %Reference{table: :users}},
                 {:modify, :group_id, %Reference{table: :groups, column: :gid}, from: %Reference{table: :groups}},
-                {:remove, :summary}]}
+                {:remove, :summary},
+                {:remove, :body, :text, []},
+                {:remove, :space_id, %Reference{table: :author}, []}]}
 
     assert execute_ddl(alter) == ["""
     ALTER TABLE `posts` ADD `title` varchar(100) DEFAULT 'Untitled' NOT NULL,
@@ -1057,7 +1059,10 @@ defmodule Ecto.Adapters.MySQLTest do
     DROP FOREIGN KEY `posts_group_id_fkey`,
     MODIFY `group_id` BIGINT UNSIGNED,
     ADD CONSTRAINT `posts_group_id_fkey` FOREIGN KEY (`group_id`) REFERENCES `groups`(`gid`),
-    DROP `summary`
+    DROP `summary`,
+    DROP `body`,
+    DROP FOREIGN KEY `posts_space_id_fkey`,
+    DROP `space_id`
     """ |> remove_newlines]
   end
 

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1233,7 +1233,9 @@ defmodule Ecto.Adapters.PostgresTest do
               {:modify, :status, :string, from: :integer},
               {:modify, :user_id, :integer, from: %Reference{table: :users}},
               {:modify, :group_id, %Reference{table: :groups, column: :gid}, from: %Reference{table: :groups}},
-              {:remove, :summary}]}
+              {:remove, :summary},
+              {:remove, :body, :text, []},
+              {:remove, :space_id, %Reference{table: :author}, []}]}
 
     assert execute_ddl(alter) == ["""
     ALTER TABLE "posts"
@@ -1253,7 +1255,10 @@ defmodule Ecto.Adapters.PostgresTest do
     DROP CONSTRAINT "posts_group_id_fkey",
     ALTER COLUMN "group_id" TYPE bigint,
     ADD CONSTRAINT "posts_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "groups"("gid"),
-    DROP COLUMN "summary"
+    DROP COLUMN "summary",
+    DROP COLUMN "body",
+    DROP CONSTRAINT "posts_space_id_fkey",
+    DROP COLUMN "space_id"
     """ |> remove_newlines]
   end
 

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -265,6 +265,14 @@ defmodule Ecto.MigrationTest do
                {:remove, :views}]}
   end
 
+  test "forward: removing a reference column (remove/3 called)" do
+    alter table(:posts) do
+      remove :author_id, references(:authors), []
+    end
+    flush()
+    assert {:alter, %Table{name: "posts"}, [{:remove, :author_id, %Reference{table: "authors"}, []}]} = last_command()
+  end
+
   test "forward: alter numeric column without specifying precision" do
     assert_raise ArgumentError, "column cost is missing precision option", fn ->
       alter table(:posts) do
@@ -643,6 +651,14 @@ defmodule Ecto.MigrationTest do
     end
     flush()
     assert {:alter, %Table{name: "posts"}, [{:add, :title, :string, []}]} = last_command()
+  end
+
+  test "backward: removing a reference column (remove/3 called)" do
+    alter table(:posts) do
+      remove :author_id, references(:authors), []
+    end
+    flush()
+    assert {:alter, %Table{name: "posts"}, [{:add, :author_id, %Reference{table: "authors"}, []}]} = last_command()
   end
 
   test "backward: rename column" do

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -255,6 +255,7 @@ defmodule Ecto.MigrationTest do
       add :summary, :text
       modify :title, :text
       remove :views
+      remove :status, :string
     end
     flush()
 
@@ -262,7 +263,8 @@ defmodule Ecto.MigrationTest do
            {:alter, %Table{name: "posts"},
               [{:add, :summary, :text, []},
                {:modify, :title, :text, []},
-               {:remove, :views}]}
+               {:remove, :views},
+               {:remove, :status, :string, []}]}
   end
 
   test "forward: removing a reference column (remove/3 called)" do


### PR DESCRIPTION
fix migration:
```elixir
alter table(:posts) do
  remove :author_uuid, references(:authors, column: :uuid, type: :uuid), null: false
end
```

error logs:
```log
** (FunctionClauseError) no function clause matching in Ecto.Adapters.Postgres.Connection.column_change/2

    The following arguments were given to Ecto.Adapters.Postgres.Connection.column_change/2:

        # 1
        %Ecto.Migration.Table{comment: nil, engine: nil, name: "posts", options: nil, prefix: nil, primary_key: true}

        # 2
        {:remove, :author_uuid, %Ecto.Migration.Reference{column: :uuid, name: nil, on_delete: :nothing, on_update: :nothing, table: "authors", type: :uuid}, [null: false]}

    Attempted function clauses (showing 5 out of 5):

        defp column_change(table, {:add, name, %Ecto.Migration.Reference{} = ref, opts})
        defp column_change(_table, {:add, name, type, opts})
        defp column_change(table, {:modify, name, %Ecto.Migration.Reference{} = ref, opts})
        defp column_change(table, {:modify, name, type, opts})
        defp column_change(_table, {:remove, name})

    (ecto_sql) lib/ecto/adapters/postgres/connection.ex:862: Ecto.Adapters.Postgres.Connection.column_change/2
    (ecto_sql) lib/ecto/adapters/postgres/connection.ex:1066: Ecto.Adapters.Postgres.Connection.intersperse_map/4
    (ecto_sql) lib/ecto/adapters/postgres/connection.ex:716: Ecto.Adapters.Postgres.Connection.execute_ddl/1
```