### PR TITLE
First version of dynamic command for Ecto.Migration

### DIFF
--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -348,13 +348,13 @@ defmodule Ecto.Integration.MigrationTest do
 
     def change do
       execute @migrate_first, @rollback_second
-      dynamic(fn -> Logger.info("This is a middle part called by dynamic/0") end)
-      dynamic(&dynamic_query/1)
+      execute(fn -> Logger.info("This is a middle part called by execute") end)
+      execute(&execute_up/0, &execute_down/0)
       execute @migrate_second, @rollback_first
     end
 
-    defp dynamic_query(:up), do: SQL.query!(repo(), @migrate_middle, [], [log: :info])
-    defp dynamic_query(:down), do: SQL.query!(repo(), @rollback_middle, [], [log: :info])
+    defp execute_up, do: SQL.query!(repo(), @migrate_middle, [], [log: :info])
+    defp execute_down, do: SQL.query!(repo(), @rollback_middle, [], [log: :info])
   end
 
   import Ecto.Query, only: [from: 2]
@@ -387,7 +387,7 @@ defmodule Ecto.Integration.MigrationTest do
     end
   end
 
-  defp get_middle_log(:up, 8, _name), do: "This is a middle part called by dynamic/0"
+  defp get_middle_log(:up, 8, _name), do: "This is a middle part called by execute"
   defp get_middle_log(:up, 11, name), do: "select 'In the middle of ecto.#{name}'; []"
   defp get_middle_log(:down, 9, name), do: get_middle_log(:up, 11, name)
   defp get_middle_log(:down, 11, name), do: get_middle_log(:up, 8, name)

--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -336,17 +336,19 @@ defmodule Ecto.Integration.MigrationTest do
     @disable_ddl_transaction true
 
     @migrate_first "select 'This is a first part of ecto.migrate';"
+    @migrate_middle "select 'In the middle of ecto.migrate';"
     @migrate_second "select 'This is a second part of ecto.migrate';"
     @rollback_first "select 'This is a first part of ecto.rollback';"
+    @rollback_middle "select 'In the middle of ecto.rollback';"
     @rollback_second "select 'This is a second part of ecto.rollback';"
 
     def change do
       execute @migrate_first, @rollback_second
 
-      dynamic do
+      dynamic migrate_middle: @migrate_middle, rollback_middle: @rollback_middle do
         case direction() do
-          :up -> Ecto.Adapters.SQL.query!(repo(), "select 'In the middle of ecto.migrate';", [], [log: :info])
-          :down -> Ecto.Adapters.SQL.query!(repo(), "select 'In the middle of ecto.rollback';", [], [log: :info])
+          :up -> Ecto.Adapters.SQL.query!(repo(), migrate_middle, [], [log: :info])
+          :down -> Ecto.Adapters.SQL.query!(repo(), rollback_middle, [], [log: :info])
         end
       end
 

--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -333,6 +333,10 @@ defmodule Ecto.Integration.MigrationTest do
   defmodule MigrationWithDynamicCommand do
     use Ecto.Migration
 
+    alias Ecto.Adapters.SQL
+
+    require Logger
+
     @disable_ddl_transaction true
 
     @migrate_first "select 'This is a first part of ecto.migrate';"
@@ -344,16 +348,13 @@ defmodule Ecto.Integration.MigrationTest do
 
     def change do
       execute @migrate_first, @rollback_second
-
-      dynamic migrate_middle: @migrate_middle, rollback_middle: @rollback_middle do
-        case direction() do
-          :up -> Ecto.Adapters.SQL.query!(repo(), migrate_middle, [], [log: :info])
-          :down -> Ecto.Adapters.SQL.query!(repo(), rollback_middle, [], [log: :info])
-        end
-      end
-
+      dynamic(fn -> Logger.info("This is a middle part called by dynamic/0") end)
+      dynamic(&dynamic_query/1)
       execute @migrate_second, @rollback_first
     end
+
+    defp dynamic_query(:up), do: SQL.query!(repo(), @migrate_middle, [], [log: :info])
+    defp dynamic_query(:down), do: SQL.query!(repo(), @rollback_middle, [], [log: :info])
   end
 
   import Ecto.Query, only: [from: 2]
@@ -368,6 +369,7 @@ defmodule Ecto.Integration.MigrationTest do
     {:ok, migration_number: System.unique_integer([:positive]) + @base_migration}
   end
 
+  @tag :current
   test "migration with dynamic", %{migration_number: num} do
     level = :info
     args = [PoolRepo, num, MigrationWithDynamicCommand, [log: level]]
@@ -377,11 +379,18 @@ defmodule Ecto.Integration.MigrationTest do
       lines = String.split(output, "\n")
       assert Enum.at(lines, 4) =~ "== Running #{num} #{inspect(MigrationWithDynamicCommand)}.change/0"
       assert Enum.at(lines, 6) =~ ~s[execute "select 'This is a first part of ecto.#{name}';"]
