### PR TITLE
Fix link markup in docs

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -583,8 +583,7 @@ defmodule Ecto.Migration do
 
   For example, PostgreSQL supports several index types like B-tree (the
   default), Hash, GIN, and GiST. More information on index types can be found
-  in the [PostgreSQL docs]
-  (http://www.postgresql.org/docs/9.4/static/indexes-types.html).
+  in the [PostgreSQL docs](http://www.postgresql.org/docs/9.4/static/indexes-types.html).
 
   ## Partial indexes
 


### PR DESCRIPTION
This PR fixes the docs markup to generate a proper link. This is what the docs generator outputs without this PR:

![image](https://user-images.githubusercontent.com/491891/52553605-4f6f5300-2de4-11e9-8939-6d8cc5ca76e6.png)
https://hexdocs.pm/ecto_sql/Ecto.Migration.html#index/3