### PR TITLE
Purge and delete compiled module between migrations to prevent warning about module current version defined in memory

### DIFF
--- a/integration_test/sql/migrator.exs
+++ b/integration_test/sql/migrator.exs
@@ -121,16 +121,12 @@ defmodule Ecto.Integration.MigratorTest do
 
   test "run down to/step migration", config do
     in_tmp fn path ->
-      migrations = [
-        create_migration(49, config),
-        create_migration(50, config),
-      ]
+      create_migration(49, config)
+      create_migration(50, config)
 
       assert [49, 50] = run(PoolRepo, path, :up, all: true, log: false)
-      purge migrations
 
       assert [50] = run(PoolRepo, path, :down, step: 1, log: false)
-      purge migrations
 
       assert count_entries() == 1
       assert [50] = run(PoolRepo, path, :up, to: 50, log: false)
@@ -139,17 +135,13 @@ defmodule Ecto.Integration.MigratorTest do
 
   test "runs all migrations", config do
     in_tmp fn path ->
-      migrations = [
-        create_migration(53, config),
-        create_migration(54, config),
-      ]
+      create_migration(53, config)
+      create_migration(54, config)
 
       assert [53, 54] = run(PoolRepo, path, :up, all: true, log: false)
       assert [] = run(PoolRepo, path, :up, all: true, log: false)
-      purge migrations
 
       assert [54, 53] = run(PoolRepo, path, :down, all: true, log: false)
-      purge migrations
 
       assert count_entries() == 0
       assert [53, 54] = run(PoolRepo, path, :up, all: true, log: false)
@@ -158,10 +150,8 @@ defmodule Ecto.Integration.MigratorTest do
 
   test "does not commit half transactions on bad syntax", config do
     in_tmp fn path ->
-      migrations = [
-        create_migration(64, config),
-        create_migration("65_+", config)
-      ]
+      create_migration(64, config)
+      create_migration("65_+", config)
 
       assert_raise SyntaxError, fn ->
         run(PoolRepo, path, :up, all: true, log: false)
@@ -169,7 +159,6 @@ defmodule Ecto.Integration.MigratorTest do
 
       refute_received {:up, _}
       assert count_entries() == 0
-      purge migrations
     end
   end
 
@@ -231,12 +220,5 @@ defmodule Ecto.Integration.MigratorTest do
     """
 
     module
-  end
-
-  defp purge(modules) do
-    Enum.each(List.wrap(modules), fn m ->
-      :code.delete m
-      :code.purge m
-    end)
   end
 end

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -467,8 +467,11 @@ defmodule Ecto.Migrator do
 
   defp migrate(migrations, direction, repo, opts) do
     for {version, mod} <- migrations,
-        do_direction(direction, repo, version, mod, opts),
-        do: version
+        do_direction(direction, repo, version, mod, opts) do
+      :code.purge(mod)
+      :code.delete(mod)
+      version
+    end
   end
 
   defp do_direction(:up, repo, version, mod, opts) do

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -446,7 +446,7 @@ defmodule Ecto.Migrator do
   end
 
   defp load_migration!({version, _, file}) when is_binary(file) do
-    loaded_modules = file |> Code.load_file() |> Enum.map(&elem(&1, 0))
+    loaded_modules = file |> Code.compile_file() |> Enum.map(&elem(&1, 0))
 
     if mod = Enum.find(loaded_modules, &migration?/1) do
       {version, mod}


### PR DESCRIPTION
Purge and delete compiled module code between migrations to prevent warning about ` redefining module current version defined in memory`. I feel anxiety when I have hundreds migration files x each tenant database with so many warnings.

Question if shouldn't `:code.purge()` and `:code.delete()` be added to Elixir Code module under one function eg. `Code.purge_and_delete(module)`?