### PR TITLE
Add parentheses to 'change' function in migrations

### DIFF
--- a/lib/mix/tasks/ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto.gen.migration.ex
@@ -96,7 +96,7 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
   defmodule <%= inspect @mod %> do
     use Ecto.Migration
 
-    def change do
+    def change() do
   <%= @change %>
     end
   end

--- a/test/mix/tasks/ecto.gen.migration_test.exs
+++ b/test/mix/tasks/ecto.gen.migration_test.exs
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Ecto.Gen.MigrationTest do
     assert_file path, fn file ->
       assert file =~ "defmodule Mix.Tasks.Ecto.Gen.MigrationTest.Repo.Migrations.MyMigration do"
       assert file =~ "use Ecto.Migration"
-      assert file =~ "def change do"
+      assert file =~ "def change() do"
     end
   end
 


### PR DESCRIPTION
Not much more to say, other than following standard practice.