### PR TITLE
Adds support for migrations sub-directories

### DIFF
--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -392,11 +392,11 @@ defmodule Ecto.Migrator do
 
   # This function will match directories passed into `Migrator.run`.
   defp migrations_for(migration_source) when is_binary(migration_source) do
-    query = Path.join(migration_source, "*")
-
-    for entry <- Path.wildcard(query),
-        info = extract_migration_info(entry),
-        do: info
+    Path.join([migration_source, "**", "*.exs"])
+    |> Path.wildcard()
+    |> Enum.map(&extract_migration_info/1)
+    |> Enum.filter(& &1)
+    |> Enum.sort()
   end
 
   # This function will match specific version/modules passed into `Migrator.run`.
@@ -406,10 +406,9 @@ defmodule Ecto.Migrator do
 
   defp extract_migration_info(file) do
     base = Path.basename(file)
-    ext  = Path.extname(base)
 
     case Integer.parse(Path.rootname(base)) do
-      {integer, "_" <> name} when ext == ".exs" ->
+      {integer, "_" <> name} ->
         {integer, name, file}
       _ ->
         nil

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -346,6 +346,18 @@ defmodule Ecto.MigratorTest do
     end
   end
 
+  test "migrations are also picked up from subdirs" do
+    in_tmp(fn path ->
+      File.mkdir_p!("foo")
+
+      create_migration "foo/6_up_migration_1.exs"
+      create_migration "7_up_migration_2.exs"
+      create_migration "8_up_migration_3.exs"
+
+      assert run(TestRepo, path, :up, all: true, log: false) == [6, 7, 8]
+    end)
+  end
+
   test "migrations will give the migration status while file is deleted" do
     in_tmp fn path ->
       create_migration "1_up_migration_1.exs"


### PR DESCRIPTION
For now only flat structure is supported:

```
migrations
|- 134567_user_table.exs
|- 134569_posts.exs
|- 134569_user_field.exs
```

This adds support to structure the folder how you like: 

```
migrations
|- accounts
    |- 134567_user_table.exs
    |- 134569_user_field.exs
|- blog
    |- 134569_posts.exs
```