### PR TITLE
Allow conditional edition on columns

### DIFF
--- a/integration_test/pg/migrations_test.exs
+++ b/integration_test/pg/migrations_test.exs
@@ -61,15 +61,31 @@ defmodule Ecto.Integration.MigrationsTest do
     end
   end
 
-  defmodule NoErrorColumnMigration do
+  defmodule NoErrorOnAddColumnMigration do
     use Ecto.Migration
 
     def up do
-      create table(:no_error_column_migration)
+      create table(:no_error_on_add_column_migration)
 
-      alter table(:no_error_column_migration) do
+      alter table(:no_error_on_add_column_migration) do
         add_if_not_exists  :value, :integer
         add_if_not_exists  :value, :integer
+      end
+    end
+
+    def down do
+      drop table(:no_error_on_add_column_migration)
+    end
+  end
+
+  defmodule NoErrorOnRemoveColumnMigration do
+    use Ecto.Migration
+
+    def up do
+      create table(:no_error_on_remove_column_migration)
+
+      alter table(:no_error_on_remove_column_migration) do
+        add :value, :integer
 
         remove_if_exists :value, :integer
         remove_if_exists :value, :integer
@@ -77,7 +93,7 @@ defmodule Ecto.Integration.MigrationsTest do
     end
 
     def down do
-      drop table(:no_error_column_migration)
+      drop table(:no_error_on_remove_column_migration)
     end
   end
 
@@ -94,10 +110,16 @@ defmodule Ecto.Integration.MigrationsTest do
     assert log =~ ~s(relation "duplicate_table" already exists, skipping)
   end
 
-  @tag :no_error_column_migration
-  test "add if not exists and drop column if exists does not raise on failure", %{migration_number: num} do
-    assert :ok == up(PoolRepo, num, NoErrorColumnMigration, log: false)
-    assert :ok == down(PoolRepo, num, NoErrorColumnMigration, log: false)
+  @tag :no_error_on_add_column_migration
+  test "add if not exists does not raise on failure", %{migration_number: num} do
+    assert :ok == up(PoolRepo, num, NoErrorOnAddColumnMigration, log: false)
+    assert :ok == down(PoolRepo, num, NoErrorOnAddColumnMigration, log: false)
+  end
+
+  @tag :no_error_on_remove_column_migration
+  test "drop column if exists does not raise on failure", %{migration_number: num} do
+    assert :ok == up(PoolRepo, num, NoErrorOnRemoveColumnMigration, log: false)
+    assert :ok == down(PoolRepo, num, NoErrorOnRemoveColumnMigration, log: false)
   end
 
   @tag :add_column_if_not_exists

--- a/integration_test/pg/migrations_test.exs
+++ b/integration_test/pg/migrations_test.exs
@@ -1,12 +1,56 @@
 defmodule Ecto.Integration.MigrationsTest do
   use ExUnit.Case, async: true
 
-  import Ecto.Migrator, only: [up: 4]
   alias Ecto.Integration.PoolRepo
 
   # Avoid migration out of order warnings
   @moduletag :capture_log
   @base_migration 3_000_000
+
+  setup do
+    {:ok, migration_number: System.unique_integer([:positive]) + @base_migration}
+  end
+
+  defmodule AddColumnIfNotExistsMigration do
+    use Ecto.Migration
+
+    def up do
+      create table(:add_col_if_not_exists_migration) do
+        add :value, :integer
+      end
+
+      alter table(:add_col_if_not_exists_migration) do
+        add :to_be_added, :integer
+      end
+
+      execute "INSERT INTO add_col_if_not_exists_migration (value, to_be_added) VALUES (1, 2)"
+    end
+
+    def down do
+      drop table(:add_col_if_not_exists_migration)
+    end
+  end
+
+  defmodule DropColumnIfExistsMigration do
+    use Ecto.Migration
+
+    def up do
+      create table(:drop_col_if_exists_migration) do
+        add :value, :integer
+        add :to_be_removed, :integer
+      end
+
+      execute "INSERT INTO drop_col_if_exists_migration (value, to_be_removed) VALUES (1, 2)"
+
+      alter table(:drop_col_if_exists_migration) do
+        remove :to_be_removed
+      end
+    end
+
+    def down do
+      drop table(:drop_col_if_exists_migration)
+    end
+  end
 
   defmodule DuplicateTableMigration do
     use Ecto.Migration
@@ -17,6 +61,29 @@ defmodule Ecto.Integration.MigrationsTest do
     end
   end
 
