### PR TITLE
remove invalid -v flag from rollback docs

### DIFF
--- a/lib/mix/tasks/ecto.rollback.ex
+++ b/lib/mix/tasks/ecto.rollback.ex
@@ -61,7 +61,6 @@ defmodule Mix.Tasks.Ecto.Rollback do
       mix ecto.rollback -n 3
       mix ecto.rollback --step 3
 
-      mix ecto.rollback -v 20080906120000
       mix ecto.rollback --to 20080906120000
 
   ## Command line options


### PR DESCRIPTION
This flag showed up in the example list, but it is not a valid flag for `mix ecto.rollback`.