### PR TITLE
MySQL >= 8.0.13 foreign key constraint support

### DIFF
--- a/integration_test/sql/sql.exs
+++ b/integration_test/sql/sql.exs
@@ -4,6 +4,7 @@ defmodule Ecto.Integration.SQLTest do
   alias Ecto.Integration.TestRepo
   alias Ecto.Integration.Barebone
   alias Ecto.Integration.Post
+  alias Ecto.Integration.Comment
   alias Ecto.Integration.CorruptedPk
   import Ecto.Query, only: [from: 2]
 
@@ -126,5 +127,16 @@ defmodule Ecto.Integration.SQLTest do
 
   test "returns false table doesn't exists" do
     refute Ecto.Adapters.SQL.table_exists?(TestRepo, "unknown")
+  end
+
+  @tag :foreign_key
+  test "foreign key error returns invalid constraint" do
+    changeset = Comment.changeset(%Comment{post_id: 9999999}, %{})
+                |> Ecto.Changeset.assoc_constraint(:post)
+
+    result = TestRepo.insert(changeset)
+    assert {:error, %{errors: [
+        post: {"does not exist", [constraint: :assoc, constraint_name: "comments_post_id_fkey"]}
+      ]}} = result
   end
 end


### PR DESCRIPTION
This test replicates the issue #126, but only in situations where the test is connected to the database as a non-root user.

```
$ docker run \
                --rm \
                --detach \
                --name ecto_sql_mysql \
                -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
                -e MYSQL_ROOT_PASSWORD= \
                -e MYSQL_USER=mysql \
                -e MYSQL_PASSWORD=mysql \
                -e MYSQL_DATABASE=ecto_test \
                -p 3306:3306 \
                mysql:8 \
                --default-authentication-plugin=mysql_native_password
$ ECTO_ADAPTER=myxql MYSQL_URL=mysql:mysql@localhost mix test --only foreign_key
```

This produces the same error I was seeing in my application:
```
  1) test foreign key error returns invalid constraint (Ecto.Integration.SQLTest)
     integration_test/sql/sql.exs:133
     ** (MyXQL.Error) (1216) (ER_NO_REFERENCED_ROW) Cannot add or update a child row: a foreign key constraint fails
     code: result = TestRepo.insert(changeset)
     stacktrace:
       (ecto_sql) lib/ecto/adapters/myxql.ex:209: Ecto.Adapters.MyXQL.insert/6
       (ecto) lib/ecto/repo/schema.ex:647: Ecto.Repo.Schema.apply/4
       (ecto) lib/ecto/repo/schema.ex:262: anonymous fn/15 in Ecto.Repo.Schema.do_insert/4
       integration_test/sql/sql.exs:137: (test)
```