### PR TITLE
Add `--skip-if-loaded` for `ecto.load`

### DIFF
--- a/lib/mix/tasks/ecto.load.ex
+++ b/lib/mix/tasks/ecto.load.ex
@@ -19,7 +19,8 @@ defmodule Mix.Tasks.Ecto.Load do
     quiet: :boolean,
     repo: [:string, :keep],
     no_compile: :boolean,
-    no_deps_check: :boolean
+    no_deps_check: :boolean,
+    skip_if_loaded: :boolean
   ]
 
   @moduledoc """
@@ -51,29 +52,54 @@ defmodule Mix.Tasks.Ecto.Load do
       (typically in production)
     * `--no-compile` - does not compile applications before loading
     * `--no-deps-check` - does not check depedendencies before loading
+    * `--skip-if-loaded` - does not load the dump file if the repo has any
+      migration up
 
   """
 
   @impl true
-  def run(args) do
-    {opts, _} = OptionParser.parse! args, strict: @switches, aliases: @aliases
+  def run(args, migrations \\ &Ecto.Migrator.migrations/2) do
+    {opts, _} = OptionParser.parse!(args, strict: @switches, aliases: @aliases)
     opts = Keyword.merge(@default_opts, opts)
 
-    Enum.each parse_repo(args), fn repo ->
+    Enum.each(parse_repo(args), fn repo ->
       ensure_repo(repo, args)
-      ensure_implements(repo.__adapter__, Ecto.Adapter.Structure,
-                                          "load structure for #{inspect repo}")
 
-      if skip_safety_warnings?() or
-          opts[:force] or
-          Mix.shell.yes?("Are you sure you want to load a new structure for #{inspect repo}? Any existing data in this repo may be lost.") do
-        load_structure(repo, opts)
+      ensure_implements(
+        repo.__adapter__,
+        Ecto.Adapter.Structure,
+        "load structure for #{inspect(repo)}"
+      )
+
+      path = ensure_migrations_path(repo)
+      {:ok, pid, _} = ensure_started(repo, all: true)
+      repo_status = migrations.(repo, path)
+      pid && repo.stop()
+
+      loaded? = loaded?(repo_status)
+
+      cond do
+        loaded? and opts[:skip_if_loaded] ->
+          Mix.shell().info("Skipped since a structure for #{inspect(repo)} has been loaded")
+
+        (skip_safety_warnings?() and !loaded?) or opts[:force] or confirm_load(repo) ->
+          load_structure(repo, opts)
       end
-    end
+    end)
+  end
+
+  def loaded?(repo_status) do
+    Enum.any?(repo_status, fn {status, _, _} -> status == :up end)
   end
 
   defp skip_safety_warnings? do
-    Mix.Project.config[:start_permanent] != true
+    Mix.Project.config()[:start_permanent] != true
+  end
+
+  defp confirm_load(repo) do
+    Mix.shell().yes?(
+      "Are you sure you want to load a new structure for #{inspect(repo)}? Any existing data in this repo may be lost."
+    )
   end
 
   defp load_structure(repo, opts) do


### PR DESCRIPTION
Today, if we want to add the `mix ecto.load` to a pipeline of tasks, it will fail if the database structure is already up and it will not run the next tasks.

For example, let's say I want to build a pipeline called `ecto.setup` like this:

```
defp aliases do
    [
      "ecto.setup": [
       "ecto.create", 
       "ecto.load", 
       "ecto.migrate", 
       "run priv/repo/seeds.exs"
    ],
``` 
If the database is already up, the `ecto.create` doesn't fail and proceed to `ecto.load`. Then, in `ecto.load` it fails if there tables there and doesn't execute the next tasks in the pipeline. But not always having tables in the database is a problem, in this pipeline would be cool just skip the `ecto.load` if the tables are already there.

We discussed this option here in the mailing list:
https://groups.google.com/forum/#!topic/elixir-ecto/8aw2DL_c9Yc

We discussed that a good approach would be, before attempting to load the bump, would be check if there's any migration run. If yes, it's not a new database, it's loaded. If there are no migrations there, we can try to load the dump.

With the `--skip-if-loaded`, when the database is not new, we can skip the load and succeed in the task. What do you folks think?