-      assert Enum.at(lines, 9) =~ "select 'In the middle of ecto.#{name}'; []"
-      assert Enum.at(lines, 11) =~ ~s[execute "select 'This is a second part of ecto.#{name}';"]
-      assert Enum.at(lines, 13) =~ ~r"Migrated #{num} in \d.\ds"
+      {first_line, second_line} = if direction == :up, do: {8, 11}, else: {9, 11}
+      assert Enum.at(lines, first_line) =~ get_middle_log(direction, first_line, name)
+      assert Enum.at(lines, second_line) =~ get_middle_log(direction, second_line, name)
+      assert Enum.at(lines, 13) =~ ~s[execute "select 'This is a second part of ecto.#{name}';"]
+      assert Enum.at(lines, 15) =~ ~r"Migrated #{num} in \d.\ds"
     end
   end
+
+  defp get_middle_log(:up, 8, _name), do: "This is a middle part called by dynamic/0"
+  defp get_middle_log(:up, 11, name), do: "select 'In the middle of ecto.#{name}'; []"
+  defp get_middle_log(:down, 9, name), do: get_middle_log(:up, 11, name)
+  defp get_middle_log(:down, 11, name), do: get_middle_log(:up, 8, name)
 
   test "create and drop table and indexes", %{migration_number: num} do
     assert :ok == up(PoolRepo, num, CreateMigration, log: false)

--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -368,16 +368,12 @@ defmodule Ecto.Integration.MigrationTest do
     {:ok, migration_number: System.unique_integer([:positive]) + @base_migration}
   end
 
-  @tag :current
   test "migration with dynamic", %{migration_number: num} do
     level = :info
     args = [PoolRepo, num, MigrationWithDynamicCommand, [log: level]]
 
     for {name, direction} <- [migrate: :up, rollback: :down] do
-      output = capture_log(fn ->
-        :ok = apply(Ecto.Migrator, direction, args)
-      end)
-
+      output = capture_log(fn -> :ok = apply(Ecto.Migrator, direction, args) end)
       lines = String.split(output, "\n")
       assert Enum.at(lines, 4) =~ "== Running #{num} #{inspect(MigrationWithDynamicCommand)}.change/0"
       assert Enum.at(lines, 6) =~ ~s[execute "select 'This is a first part of ecto.#{name}';"]

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -466,9 +466,9 @@ defmodule Ecto.Migration do
     end
   end
 
-  defmacro dynamic(do: block) do
-    quote bind_quoted: [block: Macro.escape(block)] do
-      Runner.execute({:dynamic, block, __ENV__})
+  defmacro dynamic(bindings, do: block) do
+    quote bind_quoted: [bindings: bindings, block: Macro.escape(block)] do
+      Runner.execute({:dynamic, block, bindings, __ENV__})
     end
   end
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -466,6 +466,12 @@ defmodule Ecto.Migration do
     end
   end
 
