### PR TITLE
Ecto.Adapters.MyXQL: change default charset to utf8mb4

### DIFF
--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -47,7 +47,7 @@ defmodule Ecto.Adapters.MyXQL do
 
   ### Storage options
 
-    * `:charset` - the database encoding (default: "utf8")
+    * `:charset` - the database encoding (default: "utf8mb4")
     * `:collation` - the collation order
     * `:dump_path` - where to place dumped structures
 
@@ -141,7 +141,7 @@ defmodule Ecto.Adapters.MyXQL do
   def storage_up(opts) do
     database = Keyword.fetch!(opts, :database) || raise ":database is nil in repository configuration"
     opts = Keyword.delete(opts, :database)
-    charset = opts[:charset] || "utf8"
+    charset = opts[:charset] || "utf8mb4"
 
     command =
       ~s(CREATE DATABASE `#{database}` DEFAULT CHARACTER SET = #{charset})


### PR DESCRIPTION
MyXQL was already using this charset for a few releases. Additionally, MyXQL server deprecates utf8 (which is an alias to utf8mb3) in favour of exactly utf8mb4.