### PR TITLE
Include CTE expressions in MyXQL / Postgres update_all

### DIFF
--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -99,6 +99,7 @@ if Code.ensure_loaded?(MyXQL) do
       end
 
       sources = create_names(query)
+      cte = cte(query, sources)
       {from, name} = get_source(query, sources, 0, source)
 
       fields = if prefix do
@@ -111,7 +112,7 @@ if Code.ensure_loaded?(MyXQL) do
       prefix = prefix || ["UPDATE ", from, " AS ", name, join, " SET "]
       where  = where(%{query | wheres: wheres ++ query.wheres}, sources)
 
-      [prefix, fields | where]
+      [cte, prefix, fields | where]
     end
 
     @impl true

--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -122,13 +122,14 @@ if Code.ensure_loaded?(MyXQL) do
       end
 
       sources = create_names(query)
+      cte = cte(query, sources)
       {_, name, _} = elem(sources, 0)
 
       from   = from(query, sources)
       join   = join(query, sources)
       where  = where(query, sources)
 
-      ["DELETE ", name, ".*", from, join | where]
+      [cte, "DELETE ", name, ".*", from, join | where]
     end
 
     @impl true

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -141,12 +141,13 @@ if Code.ensure_loaded?(Postgrex) do
     @impl true
     def delete_all(%{from: from} = query) do
       sources = create_names(query)
+      cte = cte(query, sources)
       {from, name} = get_source(query, sources, 0, from)
 
       {join, wheres} = using_join(query, :delete_all, "USING", sources)
       where = where(%{query | wheres: wheres ++ query.wheres}, sources)
 
-      ["DELETE FROM ", from, " AS ", name, join, where | returning(query, sources)]
+      [cte, "DELETE FROM ", from, " AS ", name, join, where | returning(query, sources)]
     end
 
     @impl true

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -127,6 +127,7 @@ if Code.ensure_loaded?(Postgrex) do
     @impl true
     def update_all(%{from: %{source: source}} = query, prefix \\ nil) do
       sources = create_names(query)
+      cte = cte(query, sources)
       {from, name} = get_source(query, sources, 0, source)
 
       prefix = prefix || ["UPDATE ", from, " AS ", name | " SET "]
@@ -134,7 +135,7 @@ if Code.ensure_loaded?(Postgrex) do
       {join, wheres} = using_join(query, :update_all, "FROM", sources)
       where = where(%{query | wheres: wheres ++ query.wheres}, sources)
 
