### PR TITLE
Fix UTC Timestamps in PostgreSQL

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -977,10 +977,10 @@ if Code.ensure_loaded?(Postgrex) do
     defp column_type({:array, type}, opts),
       do: [column_type(type, opts), "[]"]
 
-    defp column_type(type, _opts) when type in ~w(time utc_datetime naive_datetime)a,
+    defp column_type(type, _opts) when type in ~w(time naive_datetime)a,
       do: [ecto_to_db(type), "(0)"]
 
-    defp column_type(type, opts) when type in ~w(time_usec utc_datetime_usec naive_datetime_usec)a do
+    defp column_type(type, opts) when type in ~w(time_usec naive_datetime_usec)a do
       precision = Keyword.get(opts, :precision)
       type_name = ecto_to_db(type)
 
@@ -988,6 +988,20 @@ if Code.ensure_loaded?(Postgrex) do
         [type_name, ?(, to_string(precision), ?)]
       else
         type_name
+      end
+    end
+
+    defp column_type(type, _opts) when type == :utc_datetime,
+      do: [ecto_to_db(type), "(0)", " with time zone"]
+
+    defp column_type(type, opts) when type == :utc_datetime_usec do
+      precision = Keyword.get(opts, :precision)
+      type_name = ecto_to_db(type)
+
+      if precision do
+        [type_name, ?(, to_string(precision), ?), " with time zone"]
+      else
+        [type_name, " with time zone"]
       end
     end
 

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1186,7 +1186,7 @@ defmodule Ecto.Adapters.PostgresTest do
               [{:add, :published_at, :utc_datetime, [precision: 3]},
                {:add, :submitted_at, :utc_datetime, []}]}
 
-    assert execute_ddl(create) == [~s|CREATE TABLE "posts" ("published_at" timestamp(0), "submitted_at" timestamp(0))|]
+    assert execute_ddl(create) == [~s|CREATE TABLE "posts" ("published_at" timestamp(0) with time zone, "submitted_at" timestamp(0) with time zone)|]
   end
 
   test "create table with utc_datetime_usec columns" do
@@ -1194,7 +1194,7 @@ defmodule Ecto.Adapters.PostgresTest do
               [{:add, :published_at, :utc_datetime_usec, [precision: 3]},
                {:add, :submitted_at, :utc_datetime_usec, []}]}
 
-    assert execute_ddl(create) == [~s|CREATE TABLE "posts" ("published_at" timestamp(3), "submitted_at" timestamp)|]
+    assert execute_ddl(create) == [~s|CREATE TABLE "posts" ("published_at" timestamp(3) with time zone, "submitted_at" timestamp with time zone)|]
   end
 
   test "create table with naive_datetime columns" do


### PR DESCRIPTION
According to the [docs](https://hexdocs.pm/ecto_sql/Ecto.Migration.html#timestamps/1), `timestamps(type: :utc_datetime)` should result in PostgreSQL columns of type `timestamp(0) with time zone`.

However, those options result in columns with unexpected types (no time zone):
```
   Column    |              Type
-------------+--------------------------------
 inserted_at | timestamp(0) without time zone
 updated_at  | timestamp(0) without time zone
```

This change fixes those options to result in columns with the expected types (with time zone):
```
   Column    |            Type
-------------+-----------------------------
 inserted_at | timestamp(0) with time zone
 updated_at  | timestamp(0) with time zone
```