+  defmacro dynamic(do: block) do
+    quote bind_quoted: [block: Macro.escape(block)] do
+      Runner.execute({:dynamic, block, __ENV__})
+    end
+  end
+
   @doc """
   Creates one of the following:
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -466,7 +466,7 @@ defmodule Ecto.Migration do
     end
   end
 
-  defmacro dynamic(bindings, do: block) do
+  defmacro dynamic(bindings \\ [], do: block) do
     quote bind_quoted: [bindings: bindings, block: Macro.escape(block)] do
       Runner.execute({:dynamic, block, bindings, __ENV__})
     end

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -216,7 +216,8 @@ defmodule Ecto.Migration.Runner do
     end
   end
 
-  defp reverse({:dynamic, func}), do: {:dynamic, func}
+  defp reverse(func) when is_function(func, 0), do: func
+
   defp reverse({:create, %Index{} = index}),
     do: {:drop, index}
   defp reverse({:create_if_not_exists, %Index{} = index}),
@@ -333,13 +334,8 @@ defmodule Ecto.Migration.Runner do
     log_and_execute_ddl(repo, log, command)
   end
 
-  defp log_and_execute_ddl(_repo, _log, {:dynamic, func}) when is_function(func, 0) do
+  defp log_and_execute_ddl(_repo, _log, func) when is_function(func, 0) do
     func.()
-    :ok
-  end
-
-  defp log_and_execute_ddl(_repo, _log, {:dynamic, func}) do
-    func.(migrator_direction())
     :ok
   end
 

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -216,6 +216,7 @@ defmodule Ecto.Migration.Runner do
     end
   end
 
+  defp reverse({:dynamic, _macro, _env} = dynamic), do: dynamic
   defp reverse({:create, %Index{} = index}),
     do: {:drop, index}
   defp reverse({:create_if_not_exists, %Index{} = index}),
@@ -330,6 +331,11 @@ defmodule Ecto.Migration.Runner do
 
   defp log_and_execute_ddl(repo, _migration, log, command) do
     log_and_execute_ddl(repo, log, command)
+  end
+
+  defp log_and_execute_ddl(_repo, _log, {:dynamic, macro, env}) do
+    Code.eval_quoted(macro, [], env)
+    :ok
   end
 
   defp log_and_execute_ddl(repo, %{level: level, sql: sql}, command) do

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -216,7 +216,7 @@ defmodule Ecto.Migration.Runner do
     end
   end
 
-  defp reverse({:dynamic, _macro, _env} = dynamic), do: dynamic
+  defp reverse({:dynamic, _macro, _bindings, _env} = dynamic), do: dynamic
   defp reverse({:create, %Index{} = index}),
     do: {:drop, index}
   defp reverse({:create_if_not_exists, %Index{} = index}),
@@ -333,8 +333,8 @@ defmodule Ecto.Migration.Runner do
     log_and_execute_ddl(repo, log, command)
   end
 
-  defp log_and_execute_ddl(_repo, _log, {:dynamic, macro, env}) do
-    Code.eval_quoted(macro, [], env)
+  defp log_and_execute_ddl(_repo, _log, {:dynamic, macro, bindings, env}) do
+    Code.eval_quoted(macro, bindings, env)
     :ok
   end
 

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -216,7 +216,7 @@ defmodule Ecto.Migration.Runner do
     end
   end
 
-  defp reverse({:dynamic, _macro, _bindings, _env} = dynamic), do: dynamic
+  defp reverse({:dynamic, func}), do: {:dynamic, func}
   defp reverse({:create, %Index{} = index}),
     do: {:drop, index}
   defp reverse({:create_if_not_exists, %Index{} = index}),
@@ -333,8 +333,13 @@ defmodule Ecto.Migration.Runner do
     log_and_execute_ddl(repo, log, command)
   end
 
-  defp log_and_execute_ddl(_repo, _log, {:dynamic, macro, bindings, env}) do
-    Code.eval_quoted(macro, bindings, env)
+  defp log_and_execute_ddl(_repo, _log, {:dynamic, func}) when is_function(func, 0) do
+    func.()
+    :ok
+  end
+
+  defp log_and_execute_ddl(_repo, _log, {:dynamic, func}) do
+    func.(migrator_direction())
     :ok
   end
 

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -216,8 +216,6 @@ defmodule Ecto.Migration.Runner do
     end
   end
 
-  defp reverse(func) when is_function(func, 0), do: func
-
   defp reverse({:create, %Index{} = index}),
     do: {:drop, index}
   defp reverse({:create_if_not_exists, %Index{} = index}),

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -170,11 +170,9 @@ defmodule Ecto.MigratorTest do
 
   Application.put_env(:ecto_sql, MigrationSourceRepo, [migration_source: "my_schema_migrations"])
 
-  @base_migration 1_000_000
-
   setup do
     Process.put(:migrated_versions, [1, 2, 3])
-    {:ok, migration_number: System.unique_integer([:positive]) + @base_migration}
+    :ok
   end
 
   def put_test_adapter_config(config) do
@@ -205,15 +203,17 @@ defmodule Ecto.MigratorTest do
     """
   end
 
-  test "execute one anonymous function", %{migration_number: num} do
+  test "execute one anonymous function" do
     module = ExecuteOneAnonymousFunctionMigration
+    num = System.unique_integer([:positive])
     capture_log(fn -> :ok = up(TestRepo, num, module, [log: false]) end)
     message = "no function clause matching in Ecto.Migration.Runner.command/1"
     assert_raise(FunctionClauseError, message, fn -> down(TestRepo, num, module, [log: false]) end)
   end
 
-  test "execute two anonymous functions", %{migration_number: num} do
+  test "execute two anonymous functions" do
     module = ExecuteTwoAnonymousFunctionsMigration
+    num = System.unique_integer([:positive])
     args = [TestRepo, num, module, [log: :info]]
 
     for {name, direction} <- [migrate: :up, rollback: :down] do

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -216,7 +216,6 @@ defmodule Ecto.MigratorTest do
   defp get_middle_log(:down, :first, name), do: get_middle_log(:up, :second, name)
   defp get_middle_log(:down, :second, name), do: get_middle_log(:up, :first, name)
 
-  @tag :current
   test "flush" do
     num = System.unique_integer([:positive])
     assert :ok == up(TestRepo, num, EmptyUpDownMigration, log: false)


### PR DESCRIPTION
- [x] Added `Ecto.Migration.dynamic/1` macro.
- [x] Added integration test for ensuring correct order.
- [x] Added optional support for passing an anonymous function with one arity.
- [x] Added special function clausule in `Migration.Runner` in order to **not afftect** currect adapters implementations.
- [x] Documentation and specs
- [x] Ensure that `{:dynamic, func}` command is self-reversible in runner.

**TODO**:
- [x] Discuss the implementation details

Related issue: #157