+  defmodule NoErrorColumnMigration do
+    use Ecto.Migration
+
+    def up do
+      create table(:no_error_column_migration)
+
+      alter table(:no_error_column_migration) do
+        add_if_not_exists  :value, :integer
+        add_if_not_exists  :value, :integer
+
+        remove_if_exists :value
+        remove_if_exists :value
+      end
+    end
+
+    def down do
+      drop table(:no_error_column_migration)
+    end
+  end
+
+  import Ecto.Query, only: [from: 2]
+  import Ecto.Migrator, only: [up: 4, down: 4]
+
   test "logs Postgres notice messages" do
     log =
       ExUnit.CaptureLog.capture_log(fn ->
@@ -25,5 +92,25 @@ defmodule Ecto.Integration.MigrationsTest do
       end)
 
     assert log =~ ~s(relation "duplicate_table" already exists, skipping)
+  end
+
+  @tag :no_error_column_migration
+  test "add if not exists and drop column if exists does not raise on failure", %{migration_number: num} do
+    assert :ok == up(PoolRepo, num, NoErrorColumnMigration, log: false)
+    assert :ok == down(PoolRepo, num, NoErrorColumnMigration, log: false)
+  end
+
+  @tag :add_column_if_not_exists
+  test "add column if not exists", %{migration_number: num} do
+    assert :ok == up(PoolRepo, num, AddColumnIfNotExistsMigration, log: false)
+    assert [2] == PoolRepo.all from p in "add_col_if_not_exists_migration", select: p.to_be_added
+    :ok = down(PoolRepo, num, AddColumnIfNotExistsMigration, log: false)
+  end
+
+  @tag :remove_column_if_exists
+  test "remove column when exists", %{migration_number: num} do
+    assert :ok == up(PoolRepo, num, DropColumnIfExistsMigration, log: false)
+    assert catch_error(PoolRepo.all from p in "drop_col_if_exists_migration", select: p.to_be_removed)
+    :ok = down(PoolRepo, num, DropColumnIfExistsMigration, log: false)
   end
 end

--- a/integration_test/pg/migrations_test.exs
+++ b/integration_test/pg/migrations_test.exs
@@ -60,31 +60,15 @@ defmodule Ecto.Integration.MigrationsTest do
     end
   end
 
-  defmodule NoErrorOnAddColumnMigration do
+  defmodule NoErrorOnConditionalColumnMigration do
     use Ecto.Migration
 
     def up do
-      create table(:no_error_on_add_column_migration)
+      create table(:no_error_on_conditional_column_migration)
 
-      alter table(:no_error_on_add_column_migration) do
+      alter table(:no_error_on_conditional_column_migration) do
         add_if_not_exists  :value, :integer
         add_if_not_exists  :value, :integer
-      end
-    end
-
-    def down do
-      drop table(:no_error_on_add_column_migration)
-    end
-  end
-
-  defmodule NoErrorOnRemoveColumnMigration do
-    use Ecto.Migration
-
-    def up do
-      create table(:no_error_on_remove_column_migration)
-
-      alter table(:no_error_on_remove_column_migration) do
-        add :value, :integer
 
         remove_if_exists :value, :integer
         remove_if_exists :value, :integer
@@ -92,7 +76,7 @@ defmodule Ecto.Integration.MigrationsTest do
     end
 
     def down do
-      drop table(:no_error_on_remove_column_migration)
+      drop table(:no_error_on_conditional_column_migration)
     end
   end
 
@@ -109,16 +93,10 @@ defmodule Ecto.Integration.MigrationsTest do
     assert log =~ ~s(relation "duplicate_table" already exists, skipping)
   end
 
-  @tag :no_error_on_add_column_migration
-  test "add if not exists does not raise on failure", %{migration_number: num} do
-    assert :ok == up(PoolRepo, num, NoErrorOnAddColumnMigration, log: false)
-    assert :ok == down(PoolRepo, num, NoErrorOnAddColumnMigration, log: false)
-  end
-
-  @tag :no_error_on_remove_column_migration
-  test "drop column if exists does not raise on failure", %{migration_number: num} do
-    assert :ok == up(PoolRepo, num, NoErrorOnRemoveColumnMigration, log: false)
-    assert :ok == down(PoolRepo, num, NoErrorOnRemoveColumnMigration, log: false)
+  @tag :no_error_on_conditional_column_migration
+  test "add if not exists and drop if exists does not raise on failure", %{migration_number: num} do
+    assert :ok == up(PoolRepo, num, NoErrorOnConditionalColumnMigration, log: false)
+    assert :ok == down(PoolRepo, num, NoErrorOnConditionalColumnMigration, log: false)
   end
 
   @tag :add_column_if_not_exists

