### PR TITLE
add to Ecto.Migration.Runner repo_name helper function

### DIFF
--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -85,6 +85,13 @@ defmodule Ecto.Migration.Runner do
   end
 
   @doc """
+  Gets the repo_name for this migration
+  """
+  def repo_name do
+    Agent.get(runner(), & &1.repo_name)
+  end
+
+  @doc """
   Gets the prefix for this migration
   """
   def prefix do

--- a/test/ecto/runner_test.exs
+++ b/test/ecto/runner_test.exs
@@ -1,0 +1,31 @@
+defmodule Ecto.Migration.RunnerTest do
+  use ExUnit.Case
+
+  import Ecto.Migration.Runner
+
+  alias EctoSQL.TestRepo
+
+  describe "repo_name" do
+    test "get by repo name" do
+      {:ok, runner} = start_link(self(), TestRepo, :tenant_db, :forward, :up, %{level: false, sql: false})
+      Process.put(:ecto_migration, %{runner: runner, prefix: nil})
+
+      assert repo_name() == :tenant_db
+      stop()
+    end
+
+    test "get by named repo" do
+      {:ok, runner} = start_link(self(), TestRepo, TestRepo, :forward, :up, %{level: false, sql: false})
+      Process.put(:ecto_migration, %{runner: runner, prefix: nil})
+
+      assert repo_name() == TestRepo
+      stop()
+    end
+
+    test "get when runner is not started" do
+      assert_raise RuntimeError, ~r/could not find migration runner process/, fn ->
+        repo_name()
+      end
+    end
+  end
+end

--- a/test/ecto/runner_test.exs
+++ b/test/ecto/runner_test.exs
@@ -14,14 +14,6 @@ defmodule Ecto.Migration.RunnerTest do
       stop()
     end
 
-    test "get by named repo" do
-      {:ok, runner} = start_link(self(), TestRepo, TestRepo, :forward, :up, %{level: false, sql: false})
-      Process.put(:ecto_migration, %{runner: runner, prefix: nil})
-
-      assert repo_name() == TestRepo
-      stop()
-    end
-
     test "get when runner is not started" do
       assert_raise RuntimeError, ~r/could not find migration runner process/, fn ->
         repo_name()

--- a/test/ecto/runner_test.exs
+++ b/test/ecto/runner_test.exs
@@ -5,8 +5,8 @@ defmodule Ecto.Migration.RunnerTest do
 
   alias EctoSQL.TestRepo
 
-  describe "repo_name" do
-    test "get by repo name" do
+  describe "repo_name/0" do
+    test "runner repo_name" do
       {:ok, runner} = start_link(self(), TestRepo, :tenant_db, :forward, :up, %{level: false, sql: false})
       Process.put(:ecto_migration, %{runner: runner, prefix: nil})
 
@@ -14,7 +14,7 @@ defmodule Ecto.Migration.RunnerTest do
       stop()
     end
 
-    test "get when runner is not started" do
+    test "when runner is not started" do
       assert_raise RuntimeError, ~r/could not find migration runner process/, fn ->
         repo_name()
       end


### PR DESCRIPTION
I realised that `Process.put(:repo_name, current_tenant_repo_name)` doesn't work during migrations, so it might be helpful to get `repo_name` directly from migration runner process instead of
```elixir
case Process.get(:ecto_migration) do
  %{runner: runner} ->
    Agent.get(runner, & &1.repo_name)
  nil -> nil
end
```