### PR TITLE
Support migrations in subdirectories

### DIFF
--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -392,7 +392,7 @@ defmodule Ecto.Migrator do
 
   # This function will match directories passed into `Migrator.run`.
   defp migrations_for(migration_source) when is_binary(migration_source) do
-    query = Path.join(migration_source, "*")
+    query = Path.join([migration_source, "**", "*.exs"])
 
     for entry <- Path.wildcard(query),
         info = extract_migration_info(entry),
@@ -406,10 +406,9 @@ defmodule Ecto.Migrator do
 
   defp extract_migration_info(file) do
     base = Path.basename(file)
-    ext  = Path.extname(base)
 
     case Integer.parse(Path.rootname(base)) do
-      {integer, "_" <> name} when ext == ".exs" ->
+      {integer, "_" <> name} ->
         {integer, name, file}
       _ ->
         nil

--- a/lib/mix/tasks/ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto.gen.migration.ex
@@ -9,12 +9,14 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
   @shortdoc "Generates a new migration for the repo"
 
   @aliases [
-    r: :repo
+    r: :repo,
+    d: :subdir
   ]
 
   @switches [
     change: :string,
     repo: [:string, :keep],
+    subdir: :string,
     no_compile: :boolean,
     no_deps_check: :boolean
   ]
@@ -29,6 +31,7 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
 
       mix ecto.gen.migration add_posts_table
       mix ecto.gen.migration add_posts_table -r Custom.Repo
+      mix ecto.gen.migration add_posts_table -d blog
 
   The generated migration filename will be prefixed with the current
   timestamp in UTC which is used for versioning and ordering.
@@ -44,6 +47,7 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
   ## Command line options
 
     * `-r`, `--repo` - the repo to generate migration for
+    * `-d`, `--subdir` - the subdirectory within the migration folder
     * `--no-compile` - does not compile applications before running
     * `--no-deps-check` - does not check depedendencies before running
 
@@ -58,7 +62,7 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
       case OptionParser.parse!(args, strict: @switches, aliases: @aliases) do
         {opts, [name]} ->
           ensure_repo(repo, args)
-          path = Path.join(source_repo_priv(repo), "migrations")
+          path = Path.join([source_repo_priv(repo), "migrations", opts[:subdir] || ""])
           base_name = "#{underscore(name)}.exs"
           file = Path.join(path, "#{timestamp()}_#{base_name}")
           unless File.dir?(path), do: create_directory path

--- a/test/mix/tasks/ecto.gen.migration_test.exs
+++ b/test/mix/tasks/ecto.gen.migration_test.exs
@@ -33,6 +33,15 @@ defmodule Mix.Tasks.Ecto.Gen.MigrationTest do
     end
   end
 
+  test "generates a new migration within a subdirectory" do
+    [path] = run ["-r", to_string(Repo), "my_migration2", "-d", "mydomain"]
+    assert Path.dirname(path) == Path.join(@migrations_path, "mydomain")
+    assert Path.basename(path) =~ ~r/^\d{14}_my_migration2\.exs$/
+    assert_file path, fn file ->
+      assert file =~ "defmodule Mix.Tasks.Ecto.Gen.MigrationTest.Repo.Migrations.MyMigration2 do"
+    end
+  end
+
   test "underscores the filename when generating a migration" do
     run ["-r", to_string(Repo), "MyMigration"]
     assert [name] = File.ls!(@migrations_path)


### PR DESCRIPTION
Hello, it gets pretty quick, that you end up with lots and lots of files within the priv/repo/migrations directory.. while the application gets bigger, changes are happening, so the single directory approach does not scale well

It might be helpful, when subdirectories were supported.

priv/repo/migrations/accounts/
priv/repo/migrations/dependency_migration/
ect.

This PR includes

* finding migrations within subdirectories
* define the subdirectory (domain) with the (`-d`, `--subdir`) option to generate a migration inside the `subdir`