--- a/integration_test/pg/migrations_test.exs
+++ b/integration_test/pg/migrations_test.exs
@@ -15,12 +15,11 @@ defmodule Ecto.Integration.MigrationsTest do
     use Ecto.Migration
 
     def up do
-      create table(:add_col_if_not_exists_migration) do
-        add :value, :integer
-      end
+      create table(:add_col_if_not_exists_migration)
 
       alter table(:add_col_if_not_exists_migration) do
-        add :to_be_added, :integer
+        add_if_not_exists :value, :integer
+        add_if_not_exists :to_be_added, :integer
       end
 
       execute "INSERT INTO add_col_if_not_exists_migration (value, to_be_added) VALUES (1, 2)"
@@ -43,7 +42,7 @@ defmodule Ecto.Integration.MigrationsTest do
       execute "INSERT INTO drop_col_if_exists_migration (value, to_be_removed) VALUES (1, 2)"
 
       alter table(:drop_col_if_exists_migration) do
-        remove :to_be_removed
+        remove_if_exists :to_be_removed, :integer
       end
     end
 

--- a/integration_test/pg/migrations_test.exs
+++ b/integration_test/pg/migrations_test.exs
@@ -71,8 +71,8 @@ defmodule Ecto.Integration.MigrationsTest do
         add_if_not_exists  :value, :integer
         add_if_not_exists  :value, :integer
 
-        remove_if_exists :value
-        remove_if_exists :value
+        remove_if_exists :value, :integer
+        remove_if_exists :value, :integer
       end
     end
 

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -81,7 +81,7 @@ version =
 
 excludes_above_9_5 = [:without_conflict_target]
 excludes_below_9_5 = [:upsert, :upsert_all, :array_type, :aggregate_filters]
-excludes_below_9_6 = [:add_column_if_not_exists, :no_error_on_add_column_migration]
+excludes_below_9_6 = [:add_column_if_not_exists, :no_error_on_conditional_column_migration]
 
 cond do
   Version.match?(version, "< 9.5.0") ->

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -79,11 +79,18 @@ version =
     _other -> version
   end
 
-if Version.match?(version, ">= 9.5.0") do
-  ExUnit.configure(exclude: [:without_conflict_target])
-else
-  Application.put_env(:ecto_sql, :postgres_map_type, "json")
-  ExUnit.configure(exclude: [:upsert, :upsert_all, :array_type, :aggregate_filters])
+excludes_above_9_5 = [:without_conflict_target]
+excludes_below_9_5 = [:upsert, :upsert_all, :array_type, :aggregate_filters]
+excludes_below_9_6 = [:add_column_if_not_exists, :no_error_on_add_column_migration]
+
+cond do
+  Version.match?(version, "< 9.5.0") ->
+    ExUnit.configure(exclude: excludes_below_9_5 ++ excludes_below_9_6)
+    Application.put_env(:ecto_sql, :postgres_map_type, "json")
+  Version.match?(version, ">= 9.5.0") and Version.match?(version, "< 9.6.0") ->
+    ExUnit.configure(exclude: excludes_above_9_5 ++ excludes_below_9_6)
+  true ->
+    ExUnit.configure(exclude: excludes_above_9_5)
 end
 
 :ok = Ecto.Migrator.up(TestRepo, 0, Ecto.Integration.Migration, log: false)

--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -42,6 +42,26 @@ defmodule Ecto.Integration.MigrationTest do
     end
   end
 
+  defmodule AddColumnIfNotExistsMigration do
+    use Ecto.Migration
+
+    def up do
+      create table(:add_col_if_not_exists_migration) do
+        add :value, :integer
+      end
+
+      alter table(:add_col_if_not_exists_migration) do
+        add :to_be_added, :integer
+      end
+
+      execute "INSERT INTO add_col_if_not_exists_migration (value, to_be_added) VALUES (1, 2)"
+    end
+
+    def down do
+      drop table(:add_col_if_not_exists_migration)
+    end
+  end
+
   defmodule AlterColumnMigration do
     use Ecto.Migration
 
@@ -337,7 +357,11 @@ defmodule Ecto.Integration.MigrationTest do
       create table(:no_error_column_migration)
 
       alter table(:no_error_column_migration) do
-        remove_if_exists :posts
+        add_if_not_exists  :value, :integer
+        add_if_not_exists  :value, :integer
+
+        remove_if_exists :value
+        remove_if_exists :value
       end
     end
 
