### PR TITLE
Add Ecto.Migrator.with_repo/2 to start/stop apps for migrations

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -204,6 +204,11 @@ defmodule Ecto.Migration do
 
           config :app, App.Repo, migration_default_prefix: "my_prefix"
 
+    * `:start_apps_before_migration` - A list of applications to be started before
+      running migrations. Used by `Ecto.Migrator.with_repo/3` and the migration tasks:
+
+          config :app, App.Repo, start_apps_before_migration: [:ssl, :some_custom_logger]
+
   """
 
   @doc """

--- a/lib/mix/ecto_sql.ex
+++ b/lib/mix/ecto_sql.ex
@@ -2,41 +2,6 @@ defmodule Mix.EctoSQL do
   @moduledoc false
 
   @doc """
-  Ensures the given repository is started and running.
-  """
-  @spec ensure_started(Ecto.Repo.t, Keyword.t) :: {:ok, pid | nil, [atom]}
-  def ensure_started(repo, opts) do
-    {:ok, started} = Application.ensure_all_started(:ecto_sql)
-
-    # If we starting EctoSQL just now, assume
-    # logger has not been properly booted yet.
-    if :ecto_sql in started && Process.whereis(Logger) do
-      backends = Application.get_env(:logger, :backends, [])
-      try do
-        Logger.App.stop
-        Application.put_env(:logger, :backends, [:console])
-        :ok = Logger.App.start
-      after
-        Application.put_env(:logger, :backends, backends)
-      end
-    end
-
-    {:ok, apps} = repo.__adapter__.ensure_all_started(repo.config(), :temporary)
-    pool_size = Keyword.get(opts, :pool_size, 2)
-
-    case repo.start_link(pool_size: pool_size) do
-      {:ok, pid} ->
-        {:ok, pid, apps}
-
-      {:error, {:already_started, _pid}} ->
-        {:ok, nil, apps}
-
-      {:error, error} ->
-        Mix.raise "Could not start repo #{inspect repo}, error: #{inspect error}"
-    end
-  end
-
-  @doc """
   Ensures the given repository's migrations path exists on the file system.
   """
   @spec ensure_migrations_path(Ecto.Repo.t) :: String.t

--- a/lib/mix/tasks/ecto.rollback.ex
+++ b/lib/mix/tasks/ecto.rollback.ex
@@ -71,7 +71,7 @@ defmodule Mix.Tasks.Ecto.Rollback do
     * `--to` - revert all migrations down to and including version
     * `--quiet` - do not log migration commands
     * `--prefix` - the prefix to run migrations on
-    * `--pool-size` - the pool size if the repository is started only for the task (defaults to 1)
+    * `--pool-size` - the pool size if the repository is started only for the task (defaults to 2)
     * `--log-sql` - log the raw sql migrations are running
     * `--no-compile` - does not compile applications before rolling back
     * `--no-deps-check` - does not check depedendencies before rolling back
@@ -93,21 +93,28 @@ defmodule Mix.Tasks.Ecto.Rollback do
         do: Keyword.merge(opts, [log: false, log_sql: false]),
         else: opts
 
-    Enum.each repos, fn repo ->
+    # Start ecto_sql explicitly before as we don't need
+    # to restart those apps if migrated.
+    {:ok, _} = Application.ensure_all_started(:ecto_sql)
+
+    for repo <- repos do
       ensure_repo(repo, args)
       path = ensure_migrations_path(repo)
-      {:ok, pid, apps} = ensure_started(repo, opts)
-
       pool = repo.config[:pool]
-      migrated =
+
+      fun =
         if function_exported?(pool, :unboxed_run, 2) do
-          pool.unboxed_run(repo, fn -> migrator.(repo, path, :down, opts) end)
+          &pool.unboxed_run(&1, fn -> migrator.(&1, path, :down, opts) end)
         else
-          migrator.(repo, path, :down, opts)
+          &migrator.(&1, path, :down, opts)
         end
 
-      pid && repo.stop()
-      restart_apps_if_migrated(apps, migrated)
+      case Ecto.Migrator.with_repo(repo, fun, [mode: :temporary] ++ opts) do
+        {:ok, migrated, apps} -> restart_apps_if_migrated(apps, migrated)
+        {:error, error} -> Mix.raise "Could not start repo #{inspect repo}, error: #{inspect error}"
+      end
     end
+
+    :ok
   end
 end

--- a/test/mix/ecto_sql_test.exs
+++ b/test/mix/ecto_sql_test.exs
@@ -3,29 +3,9 @@ defmodule Mix.EctoSQLTest do
   import Mix.EctoSQL
 
   defmodule Repo do
-    def start_link(opts) do
-      assert opts[:pool_size] == 2
-      Process.get(:start_link)
-    end
-
-    def __adapter__ do
-      EctoSQL.TestAdapter
-    end
-
     def config do
       [priv: Process.get(:priv), otp_app: :ecto_sql]
     end
-  end
-
-  test "ensure_started" do
-    Process.put(:start_link, {:ok, self()})
-    assert ensure_started(Repo, []) == {:ok, self(), []}
-
-    Process.put(:start_link, {:error, {:already_started, self()}})
-    assert ensure_started(Repo, []) == {:ok, nil, []}
-
-    Process.put(:start_link, {:error, self()})
-    assert_raise Mix.Error, fn -> ensure_started(Repo, []) end
   end
 
   test "source_priv_repo" do

--- a/test/mix/tasks/ecto.migrate_test.exs
+++ b/test/mix/tasks/ecto.migrate_test.exs
@@ -112,7 +112,7 @@ defmodule Mix.Tasks.Ecto.MigrateTest do
       assert repo == Repo
       refute path =~ ~r/_build/
       assert direction == :up
-      assert opts == [mode: :temporary, repo: "Elixir.Mix.Tasks.Ecto.MigrateTest.Repo", step: 1]
+      assert opts == [repo: "Elixir.Mix.Tasks.Ecto.MigrateTest.Repo", step: 1]
       []
     end
     assert Process.get(:started)

--- a/test/mix/tasks/ecto.migrate_test.exs
+++ b/test/mix/tasks/ecto.migrate_test.exs
@@ -112,7 +112,7 @@ defmodule Mix.Tasks.Ecto.MigrateTest do
       assert repo == Repo
       refute path =~ ~r/_build/
       assert direction == :up
-      assert opts == [repo: "Elixir.Mix.Tasks.Ecto.MigrateTest.Repo", step: 1]
+      assert opts == [mode: :temporary, repo: "Elixir.Mix.Tasks.Ecto.MigrateTest.Repo", step: 1]
       []
     end
     assert Process.get(:started)


### PR DESCRIPTION
This will be useful to create minimum release scripts
that migrate or rollback the repository, such as:

    defmodule MyApp.Release do
      @app :my_app

      def migrate do
        for repo <- repos() do
          {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
        end
      end

      def rollback(repo, version) do
        {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
      end

      defp repos do
        Application.get_env(@app, :ecto_repos, [])
      end
    end

There is also a configuration called :start_apps_before_migration
that will help guarantee any auxiliary app is started before
migrations run.