### PR TITLE
Fix generated "COMMENT ON INDEX" SQL (PostgreSQL)

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -763,7 +763,7 @@ if Code.ensure_loaded?(Postgrex) do
                   ?\s, ?(, fields, ?),
                   if_do(index.where, [" WHERE ", to_string(index.where)])]]
 
-      queries ++ comments_on("INDEX", quote_name(index.name), index.comment)
+      queries ++ comments_on("INDEX", quote_table(index.prefix, index.name), index.comment)
     end
 
     def execute_ddl({:create_if_not_exists, %Index{} = index}) do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1510,7 +1510,7 @@ defmodule Ecto.Adapters.PostgresTest do
     assert execute_ddl(create) == [remove_newlines("""
     CREATE INDEX "posts_category_id_permalink_index" ON "foo"."posts" ("category_id", "permalink")
     """),
-    ~s|COMMENT ON INDEX "posts_category_id_permalink_index" IS 'comment'|]
+    ~s|COMMENT ON INDEX "foo"."posts_category_id_permalink_index" IS 'comment'|]
   end
 
   test "create unique index" do


### PR DESCRIPTION
PostgreSQL will automatically create indexes in the same schema as the
table for which indexes are created.  While the "CREATE INDEX" DDL
requires that the index name is not schema qualified, most other SQL
referencing the index directly, including "COMMENT ON INDEX" must
schema qualify the index's name.

Resolves: #134 