### PR TITLE
Fix measurements logging

### DIFF
--- a/integration_test/sql/logging.exs
+++ b/integration_test/sql/logging.exs
@@ -35,6 +35,12 @@ defmodule Ecto.Integration.LoggingTest do
     refute_received :logged
   end
 
+  test "log entry when some measurements are nil" do
+    assert ExUnit.CaptureLog.capture_log(fn ->
+             TestRepo.query("BEG", [], log: :error)
+           end) =~ "[error]"
+  end
+
   test "log entry with custom log level" do
     assert ExUnit.CaptureLog.capture_log(fn ->
              TestRepo.insert!(%Post{title: "1"}, [log: :error])

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -819,11 +819,9 @@ defmodule Ecto.Adapters.SQL do
   defp log_result(_), do: :error
 
   defp log_iodata(measurements, metadata) do
-    %{
-      query_time: query_time,
-      decode_time: decode_time,
-      queue_time: queue_time,
-    } = measurements
+    query_time = Map.get(measurements, :query_time)
+    decode_time = Map.get(measurements, :decode_time)
+    queue_time = Map.get(measurements, :queue_time)
 
     %{
       params: params,


### PR DESCRIPTION
Given that `queue_time`, `decode_time` and `query_time` can be `nil`, the `log_measurements` function could return a map striped off of these `nil` values. In such cases, the `log_iodata` function would then try to pattern match against a map that contain these keys and fail with the following error:

```
an exception was raised logging %DBConnection.LogEntry{call: :begin, connection_time: 3222624, decode_time: nil, params: nil, pool_time: 68280, query: :begin, result: {:ok, %DBConnection{co
nn_mode: nil, conn_ref: #Reference<0.1163111061.2296119302.242869>, pool_ref: {:pool_ref, #PID<0.441.0>, #Reference<0.1163111061.2296250374.242483>, #Reference<0.1163111061.2296119302.242868>, #Reference<0.1163111061.2296250374.242753>, #
Reference<0.1163111061.2296119302.242867>}}, %Postgrex.Result{columns: nil, command: :commit, connection_id: 3466, messages: [], num_rows: nil, rows: nil}}}: ** (MatchError) no match of right hand side value: %{query_time: 3222624, queue_
time: 68280, total_time: 3290904}
    (ecto_sql) lib/ecto/adapters/sql.ex:826: Ecto.Adapters.SQL.log_iodata/2
    (logger) lib/logger.ex:758: Logger.normalize_message/2
    (logger) lib/logger.ex:618: Logger.bare_log/3
    (ecto_sql) lib/ecto/adapters/sql.ex:798: Ecto.Adapters.SQL.log/4
    (db_connection) lib/db_connection.ex:1317: DBConnection.log/5
    (db_connection) lib/db_connection.ex:778: DBConnection.transaction/3
```

This PR fixes that issue by removing the pattern matching and replacing it by a `Map.get`.

The only way I found to reproduce this in the tests was to run an invalid query so that the `decode_time` would be `nil`. I'm open to any other suggestion.