@@ -440,6 +464,13 @@ defmodule Ecto.Integration.MigrationTest do
     assert :ok == up(PoolRepo, num, AddColumnMigration, log: false)
     assert [2] == PoolRepo.all from p in "add_col_migration", select: p.to_be_added
     :ok = down(PoolRepo, num, AddColumnMigration, log: false)
+  end
+
+  @tag :add_column_if_not_exists
+  test "add column if not exists", %{migration_number: num} do
+    assert :ok == up(PoolRepo, num, AddColumnIfNotExistsMigration, log: false)
+    assert [2] == PoolRepo.all from p in "add_col_if_not_exists_migration", select: p.to_be_added
+    :ok = down(PoolRepo, num, AddColumnIfNotExistsMigration, log: false)
   end
 
   @tag :modify_column

--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -42,26 +42,6 @@ defmodule Ecto.Integration.MigrationTest do
     end
   end
 
-  defmodule AddColumnIfNotExistsMigration do
-    use Ecto.Migration
-
-    def up do
-      create table(:add_col_if_not_exists_migration) do
-        add :value, :integer
-      end
-
-      alter table(:add_col_if_not_exists_migration) do
-        add :to_be_added, :integer
-      end
-
-      execute "INSERT INTO add_col_if_not_exists_migration (value, to_be_added) VALUES (1, 2)"
-    end
-
-    def down do
-      drop table(:add_col_if_not_exists_migration)
-    end
-  end
-
   defmodule AlterColumnMigration do
     use Ecto.Migration
 
@@ -189,27 +169,6 @@ defmodule Ecto.Integration.MigrationTest do
 
     def down do
       drop table(:drop_col_migration)
-    end
-  end
-
-  defmodule DropColumnIfExistsMigration do
-    use Ecto.Migration
-
-    def up do
-      create table(:drop_col_if_exists_migration) do
-        add :value, :integer
-        add :to_be_removed, :integer
-      end
-
-      execute "INSERT INTO drop_col_if_exists_migration (value, to_be_removed) VALUES (1, 2)"
-
-      alter table(:drop_col_if_exists_migration) do
-        remove :to_be_removed
-      end
-    end
-
-    def down do
-      drop table(:drop_col_if_exists_migration)
     end
   end
 
@@ -350,26 +309,6 @@ defmodule Ecto.Integration.MigrationTest do
     end
   end
 
-  defmodule NoErrorColumnMigration do
-    use Ecto.Migration
-
-    def up do
-      create table(:no_error_column_migration)
-
-      alter table(:no_error_column_migration) do
-        add_if_not_exists  :value, :integer
-        add_if_not_exists  :value, :integer
-
-        remove_if_exists :value
-        remove_if_exists :value
-      end
-    end
-
-    def down do
-      drop table(:no_error_column_migration)
-    end
-  end
-
   defmodule InferredDropIndexMigration do
     use Ecto.Migration
 
@@ -447,12 +386,6 @@ defmodule Ecto.Integration.MigrationTest do
     assert :ok == up(PoolRepo, num, NoErrorIndexMigration, log: false)
   end
 
-  @tag :remove_column_if_exists
-  test "drop column if exists does not raise on failure", %{migration_number: num} do
-    assert :ok == up(PoolRepo, num, NoErrorColumnMigration, log: false)
-    assert :ok == down(PoolRepo, num, NoErrorColumnMigration, log: false)
-  end
-
   test "raises on NoSQL migrations", %{migration_number: num} do
     assert_raise ArgumentError, ~r"does not support keyword lists in :options", fn ->
       up(PoolRepo, num, NoSQLMigration, log: false)
@@ -464,13 +397,6 @@ defmodule Ecto.Integration.MigrationTest do
     assert :ok == up(PoolRepo, num, AddColumnMigration, log: false)
     assert [2] == PoolRepo.all from p in "add_col_migration", select: p.to_be_added
     :ok = down(PoolRepo, num, AddColumnMigration, log: false)
-  end
-
-  @tag :add_column_if_not_exists
-  test "add column if not exists", %{migration_number: num} do
-    assert :ok == up(PoolRepo, num, AddColumnIfNotExistsMigration, log: false)
-    assert [2] == PoolRepo.all from p in "add_col_if_not_exists_migration", select: p.to_be_added
-    :ok = down(PoolRepo, num, AddColumnIfNotExistsMigration, log: false)
   end
 
   @tag :modify_column
