### PR TITLE
Deprecate Ecto.Adapters.MySQL

### DIFF
--- a/lib/ecto/adapters/mysql.ex
+++ b/lib/ecto/adapters/mysql.ex
@@ -115,6 +115,15 @@ defmodule Ecto.Adapters.MySQL do
     driver: :mariaex,
     migration_lock: "FOR UPDATE"
 
+  defmacro __before_compile__(env) do
+    message =
+      "#{inspect(__MODULE__)} is deprecated in favour of Ecto.Adapters.MyXQL " <>
+        "which uses the new MyXQL driver."
+
+    IO.warn(message, [])
+    super(env)
+  end
+
   # And provide a custom storage implementation
   @behaviour Ecto.Adapter.Storage
   @behaviour Ecto.Adapter.Structure

--- a/lib/ecto/adapters/mysql.ex
+++ b/lib/ecto/adapters/mysql.ex
@@ -117,7 +117,7 @@ defmodule Ecto.Adapters.MySQL do
 
   defmacro __before_compile__(env) do
     message = """
-      Ecto.Adapters.SQL is deprecated in favour of Ecto.Adapters.MyXQL
+      Ecto.Adapters.MySQL is deprecated in favour of Ecto.Adapters.MyXQL
       which uses the new MyXQL driver. To switch your repo to that adapter do:
 
           use Ecto.Repo,

--- a/lib/ecto/adapters/mysql.ex
+++ b/lib/ecto/adapters/mysql.ex
@@ -116,9 +116,15 @@ defmodule Ecto.Adapters.MySQL do
     migration_lock: "FOR UPDATE"
 
   defmacro __before_compile__(env) do
-    message =
-      "#{inspect(__MODULE__)} is deprecated in favour of Ecto.Adapters.MyXQL " <>
-        "which uses the new MyXQL driver."
+    message = """
+      Ecto.Adapters.SQL is deprecated in favour of Ecto.Adapters.MyXQL
+      which uses the new MyXQL driver. To switch your repo to that adapter do:
+
+          use Ecto.Repo,
+            otp_app: :myapp,
+            adapter: Ecto.Adpaters.MyXQL
+
+      """
 
     IO.warn(message, Macro.Env.stacktrace(env))
     super(env)

--- a/lib/ecto/adapters/mysql.ex
+++ b/lib/ecto/adapters/mysql.ex
@@ -123,7 +123,6 @@ defmodule Ecto.Adapters.MySQL do
           use Ecto.Repo,
             otp_app: :myapp,
             adapter: Ecto.Adpaters.MyXQL
-
       """
 
     IO.warn(message, Macro.Env.stacktrace(env))

--- a/lib/ecto/adapters/mysql.ex
+++ b/lib/ecto/adapters/mysql.ex
@@ -120,7 +120,7 @@ defmodule Ecto.Adapters.MySQL do
       "#{inspect(__MODULE__)} is deprecated in favour of Ecto.Adapters.MyXQL " <>
         "which uses the new MyXQL driver."
 
-    IO.warn(message, [])
+    IO.warn(message, Macro.Env.stacktrace(env))
     super(env)
   end
 

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -205,7 +205,7 @@ defmodule Ecto.Adapters.SQL do
 
       defoverridable [prepare: 2, execute: 5, insert: 6, update: 6, delete: 4, insert_all: 7,
                       execute_ddl: 3, loaders: 2, dumpers: 2, autogenerate: 1,
-                      ensure_all_started: 2, lock_for_migrations: 4]
+                      ensure_all_started: 2, lock_for_migrations: 4, __before_compile__: 1]
     end
   end
 


### PR DESCRIPTION
When running tests, I got the warning 4 times:

```
$ ECTO_ADAPTER=mysql mix test
Compiling 4 files (.ex)
warning: Ecto.Adapters.MySQL is deprecated in favour of Ecto.Adapters.MyXQL which uses the new MyXQL driver.

warning: Ecto.Adapters.MySQL is deprecated in favour of Ecto.Adapters.MyXQL which uses the new MyXQL driver.

Excluding tags: [:rename_column, :array_type, :read_after_writes, :returning, :create_index_if_not_exists, :aggregate_filters, :transaction_isolation, :with_conflict_target, :map_boolean_in_expression]

............................................................................warning: Ecto.Adapters.MySQL is deprecated in favour of Ecto.Adapters.MyXQL which uses the new MyXQL driver.

......warning: Ecto.Adapters.MySQL is deprecated in favour of Ecto.Adapters.MyXQL which uses the new MyXQL driver.

.
13:59:02.757 [error] Mariaex.Protocol (#PID<0.299.0>) disconnected: ** (DBConnection.TransactionError) transaction is not started
.
13:59:02.825 [error] Mariaex.Protocol (#PID<0.297.0>) disconnected: ** (DBConnection.TransactionError) transaction is not started
...........................................................................................................................................................................................................................

Finished in 10.5 seconds
343 tests, 0 failures, 40 excluded

Randomized with seed 617876
```

However, on a sample project just once - when compiling the Repo for the first time.