### PR TITLE
Implement `storage_status/1` callback in postgres and myxql adapters

### DIFF
--- a/integration_test/myxql/storage_test.exs
+++ b/integration_test/myxql/storage_test.exs
@@ -104,6 +104,25 @@ defmodule Ecto.Integration.StorageTest do
     drop_database()
   end
 
+  test "storage status is up when database is created" do
+    create_database()
+    assert :up == Ecto.Adapters.MyXQL.storage_status(params())
+  after
+    drop_database()
+  end
+
+  test "storage status is down when database is not created" do
+    create_database()
+    drop_database()
+    assert :down == Ecto.Adapters.MyXQL.storage_status(params())
+  end
+
+  test "storage status is an error when wrong credentials are passed" do
+    assert ExUnit.CaptureLog.capture_log(fn ->
+             assert {:error, _} = Ecto.Adapters.MyXQL.storage_status(wrong_params())
+           end) =~ "(1045) (ER_ACCESS_DENIED_ERROR)"
+  end
+
   defmodule Migration do
     use Ecto.Migration
     def change, do: :ok

--- a/integration_test/pg/storage_test.exs
+++ b/integration_test/pg/storage_test.exs
@@ -126,4 +126,23 @@ defmodule Ecto.Integration.StorageTest do
     contents = File.read!(path)
     assert contents =~ ~s[INSERT INTO public."schema_migrations" (version) VALUES]
   end
+
+  test "storage status is up when database is created" do
+    create_database()
+    assert :up == Postgres.storage_status(params())
+  after
+    drop_database()
+  end
+
+  test "storage status is down when database is not created" do
+    create_database()
+    drop_database()
+    assert :down == Postgres.storage_status(params())
+  end
+
+  test "storage status is an error when wrong credentials are passed" do
+    assert ExUnit.CaptureLog.capture_log(fn ->
+             assert {:error, _} = Postgres.storage_status(wrong_params())
+           end) =~ "FATAL 28000"
+  end
 end

--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -198,6 +198,19 @@ defmodule Ecto.Adapters.MyXQL do
         {:error, exit_to_exception(exit)}
     end
   end
+  
+  @impl Ecto.Adapter.Storage
+  def storage_status(opts) do
+    database = Keyword.fetch!(opts, :database) || raise ":database is nil in repository configuration"
+    opts = Keyword.delete(opts, :database)
+    check_database_query = "SELECT schema_name FROM information_schema.schemata WHERE schema_name = '#{database}'"
+
+    case run_query(check_database_query, opts) do
+      {:ok, %MyXQL.Result{num_rows: 0}} -> :down
+      {:ok, %MyXQL.Result{num_rows: _num_rows}} -> :up
+      other -> {:error, other}
+    end
+  end
 
   @impl true
   def supports_ddl_transaction? do

--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -203,6 +203,7 @@ defmodule Ecto.Adapters.MyXQL do
   def storage_status(opts) do
     database = Keyword.fetch!(opts, :database) || raise ":database is nil in repository configuration"
     opts = Keyword.delete(opts, :database)
+
     check_database_query = "SELECT schema_name FROM information_schema.schemata WHERE schema_name = '#{database}'"
 
     case run_query(check_database_query, opts) do

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -166,6 +166,21 @@ defmodule Ecto.Adapters.Postgres do
     end
   end
 
+  @impl Ecto.Adapter.Storage
+  def storage_status(opts) do
+    database = Keyword.fetch!(opts, :database) || raise ":database is nil in repository configuration"
+    maintenance_database = Keyword.get(opts, :maintenance_database, @default_maintenance_database)
+    opts = Keyword.put(opts, :database, maintenance_database)
+
+    check_database_query = "SELECT datname FROM pg_catalog.pg_database WHERE datname = '#{database}'"
+
+    case run_query(check_database_query, opts) do
+      {:ok, %Postgrex.Result{num_rows: 0}} -> :down
+      {:ok, %Postgrex.Result{num_rows: _num_rows}} -> :up
+      other -> {:error, other}
+    end
+  end
+
   @impl true
   def supports_ddl_transaction? do
     true


### PR DESCRIPTION
Implements the `storage_status/1` callback defined in elixir-ecto/ecto#3157.

### Implementation

Connects on the "metadata" database for both `mysql` and `postgres` to check whether the `database` 
passed on the `options` exists.

- For `mysql` is the `information_schema`  on the table `schemata` looking for the attribute `schema_name`.
- For postgres is the `pg_catalog` on the table `pg_database` looking for the attribute `schema_name`

cc @josevalim