@@ -521,13 +447,6 @@ defmodule Ecto.Integration.MigrationTest do
     assert :ok == up(PoolRepo, num, DropColumnMigration, log: false)
     assert catch_error(PoolRepo.all from p in "drop_col_migration", select: p.to_be_removed)
     :ok = down(PoolRepo, num, DropColumnMigration, log: false)
-  end
-
-  @tag :remove_column_if_exists
-  test "remove column when exists", %{migration_number: num} do
-    assert :ok == up(PoolRepo, num, DropColumnIfExistsMigration, log: false)
-    assert catch_error(PoolRepo.all from p in "drop_col_if_exists_migration", select: p.to_be_removed)
-    :ok = down(PoolRepo, num, DropColumnIfExistsMigration, log: false)
   end
 
   @tag :rename_column

--- a/lib/ecto/adapter/migration.ex
+++ b/lib/ecto/adapter/migration.ex
@@ -29,6 +29,7 @@ defmodule Ecto.Adapter.Migration do
           | {:modify, field :: atom, type :: Ecto.Type.t() | Reference.t(), Keyword.t()}
           | {:remove, field :: atom, type :: Ecto.Type.t() | Reference.t(), Keyword.t()}
           | {:remove, field :: atom}
+          | {:remove_if_exists, field :: atom}
 
   @typedoc """
   A struct that represents a table or index in a database schema.

--- a/lib/ecto/adapter/migration.ex
+++ b/lib/ecto/adapter/migration.ex
@@ -26,6 +26,7 @@ defmodule Ecto.Adapter.Migration do
   @typedoc "All commands allowed within the block passed to `table/2`"
   @type table_subcommand ::
           {:add, field :: atom, type :: Ecto.Type.t() | Reference.t(), Keyword.t()}
+          | {:add_if_not_exists, field :: atom, type :: Ecto.Type.t() | Reference.t(), Keyword.t()}
           | {:modify, field :: atom, type :: Ecto.Type.t() | Reference.t(), Keyword.t()}
           | {:remove, field :: atom, type :: Ecto.Type.t() | Reference.t(), Keyword.t()}
           | {:remove, field :: atom}

--- a/lib/ecto/adapter/migration.ex
+++ b/lib/ecto/adapter/migration.ex
@@ -30,7 +30,7 @@ defmodule Ecto.Adapter.Migration do
           | {:modify, field :: atom, type :: Ecto.Type.t() | Reference.t(), Keyword.t()}
           | {:remove, field :: atom, type :: Ecto.Type.t() | Reference.t(), Keyword.t()}
           | {:remove, field :: atom}
-          | {:remove_if_exists, field :: atom}
+          | {:remove_if_exists, type :: Ecto.Type.t() | Reference.t()}
 
   @typedoc """
   A struct that represents a table or index in a database schema.

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -752,6 +752,13 @@ if Code.ensure_loaded?(Mariaex) do
       ["ADD ", quote_name(name), ?\s, column_type(type, opts), column_options(opts)]
     end
 
+    defp column_change(table, {:add, name, %Reference{} = ref, opts}),
+      do: error!(nil, "PostgreSQL adapter does not support conditional add on constraints")
+
+    defp column_change(_table, {:add_if_not_exists, name, type, opts}) do
+      ["ADD IF NOT EXISTS", quote_name(name), ?\s, column_type(type, opts), column_options(opts)]
+    end
+
     defp column_change(table, {:modify, name, %Reference{} = ref, opts}) do
       [drop_constraint_expr(opts[:from], table, name), "MODIFY ", quote_name(name), ?\s, reference_column_type(ref.type, opts),
        column_options(opts), constraint_expr(ref, table, name)]
@@ -767,7 +774,7 @@ if Code.ensure_loaded?(Mariaex) do
     end
     defp column_change(_table, {:remove, name, _type, _opts}), do: ["DROP ", quote_name(name)]
 
-    defp column_change(_table, {:remove_if_exists, name}), do: ["DROP IF EXISTS ", quote_name(name)]
+    defp column_change(_table, {:remove_if_exists, name}), do: ["DROP COLUMN IF EXISTS ", quote_name(name)]
 
     defp column_options(opts) do
       default = Keyword.fetch(opts, :default)

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -767,6 +767,8 @@ if Code.ensure_loaded?(Mariaex) do
     end
     defp column_change(_table, {:remove, name, _type, _opts}), do: ["DROP ", quote_name(name)]
 
+    defp column_change(_table, {:remove_if_exists, name}), do: ["DROP IF EXISTS ", quote_name(name)]
+
     defp column_options(opts) do
       default = Keyword.fetch(opts, :default)
       null    = Keyword.get(opts, :null)

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -774,7 +774,10 @@ if Code.ensure_loaded?(Mariaex) do
     end
     defp column_change(_table, {:remove, name, _type, _opts}), do: ["DROP ", quote_name(name)]
 
