### PR TITLE
Convert migration filename with spaces to filename with underscores

### DIFF
--- a/lib/mix/tasks/ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto.gen.migration.ex
@@ -67,7 +67,8 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
         {opts, [name]} ->
           ensure_repo(repo, args)
           path = Path.join(source_repo_priv(repo), "migrations")
-          base_name = "#{underscore(name)}.exs"
+          underscore_name = underscore(name) |> String.replace(" ", "_")
+          base_name = "#{underscore_name}.exs"
           file = Path.join(path, "#{timestamp()}_#{base_name}")
           unless File.dir?(path), do: create_directory path
 

--- a/test/mix/tasks/ecto.gen.migration_test.exs
+++ b/test/mix/tasks/ecto.gen.migration_test.exs
@@ -52,6 +52,12 @@ defmodule Mix.Tasks.Ecto.Gen.MigrationTest do
     assert name =~ ~r/^\d{14}_my_migration\.exs$/
   end
 
+  test "underscores the filename when filename with spaces" do
+    run ["-r", to_string(Repo), "My migration"]
+    assert [name] = File.ls!(@migrations_path)
+    assert name =~ ~r/^\d{14}_my_migration\.exs$/
+  end
+
   test "raises when existing migration exists" do
     run ["-r", to_string(Repo), "my_migration"]
     assert_raise Mix.Error, ~r"migration can't be created", fn ->


### PR DESCRIPTION
For the case when a user will try to add migration with spaces like `mix ecto.gen.migration "event id field"`