### PR TITLE
Spelling corrections in migration docs

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -26,7 +26,7 @@ defmodule Ecto.Migration do
   migrations for `MyApp.Repo` would be found in "priv/repo/migrations".
   For `MyApp.CustomRepo`, it would be found in "priv/custom_repo/migrations".
 
-  Each file in the migratitons directory have the following structure:
+  Each file in the migrations directory has the following structure:
 
       NUMBER_NAME.exs
 


### PR DESCRIPTION
Fixes a typo and corrects a word in the migration docs.