-    defp column_change(_table, {:remove_if_exists, name}), do: ["DROP COLUMN IF EXISTS ", quote_name(name)]
+    defp column_change(table, {:remove_if_exists, name, %Reference{} = ref}) do
+      [drop_constraint_if_exists_expr(ref, table, name), "DROP IF EXISTS ", quote_name(name)]
+    end
+    defp column_change(_table, {:remove_if_exists, name, _type}), do: ["DROP IF EXISTS", quote_name(name)]
 
     defp column_options(opts) do
       default = Keyword.fetch(opts, :default)
@@ -856,6 +859,11 @@ if Code.ensure_loaded?(Mariaex) do
     defp drop_constraint_expr(%Reference{} = ref, table, name),
       do: ["DROP FOREIGN KEY ", reference_name(ref, table, name), ", "]
     defp drop_constraint_expr(_, _, _),
+      do: []
+
+    defp drop_constraint_if_exists_expr(%Reference{} = ref, table, name),
+      do: ["DROP FOREIGN KEY IF EXISTS ", reference_name(ref, table, name), ", "]
+    defp drop_constraint_if_exists_expr(_, _, _),
       do: []
 
     defp reference_name(%Reference{name: nil}, table, column),

--- a/lib/ecto/adapters/mysql/connection.ex
+++ b/lib/ecto/adapters/mysql/connection.ex
@@ -779,7 +779,7 @@ if Code.ensure_loaded?(Mariaex) do
     defp column_change(table, {:remove_if_exists, name, %Reference{} = ref}) do
       [drop_constraint_if_exists_expr(ref, table, name), "DROP IF EXISTS ", quote_name(name)]
     end
-    defp column_change(_table, {:remove_if_exists, name, _type}), do: ["DROP IF EXISTS", quote_name(name)]
+    defp column_change(_table, {:remove_if_exists, name, _type}), do: ["DROP IF EXISTS ", quote_name(name)]
 
     defp column_options(opts) do
       default = Keyword.fetch(opts, :default)

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -869,8 +869,10 @@ if Code.ensure_loaded?(Postgrex) do
        column_options(type, opts)]
     end
 
-    defp column_change(table, {:add_if_not_exists, name, %Reference{} = ref, opts}),
-      do: error!(nil, "PostgreSQL adapter does not support conditional add on constraints")
+    defp column_change(table, {:add_if_not_exists, name, %Reference{} = ref, opts}) do
+      ["ADD COLUMN IF NOT EXISTS", quote_name(name), ?\s, reference_column_type(ref.type, opts),
+       column_options(ref.type, opts), reference_expr(ref, table, name)]
+    end
 
     defp column_change(_table, {:add_if_not_exists, name, type, opts}) do
       ["ADD COLUMN IF NOT EXISTS", quote_name(name), ?\s, column_type(type, opts),

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -869,6 +869,14 @@ if Code.ensure_loaded?(Postgrex) do
        column_options(type, opts)]
     end
 
+    defp column_change(table, {:add_if_not_exists, name, %Reference{} = ref, opts}),
+      do: error!(nil, "PostgreSQL adapter does not support conditional add on constraints")
+
+    defp column_change(_table, {:add_if_not_exists, name, type, opts}) do
+      ["ADD COLUMN IF NOT EXISTS", quote_name(name), ?\s, column_type(type, opts),
+       column_options(type, opts)]
+    end
+
     defp column_change(table, {:modify, name, %Reference{} = ref, opts}) do
       [drop_constraint_expr(opts[:from], table, name), "ALTER COLUMN ", quote_name(name), " TYPE ", reference_column_type(ref.type, opts),
        constraint_expr(ref, table, name), modify_null(name, opts), modify_default(name, ref.type, opts)]

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -870,12 +870,12 @@ if Code.ensure_loaded?(Postgrex) do
     end
 
     defp column_change(table, {:add_if_not_exists, name, %Reference{} = ref, opts}) do
