### PR TITLE
work with dynamic multi tenant databases

### DIFF
--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -107,8 +107,8 @@ defmodule Ecto.Migration.Runner do
 
     commands  = if direction == :backward, do: commands, else: Enum.reverse(commands)
 
+    {repo, repo_name, direction, log} = runner_config()
     for command <- commands do
-      {repo, repo_name, direction, log} = runner_config()
       execute_in_direction(repo, repo_name, direction, log, command)
     end
   end

--- a/lib/ecto/migration/schema_migration.ex
+++ b/lib/ecto/migration/schema_migration.ex
@@ -14,10 +14,11 @@ defmodule Ecto.Migration.SchemaMigration do
 
   @opts [timeout: :infinity, log: false]
 
-  def ensure_schema_migrations_table!(repo, prefix) do
+  def ensure_schema_migrations_table!(repo, opts) do
     table_name = repo |> get_source |> String.to_atom()
-    table = %Ecto.Migration.Table{name: table_name, prefix: prefix}
-    meta = Ecto.Adapter.lookup_meta(repo)
+    table = %Ecto.Migration.Table{name: table_name, prefix: opts[:prefix]}
+    name = Keyword.get(opts, :name, repo)
+    meta = Ecto.Adapter.lookup_meta(name)
 
     commands = [
       {:add, :version, :bigint, primary_key: true},

--- a/lib/ecto/migration/schema_migration.ex
+++ b/lib/ecto/migration/schema_migration.ex
@@ -37,16 +37,24 @@ defmodule Ecto.Migration.SchemaMigration do
   def up(repo, repo_name, version, prefix) do
     %__MODULE__{version: version}
     |> Ecto.put_meta(prefix: prefix, source: get_source(repo))
-    |> (&(Ecto.Repo.Schema.insert!(repo_name, &1, @opts))).()
+    |> repo_insert(repo_name)
   end
 
   def down(repo, repo_name, version, prefix) do
     from(p in get_source(repo), where: p.version == type(^version, :integer))
     |> Map.put(:prefix, prefix)
-    |> (&(Ecto.Repo.Queryable.delete_all(repo_name, &1, @opts))).()
+    |> repo_delete_all(repo_name)
   end
 
   def get_source(repo) do
     Keyword.get(repo.config, :migration_source, "schema_migrations")
+  end
+
+  defp repo_insert(schema_migration_struct, repo_name) do
+    Ecto.Repo.Schema.insert!(repo_name, schema_migration_struct, @opts)
+  end
+
+  defp repo_delete_all(schema_migration_query, repo_name) do
+    Ecto.Repo.Queryable.delete_all(repo_name, schema_migration_query, @opts)
   end
 end

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -50,7 +50,7 @@ defmodule Ecto.Migrator do
   @spec migrated_versions(Ecto.Repo.t, Keyword.t) :: [integer]
   def migrated_versions(repo, opts \\ []) do
     verbose_schema_migration repo, "retrieve migrated versions", fn ->
-      SchemaMigration.ensure_schema_migrations_table!(repo, opts[:prefix])
+      SchemaMigration.ensure_schema_migrations_table!(repo, opts)
     end
 
     lock_for_migrations repo, opts, fn versions -> versions end
@@ -71,7 +71,7 @@ defmodule Ecto.Migrator do
   @spec up(Ecto.Repo.t, integer, module, Keyword.t) :: :ok | :already_up
   def up(repo, version, module, opts \\ []) do
     verbose_schema_migration repo, "create schema migrations table", fn ->
-      SchemaMigration.ensure_schema_migrations_table!(repo, opts[:prefix])
+      SchemaMigration.ensure_schema_migrations_table!(repo, opts)
     end
 
     lock_for_migrations repo, opts, fn versions ->
@@ -131,7 +131,7 @@ defmodule Ecto.Migrator do
   @spec down(Ecto.Repo.t, integer, module) :: :ok | :already_down
   def down(repo, version, module, opts \\ []) do
     verbose_schema_migration repo, "create schema migrations table", fn ->
-      SchemaMigration.ensure_schema_migrations_table!(repo, opts[:prefix])
+      SchemaMigration.ensure_schema_migrations_table!(repo, opts)
     end
 
     lock_for_migrations repo, opts, fn versions ->
@@ -267,7 +267,7 @@ defmodule Ecto.Migrator do
   @spec run(Ecto.Repo.t, binary | [{integer, module}], atom, Keyword.t) :: [integer]
   def run(repo, migration_source, direction, opts) do
     verbose_schema_migration repo, "create schema migrations table", fn ->
-      SchemaMigration.ensure_schema_migrations_table!(repo, opts[:prefix])
+      SchemaMigration.ensure_schema_migrations_table!(repo, opts)
     end
 
     pending =
@@ -344,7 +344,8 @@ defmodule Ecto.Migrator do
 
   defp lock_for_migrations(repo, opts, fun) do
     query = SchemaMigration.versions(repo, opts[:prefix])
-    meta = Ecto.Adapter.lookup_meta(repo)
+    name = Keyword.get(opts, :name, repo)
+    meta = Ecto.Adapter.lookup_meta(name)
     callback = &fun.(repo.all(&1, timeout: :infinity, log: false))
 
     case repo.__adapter__.lock_for_migrations(meta, query, opts, callback) do

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -45,6 +45,7 @@ defmodule Ecto.Migrator do
   ## Options
 
     * `:prefix` - the prefix to run the migrations on
+    * `:repo_name` - the name of the Repo supervisor process
 
   """
   @spec migrated_versions(Ecto.Repo.t, Keyword.t) :: [integer]
@@ -66,6 +67,7 @@ defmodule Ecto.Migrator do
     * `:log_sql` - the level to use for logging of SQL instructions.
       Defaults to `false`. Can be any of `Logger.level/0` values or a boolean.
     * `:prefix` - the prefix to run the migrations on
+    * `:repo_name` - the name of the Repo supervisor process
     * `:strict_version_order` - abort when applying a migration with old timestamp
   """
   @spec up(Ecto.Repo.t, integer, module, Keyword.t) :: :ok | :already_up
@@ -126,6 +128,7 @@ defmodule Ecto.Migrator do
     * `:log_sql` - the level to use for logging of SQL instructions.
       Defaults to `false`. Can be any of `Logger.level/0` values or a boolean.
     * `:prefix` - the prefix to run the migrations on
+    * `:repo_name` - the name of the Repo supervisor process
 
   """
   @spec down(Ecto.Repo.t, integer, module) :: :ok | :already_down

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -348,7 +348,7 @@ defmodule Ecto.Migrator do
     query = SchemaMigration.versions(repo, opts[:prefix])
     repo_name = Keyword.get(opts, :repo_name, repo)
     meta = Ecto.Adapter.lookup_meta(repo_name)
-    callback = &fun.(Ecto.Repo.Queryable.all(repo_name, &1, timeout: :infinity, log: false, repo_name: repo_name))
+    callback = &fun.(Ecto.Repo.Queryable.all(repo_name, &1, timeout: :infinity, log: false))
 
     case repo.__adapter__.lock_for_migrations(meta, query, opts, callback) do
       {kind, reason, stacktrace} ->

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -18,7 +18,7 @@ defmodule Ecto.MigrationTest do
 
   setup meta do
     direction = meta[:direction] || :forward
-    {:ok, runner} = Runner.start_link(self(), TestRepo, direction, :up, %{level: false, sql: false})
+    {:ok, runner} = Runner.start_link(self(), TestRepo, TestRepo, direction, :up, %{level: false, sql: false})
     Runner.metadata(runner, meta)
     {:ok, runner: runner}
   end

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -466,7 +466,7 @@ defmodule Ecto.MigratorTest do
     end
 
     test "version migrations stop before all have been run" do
-      assert run(TestRepo, [{13, ChangeMigration}, {14, UpDownMigration}], :up, to: 13, log: false, repo_name: :tenant_db) == [13]
+      assert run(TestRepo, [{13, ChangeMigration}, {14, UpDownMigration}], :up, to: 13, log: false) == [13]
     end
 
     test "version migrations stop at the number of available migrations" do

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -466,8 +466,7 @@ defmodule Ecto.MigratorTest do
     end
 
     test "version migrations stop before all have been run" do
-      TestRepo.put_dynamic_repo(:tenant_db)
-      assert run(TestRepo, [{13, ChangeMigration}, {14, UpDownMigration}], :up, to: 13, log: false, name: :tenant_db) == [13]
+      assert run(TestRepo, [{13, ChangeMigration}, {14, UpDownMigration}], :up, to: 13, log: false, repo_name: :tenant_db) == [13]
     end
 
     test "version migrations stop at the number of available migrations" do

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -466,7 +466,8 @@ defmodule Ecto.MigratorTest do
     end
 
     test "version migrations stop before all have been run" do
-      assert run(TestRepo, [{13, ChangeMigration}, {14, UpDownMigration}], :up, to: 13, log: false) == [13]
+      TestRepo.put_dynamic_repo(:tenant_db)
+      assert run(TestRepo, [{13, ChangeMigration}, {14, UpDownMigration}], :up, to: 13, log: false, name: :tenant_db) == [13]
     end
 
     test "version migrations stop at the number of available migrations" do

--- a/test/ecto/tenant_migrator_test.exs
+++ b/test/ecto/tenant_migrator_test.exs
@@ -1,0 +1,70 @@
+defmodule Ecto.TenantMigratorTest do
+  use ExUnit.Case
+
+  import Ecto.Migrator
+  import ExUnit.CaptureLog
+
+  alias EctoSQL.TestRepo
+
+  defmodule Migration do
+    use Ecto.Migration
+
+    def up do
+      execute "up"
+    end
+
+    def down do
+      execute "down"
+    end
+  end
+
+  defmodule ChangeMigration do
+    use Ecto.Migration
+
+    def change do
+      create table(:posts) do
+        add :name, :string
+      end
+
+      create index(:posts, [:title])
+    end
+  end
+
+  setup do
+    Process.put(:migrated_versions, [1, 2, 3])
+    :ok
+  end
+
+  def put_test_adapter_config(config) do
+    Application.put_env(:ecto_sql, EctoSQL.TestAdapter, config)
+
+    on_exit fn ->
+      Application.delete_env(:ecto, EctoSQL.TestAdapter)
+    end
+  end
+
+  describe "repo_name option" do
+    test "upwards and downwards migrations" do
+      assert run(TestRepo, [{3, ChangeMigration}, {4, Migration}], :up, to: 4, log: false, repo_name: :tenant_db) == [4]
+      assert run(TestRepo, [{2, ChangeMigration}, {3, Migration}], :down, all: true, log: false, repo_name: :tenant_db) == [3, 2]
+    end
+
+    test "down invokes the repository adapter with down commands" do
+      assert down(TestRepo, 0, Migration, log: false, repo_name: :tenant_db) == :already_down
+      assert down(TestRepo, 2, Migration, log: false, repo_name: :tenant_db) == :ok
+    end
+
+    test "up invokes the repository adapter with up commands" do
+      assert up(TestRepo, 3, Migration, log: false, repo_name: :tenant_db) == :already_up
+      assert up(TestRepo, 4, Migration, log: false, repo_name: :tenant_db) == :ok
+    end
+
+    test "migrations run inside a transaction if the adapter supports ddl transactions" do
+      capture_log fn ->
+        put_test_adapter_config(supports_ddl_transaction?: true, test_process: self())
+        up(TestRepo, 0, Migration, repo_name: :tenant_db)
+        assert_receive {:transaction, _}
+      end
+    end
+  end
+end

--- a/test/test_repo.exs
+++ b/test/test_repo.exs
@@ -91,6 +91,16 @@ end
 
 defmodule EctoSQL.TestRepo do
   use Ecto.Repo, otp_app: :ecto_sql, adapter: EctoSQL.TestAdapter
+
+  def put_dynamic_repo(name) do
+    Process.put(:current_repo, name)
+  end
+
+  defp dynamic_repo(), do: Process.get(:current_repo, __MODULE__)
+
+  def all(queryable, opts) do
+    Ecto.Repo.Queryable.all(dynamic_repo(), queryable, opts)
+  end
 end
 
 EctoSQL.TestRepo.start_link()

--- a/test/test_repo.exs
+++ b/test/test_repo.exs
@@ -94,3 +94,4 @@ defmodule EctoSQL.TestRepo do
 end
 
 EctoSQL.TestRepo.start_link()
+EctoSQL.TestRepo.start_link(name: :tenant_db)

--- a/test/test_repo.exs
+++ b/test/test_repo.exs
@@ -91,16 +91,6 @@ end
 
 defmodule EctoSQL.TestRepo do
   use Ecto.Repo, otp_app: :ecto_sql, adapter: EctoSQL.TestAdapter
-
-  def put_dynamic_repo(name) do
-    Process.put(:current_repo, name)
-  end
-
-  defp dynamic_repo(), do: Process.get(:current_repo, __MODULE__)
-
-  def all(queryable, opts) do
-    Ecto.Repo.Queryable.all(dynamic_repo(), queryable, opts)
-  end
 end
 
 EctoSQL.TestRepo.start_link()


### PR DESCRIPTION
This is proposal to get working with multiple tenant databases under one Repo. Despite of fact that `ecto_sql` seems to have only one `repo.all` callback I've used here `put_dynamic_repo` helper function from https://github.com/elixir-ecto/ecto/pull/2947 to avoid writing extra repo code or modifying repo functions to pass extra `:name` arg just to find right tenant db repo process. The idea is to add `:name` argument to `Ecto.Migrator.run` if my Repo has linked multiple tenant databases and iterate migrations trough all defined names. For now I've modified only one test to check this proof of concept.