### PR TITLE
Configurable Migrations Module

### DIFF
--- a/lib/mix/tasks/ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto.gen.migration.ex
@@ -25,6 +25,12 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
   The repository must be set under `:ecto_repos` in the
   current app configuration or given via the `-r` option.
 
+  If the current app configuration specifies a custom migration module
+  the generated migration code will use that rather than the default
+  Ecto.Migration
+
+    config :ecto_sql, migration_module: MyApplication.CustomMigrationModule
+
   ## Examples
 
       mix ecto.gen.migration add_posts_table
@@ -94,7 +100,7 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
 
   embed_template :migration, """
   defmodule <%= inspect @mod %> do
-    use <%= libraryName() %>.Migration
+    use <%=  inspect migration_module() %>
 
     def change do
   <%= @change %>
@@ -102,12 +108,20 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
   end
   """
   
-  defp libraryName() do
-    case Application.get_env(:ecto_sql, :migration_library) do
+  @doc """
+  Looks in the application configuration file for a custom migration module to use when generating the migration file.
+  
+  ## Example
+    config :ecto_sql, migration_module: MyApplication.CustomMigrationModule
+
+  If a custom migration module is not defined in the configuration, returns the default Ecto.Migration
+  """
+  defp migration_module() do
+    case Application.get_env(:ecto_sql, :migration_module) do
       x when x != nil ->
         x
       _->
-        "Ecto"
+        Ecto.Migration
     end
   end
 

--- a/lib/mix/tasks/ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto.gen.migration.ex
@@ -25,12 +25,6 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
   The repository must be set under `:ecto_repos` in the
   current app configuration or given via the `-r` option.
 
-  If the current app configuration specifies a custom migration module
-  the generated migration code will use that rather than the default
-  Ecto.Migration
-
-    config :ecto_sql, migration_module: MyApplication.CustomMigrationModule
-
   ## Examples
 
       mix ecto.gen.migration add_posts_table
@@ -52,6 +46,14 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
     * `-r`, `--repo` - the repo to generate migration for
     * `--no-compile` - does not compile applications before running
     * `--no-deps-check` - does not check depedendencies before running
+
+  ## Configuration
+
+  If the current app configuration specifies a custom migration module
+  the generated migration code will use that rather than the default
+  `Ecto.Migration`:
+
+      config :ecto_sql, migration_module: MyApplication.CustomMigrationModule
 
   """
 
@@ -98,28 +100,20 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
   defp pad(i) when i < 10, do: << ?0, ?0 + i >>
   defp pad(i), do: to_string(i)
 
+  defp migration_module do
+    case Application.get_env(:ecto_sql, :migration_module, Ecto.Migration) do
+      migration_module when is_atom(migration_module) -> migration_module
+      other -> Mix.raise "Expected :migration_module to be a module, got: #{inspect(other)}"
+    end
+  end
+
   embed_template :migration, """
   defmodule <%= inspect @mod %> do
-    use <%=  inspect migration_module() %>
+    use <%= inspect migration_module() %>
 
     def change do
   <%= @change %>
     end
   end
   """
-  
-  @doc """
-  Looks in the application configuration file for a custom migration module to use when generating the migration file.
-  
-  ## Example
-    config :ecto_sql, migration_module: MyApplication.CustomMigrationModule
-
-  If a custom migration module is not defined in the configuration, returns the default Ecto.Migration
-  """
-  defp migration_module() do
-    case Application.get_env(:ecto_sql, :migration_module, Ecto.Migration) do
-      migration_module when is_atom(migration_module) -> migration_module
-      other -> Mix.raise "Expected :migration_module to be a module, got: #{inspect(other)}"
-    end
-  end
 end

--- a/lib/mix/tasks/ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto.gen.migration.ex
@@ -94,11 +94,22 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
 
   embed_template :migration, """
   defmodule <%= inspect @mod %> do
-    use TransportApi.Migration
+    use <%= libraryName() %>.Migration
 
     def change do
   <%= @change %>
     end
   end
   """
+  
+  defp libraryName() do
+    case Application.get_env(:ecto_sql, :migration_library) do
+      x when x != nil ->
+        x
+      _->
+        "Ecto"
+    end
+  end
+
+  
 end

--- a/lib/mix/tasks/ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto.gen.migration.ex
@@ -117,10 +117,9 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
   If a custom migration module is not defined in the configuration, returns the default Ecto.Migration
   """
   defp migration_module() do
-    case Application.get_env(:ecto_sql, :migration_module) do
-      nil -> Ecto.Migration
+    case Application.get_env(:ecto_sql, :migration_module, Ecto.Migration) do
       migration_module when is_atom(migration_module) -> migration_module
-      other -> raise "Expect :migration_module to be a module, got: #{inspect(other)}"
+      other -> Mix.raise "Expected :migration_module to be a module, got: #{inspect(other)}"
     end
   end
 end

--- a/lib/mix/tasks/ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto.gen.migration.ex
@@ -94,7 +94,7 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
 
   embed_template :migration, """
   defmodule <%= inspect @mod %> do
-    use Ecto.Migration
+    use TransportApi.Migration
 
     def change do
   <%= @change %>

--- a/lib/mix/tasks/ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto.gen.migration.ex
@@ -118,12 +118,9 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
   """
   defp migration_module() do
     case Application.get_env(:ecto_sql, :migration_module) do
-      x when x != nil ->
-        x
-      _->
-        Ecto.Migration
+      nil -> Ecto.Migration
+      migration_module when is_atom(migration_module) -> migration_module
+      other -> raise "Expect :migration_module to be a module, got: #{inspect(other)}"
     end
   end
-
-  
 end

--- a/test/mix/tasks/ecto.gen.migration_test.exs
+++ b/test/mix/tasks/ecto.gen.migration_test.exs
@@ -33,6 +33,19 @@ defmodule Mix.Tasks.Ecto.Gen.MigrationTest do
     end
   end
 
+  test "generates a new migration with Custom Migration Module" do
+    Application.put_env(:ecto_sql, :migration_module, MyCustomApp.MigrationModule)
+    [path] = run ["-r", to_string(Repo), "my_custom_migration"]
+    Application.delete_env(:ecto_sql, :migration_module)
+    assert Path.dirname(path) == @migrations_path
+    assert Path.basename(path) =~ ~r/^\d{14}_my_custom_migration\.exs$/
+    assert_file path, fn file ->
+      assert file =~ "defmodule Mix.Tasks.Ecto.Gen.MigrationTest.Repo.Migrations.MyCustomMigration do"
+      assert file =~ "use MyCustomApp.MigrationModule"
+      assert file =~ "def change do"
+    end
+  end
+
   test "underscores the filename when generating a migration" do
     run ["-r", to_string(Repo), "MyMigration"]
     assert [name] = File.ls!(@migrations_path)


### PR DESCRIPTION
I needed to make sure all migrations used my custom migration module;  I also need to make certain I can take ecto_sql upgrades and not have to make one off changes in my fork each time.  Tests pass, and I feel like the change is consistent with the norms of the language and code base.  If there is a character flaw in the code, please let me know what to correct.

Thanks!