### PR TITLE
Telemetry event `metadata.result` missing actual result

### DIFF
--- a/integration_test/sql/logging.exs
+++ b/integration_test/sql/logging.exs
@@ -7,7 +7,7 @@ defmodule Ecto.Integration.LoggingTest do
   test "log entry is sent to telemetry" do
     log = fn event_name, measurement, metadata ->
       assert Enum.at(event_name, -1) == :query
-      assert %{result: :ok} = metadata
+      assert %{result: {:ok, _res}} = metadata
       assert measurement.total_time == measurement.query_time + measurement.decode_time + measurement.queue_time
       send(self(), :logged)
     end
@@ -19,7 +19,7 @@ defmodule Ecto.Integration.LoggingTest do
 
   test "log entry sent under another event name" do
     log = fn [:custom], measurements, metadata ->
-      assert %{result: :ok} = metadata
+      assert %{result: {:ok, _res}} = metadata
       assert measurements.total_time == measurements.query_time + measurements.decode_time + measurements.queue_time
       send(self(), :logged)
     end

--- a/integration_test/sql/transaction.exs
+++ b/integration_test/sql/transaction.exs
@@ -222,7 +222,7 @@ defmodule Ecto.Integration.TransactionTest do
     register_telemetry()
 
     PoolRepo.transaction(fn ->
-      assert_received {measurements, %{params: [], result: :ok}}
+      assert_received {measurements, %{params: [], result: {:ok, _res}}}
       assert is_integer(measurements.query_time) and measurements.query_time >= 0
       assert is_integer(measurements.queue_time) and measurements.queue_time >= 0
 
@@ -230,7 +230,7 @@ defmodule Ecto.Integration.TransactionTest do
       register_telemetry()
     end)
 
-    assert_received {measurements, %{params: [], result: :ok}}
+    assert_received {measurements, %{params: [], result: {:ok, _res}}}
     assert is_integer(measurements.query_time) and measurements.query_time >= 0
     refute Map.has_key?(measurements, :queue_time)
 
@@ -240,7 +240,7 @@ defmodule Ecto.Integration.TransactionTest do
       PoolRepo.rollback(:log_rollback)
     end) == {:error, :log_rollback}
 
-    assert_received {measurements, %{params: [], result: :ok}}
+    assert_received {measurements, %{params: [], result: {:ok, _res}}}
     assert is_integer(measurements.query_time) and measurements.query_time >= 0
     refute Map.has_key?(measurements, :queue_time)
   end
@@ -250,7 +250,7 @@ defmodule Ecto.Integration.TransactionTest do
       register_telemetry()
       assert [] = PoolRepo.all(Trans)
 
-      assert_received {measurements, %{params: [], result: :ok}}
+      assert_received {measurements, %{params: [], result: {:ok, _res}}}
       assert is_integer(measurements.query_time) and measurements.query_time >= 0
       assert is_integer(measurements.decode_time) and measurements.query_time >= 0
       refute Map.has_key?(measurements, :queue_time)

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -812,9 +812,8 @@ defmodule Ecto.Adapters.SQL do
   defp log_measurements([], total, acc),
     do: Map.new([total_time: total] ++ acc)
 
-  defp log_result({:ok, _query, _res}), do: :ok
-  defp log_result({:ok, _res}), do: :ok
-  defp log_result(_), do: :error
+  defp log_result({:ok, _query, res}), do: {:ok, res}
+  defp log_result(other), do: other
 
   defp log_iodata(measurements, metadata) do
     %{
@@ -839,8 +838,8 @@ defmodule Ecto.Adapters.SQL do
     ]
   end
 
-  defp log_ok_error(:ok), do: "OK"
-  defp log_ok_error(:error), do: "ERROR"
+  defp log_ok_error({:ok, _res}), do: "OK"
+  defp log_ok_error({:error, _err}), do: "ERROR"
 
   defp log_ok_source(nil), do: ""
   defp log_ok_source(source), do: " source=#{inspect(source)}"


### PR DESCRIPTION
Hi,

it looks like the metadata which is attached to telemetry events changed with #83; specifically the `result` property is now a simple `:ok` or `:error` atom, instead of a tuple with the actual result (rows and row count.

Would it be possible to re-introduce the rows and row count? The row count, specifically, is something which I'd consider useful information for monitoring tools that attach themselves to ecto events via telemetry... 

I wasn't able to figure out whether this was changed on purpose or not; if there is a good reason for not having it there, I'd love to know! :-) 