-      ["ADD COLUMN IF NOT EXISTS", quote_name(name), ?\s, reference_column_type(ref.type, opts),
+      ["ADD COLUMN IF NOT EXISTS ", quote_name(name), ?\s, reference_column_type(ref.type, opts),
        column_options(ref.type, opts), reference_expr(ref, table, name)]
     end
 
     defp column_change(_table, {:add_if_not_exists, name, type, opts}) do
-      ["ADD COLUMN IF NOT EXISTS", quote_name(name), ?\s, column_type(type, opts),
+      ["ADD COLUMN IF NOT EXISTS ", quote_name(name), ?\s, column_type(type, opts),
        column_options(type, opts)]
     end
 
@@ -898,7 +898,7 @@ if Code.ensure_loaded?(Postgrex) do
     defp column_change(table, {:remove_if_exists, name, %Reference{} = ref}) do
       [drop_constraint_if_exists_expr(ref, table, name), "DROP COLUMN IF EXISTS ", quote_name(name)]
     end
-    defp column_change(_table, {:remove_if_exists, name, _type}), do: ["DROP COLUMN IF EXISTS", quote_name(name)]
+    defp column_change(_table, {:remove_if_exists, name, _type}), do: ["DROP COLUMN IF EXISTS ", quote_name(name)]
 
     defp modify_null(name, opts) do
       case Keyword.get(opts, :null) do

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -885,6 +885,8 @@ if Code.ensure_loaded?(Postgrex) do
     end
     defp column_change(_table, {:remove, name, _type, _opts}), do: ["DROP COLUMN ", quote_name(name)]
 
+    defp column_change(_table, {:remove_if_exists, name}), do: ["DROP COLUMN IF EXISTS", quote_name(name)]
+
     defp modify_null(name, opts) do
       case Keyword.get(opts, :null) do
         true  -> [", ALTER COLUMN ", quote_name(name), " DROP NOT NULL"]

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -893,7 +893,10 @@ if Code.ensure_loaded?(Postgrex) do
     end
     defp column_change(_table, {:remove, name, _type, _opts}), do: ["DROP COLUMN ", quote_name(name)]
 
-    defp column_change(_table, {:remove_if_exists, name}), do: ["DROP COLUMN IF EXISTS", quote_name(name)]
+    defp column_change(table, {:remove_if_exists, name, %Reference{} = ref}) do
+      [drop_constraint_if_exists_expr(ref, table, name), "DROP COLUMN IF EXISTS ", quote_name(name)]
+    end
+    defp column_change(_table, {:remove_if_exists, name, _type}), do: ["DROP COLUMN IF EXISTS", quote_name(name)]
 
     defp modify_null(name, opts) do
       case Keyword.get(opts, :null) do
@@ -1014,6 +1017,11 @@ if Code.ensure_loaded?(Postgrex) do
     defp drop_constraint_expr(%Reference{} = ref, table, name),
       do: ["DROP CONSTRAINT ", reference_name(ref, table, name), ", "]
     defp drop_constraint_expr(_, _, _),
+      do: []
+
+    defp drop_constraint_if_exists_expr(%Reference{} = ref, table, name),
+      do: ["DROP CONSTRAINT IF EXISTS ", reference_name(ref, table, name), ", "]
+    defp drop_constraint_if_exists_expr(_, _, _),
       do: []
 
     defp reference_name(%Reference{name: nil}, table, column),

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -788,7 +788,7 @@ defmodule Ecto.Migration do
 
   If the `type` value is a `%Reference{}`, it is used to remove the constraint.
 
- `opts` are exactly the same as in `add/3`, and
+  `type` and `opts` are exactly the same as in `add/3`, and
   they are used when the command is reversed.
 
   ## Examples

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -927,6 +927,22 @@ defmodule Ecto.Migration do
     Runner.subcommand {:remove, column, type, opts}
   end
 
+  @doc """
+  Removes a column only if the column exists when altering a table.
+
+  This command is not reversible as Ecto does not know about column existense before removal.
+
+  ## Examples
+
+      alter table("posts") do
+        remove_if_exists :title
+      end
+
+  """
+  def remove_if_exists(column) when is_atom(column) do
+    Runner.subcommand {:remove_if_exists, column}
+  end
+
   @doc ~S"""
   Defines a foreign key.
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -784,6 +784,37 @@ defmodule Ecto.Migration do
   end
 
   @doc """
+  Adds a column if it not exists yet when altering a table.
+
+  If the `type` value is a `%Reference{}`, it is used to remove the constraint.
+
+ `opts` are exactly the same as in `add/3`, and
+  they are used when the command is reversed.
+
+  ## Examples
+
+      alter table("posts") do
+        add_if_not_exists :title, :string, default: ""
+      end
+
+  """
+  def add_if_not_exists(column, type, opts \\ [])
+
+  def add_if_not_exists(column, :datetime, _opts) when is_atom(column) do
+    raise ArgumentError, "the :datetime type in migrations is not supported, " <>
+                         "please use :utc_datetime or :naive_datetime instead"
+  end
+
+  def add_if_not_exists(column, type, opts) when is_atom(column) and is_list(opts) do
+    if opts[:scale] && !opts[:precision] do
+      raise ArgumentError, "column #{Atom.to_string(column)} is missing precision option"
+    end
+
+    validate_type!(type)
+    Runner.subcommand {:add_if_not_exists, column, type, opts}
+  end
+
+  @doc """
   Renames a table.
 
   ## Examples

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -959,19 +959,21 @@ defmodule Ecto.Migration do
   end
 
   @doc """
-  Removes a column only if the column exists when altering a table.
+  Removes a column only if the column exists when altering the constraint if the reference type is passed
+  once it only has the constraint name on reference structure.
 
-  This command is not reversible as Ecto does not know about column existense before removal.
+  This command is not reversible as Ecto does not know about column existense before the removal attempt.
 
   ## Examples
 
-      alter table("posts") do
-        remove_if_exists :title
-      end
+  alter table("posts") do
+    remove_if_exists :title, :string
+  end
 
   """
-  def remove_if_exists(column) when is_atom(column) do
-    Runner.subcommand {:remove_if_exists, column}
+  def remove_if_exists(column, type) when is_atom(column) do
+    validate_type!(type)
+    Runner.subcommand {:remove_if_exists, column, type}
   end
 
   @doc ~S"""

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -966,9 +966,9 @@ defmodule Ecto.Migration do
 
   ## Examples
 
-  alter table("posts") do
-    remove_if_exists :title, :string
-  end
+      alter table("posts") do
+        remove_if_exists :title, :string
+      end
 
   """
   def remove_if_exists(column, type) when is_atom(column) do

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -253,18 +253,23 @@ defmodule Ecto.MigrationTest do
   test "forward: alters a table" do
     alter table(:posts) do
       add :summary, :text
+      add_if_not_exists :summary, :text
       modify :title, :text
       remove :views
       remove :status, :string
+      remove_if_exists :status, :string
     end
     flush()
 
     assert last_command() ==
            {:alter, %Table{name: "posts"},
               [{:add, :summary, :text, []},
+               {:add_if_not_exists, :summary, :text, []},
                {:modify, :title, :text, []},
                {:remove, :views},
-               {:remove, :status, :string, []}]}
+               {:remove, :status, :string, []},
+               {:remove_if_exists, :status, :string}]
+              }
   end
 
   test "forward: removing a reference column (remove/3 called)" do