-      [prefix, fields, join, where | returning(query, sources)]
+      [cte, prefix, fields, join, where | returning(query, sources)]
     end
 
     @impl true

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,7 @@
   "decimal": {:hex, :decimal, "1.7.0", "30d6b52c88541f9a66637359ddf85016df9eb266170d53105f02e4a67e00c5aa", [:mix], [], "hexpm"},
   "deep_merge": {:hex, :deep_merge, "0.2.0", "c1050fa2edf4848b9f556fba1b75afc66608a4219659e3311d9c9427b5b680b3", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
-  "ecto": {:git, "https://github.com/elixir-ecto/ecto.git", "ac1daff325bb681465aa4d68ea18955ad6f8b10a", []},
+  "ecto": {:git, "https://github.com/elixir-ecto/ecto.git", "6791fc8b967c851414d0ad4d83c7b2aa7bd1bbd4", []},
   "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -189,7 +189,7 @@ defmodule Ecto.Adapters.MyXQLTest do
       ~s{INNER JOIN `tree` AS t1 ON t1.`id` = s0.`category_id`}
   end
 
-  test "CTE update" do
+  test "CTE update_all" do
     cte_query =
       from(x in Schema, order_by: [asc: :id], limit: 10, lock: "FOR UPDATE SKIP LOCKED", select: %{id: x.id})
 
@@ -206,6 +206,24 @@ defmodule Ecto.Adapters.MyXQLTest do
       ~s{UPDATE `schema` AS s0, `target_rows` AS t1 } <>
       ~s{SET s0.`x` = 123 } <>
       ~s{WHERE (t1.`id` = s0.`id`)}
+  end
+
+  test "CTE delete_all" do
+    cte_query =
+      from(x in Schema, order_by: [asc: :id], limit: 10, lock: "FOR UPDATE SKIP LOCKED", select: %{id: x.id})
+
+    query =
+      Schema
+      |> with_cte("target_rows", as: ^cte_query)
+      |> join(:inner, [row], target in "target_rows", on: target.id == row.id)
+      |> plan(:delete_all)
+
+    assert delete_all(query) ==
+      ~s{WITH `target_rows` AS } <>
+      ~s{(SELECT s0.`id` AS `id` FROM `schema` AS s0 ORDER BY s0.`id` LIMIT 10 FOR UPDATE SKIP LOCKED) } <>
+      ~s{DELETE s0.* } <>
+      ~s{FROM `schema` AS s0 } <>
+      ~s{INNER JOIN `target_rows` AS t1 ON t1.`id` = s0.`id`}
   end
 
   test "select" do

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -189,6 +189,25 @@ defmodule Ecto.Adapters.MyXQLTest do
       ~s{INNER JOIN `tree` AS t1 ON t1.`id` = s0.`category_id`}
   end
 
+  test "CTE update" do
+    cte_query =
+      from(x in Schema, order_by: [asc: :id], limit: 10, lock: "FOR UPDATE SKIP LOCKED", select: %{id: x.id})
+
+    query =
+      Schema
+      |> with_cte("target_rows", as: ^cte_query)
+      |> join(:inner, [row], target in "target_rows", on: target.id == row.id)
+      |> update(set: [x: 123])
+      |> plan(:update_all)
+
+    assert update_all(query) ==
+      ~s{WITH `target_rows` AS } <>
+      ~s{(SELECT s0.`id` AS `id` FROM `schema` AS s0 ORDER BY s0.`id` LIMIT 10 FOR UPDATE SKIP LOCKED) } <>
+      ~s{UPDATE `schema` AS s0, `target_rows` AS t1 } <>
+      ~s{SET s0.`x` = 123 } <>
+      ~s{WHERE (t1.`id` = s0.`id`)}
+  end
+
   test "select" do
     query = Schema |> select([r], {r.x, r.y}) |> plan()
     assert all(query) == ~s{SELECT s0.`x`, s0.`y` FROM `schema` AS s0}

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -192,6 +192,28 @@ defmodule Ecto.Adapters.PostgresTest do
       ~s{INNER JOIN "tree" AS t1 ON t1."id" = s0."category_id"}
   end
 
+  test "CTE update" do
+    cte_query =
+      from(x in Schema, order_by: [asc: :id], limit: 10, lock: "FOR UPDATE SKIP LOCKED", select: %{id: x.id})
+
+    query =
+      Schema
+      |> with_cte("target_rows", as: ^cte_query)
+      |> join(:inner, [row], target in "target_rows", on: target.id == row.id)
+      |> select([r, t], r)
+      |> update(set: [x: 123])
+      |> plan(:update_all)
+
+    assert update_all(query) ==
+      ~s{WITH "target_rows" AS } <>
+      ~s{(SELECT s0."id" AS "id" FROM "schema" AS s0 ORDER BY s0."id" LIMIT 10 FOR UPDATE SKIP LOCKED) } <>
+      ~s{UPDATE "schema" AS s0 } <>
+      ~s{SET "x" = 123 } <>
+      ~s{FROM "target_rows" AS t1 } <>
+      ~s{WHERE (t1."id" = s0."id") } <>
+      ~s{RETURNING s0."id", s0."x", s0."y", s0."z", s0."w"}
+  end
+
   test "select" do
     query = Schema |> select([r], {r.x, r.y}) |> plan()
     assert all(query) == ~s{SELECT s0."x", s0."y" FROM "schema" AS s0}


### PR DESCRIPTION
Related to issue: https://github.com/elixir-ecto/ecto/issues/3052

This enables upates of the form:

```sql
with target_rows as (
  select id
  from some_table
  where some_condition
  limit some_limit
  for update skip locked
)
update some_table
from target_rows
where some_table.id = target_rows.id
returning some_table.*
```

The tests depend on the corresponding change in ecto to allow CTEs in update queries.