@@ -273,6 +278,14 @@ defmodule Ecto.MigrationTest do
     end
     flush()
     assert {:alter, %Table{name: "posts"}, [{:remove, :author_id, %Reference{table: "authors"}, []}]} = last_command()
+  end
+
+  test "forward: removing a reference if column (remove_if_exists/2 called)" do
+    alter table(:posts) do
+      remove_if_exists :author_id, references(:authors)
+    end
+    flush()
+    assert {:alter, %Table{name: "posts"}, [{:remove_if_exists, :author_id, %Reference{table: "authors"}}]} = last_command()
   end
 
   test "forward: alter numeric column without specifying precision" do


### PR DESCRIPTION
[This PR came from this suggestion](https://groups.google.com/forum/#!topic/elixir-ecto/zjl55R2jqEk) and it adds `add_if_not_exists/3` and `remove_if_exists/2` functions for columns.

Only accepting `remove_if_exists/2` with `type` as param, because the constraint/foreign key would not be removed if the user does not pass the type `Reference`. Always try to remove the constraint is an option, but I guess it's better to be explicit here. 

Removed the options from `remove_if_exists` because these operations are not reversible once we have no sure about if the column exists or not before the operations.

Points about compatibility: 
- Postgres only accepts `... IF NOT EXISTS ...` clause [on 9.6 and above versions](https://www.postgresql.org/docs/9.6/sql-altertable.html), skipped below versions on integration tests. 
- [While MySQL doesn't accept conditional column changes](https://dev.mysql.com/doc/refman/5.7/en/alter-table.html), [MariaDB does](https://mariadb.com/kb/en/library/alter-table/), as the build on CI only test on the MySQL, I didn't write any integration tests for MySQL. 

Maybe add MariaDB integration test is a good idea, once the behavior for the same adapter can change, I.E: [this test always fail on integration tests while using MariaDB](https://github.com/elixir-ecto/ecto_sql/blob/master/integration_test/sql/migration.exs#L453-L457). :thinking: 


