### PR TITLE
Fix can't compile `ecto_sql` when application has only one database lib

### DIFF
--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -207,8 +207,8 @@ defmodule Ecto.Adapters.MyXQL do
     check_database_query = "SELECT schema_name FROM information_schema.schemata WHERE schema_name = '#{database}'"
 
     case run_query(check_database_query, opts) do
-      {:ok, %MyXQL.Result{num_rows: 0}} -> :down
-      {:ok, %MyXQL.Result{num_rows: _num_rows}} -> :up
+      {:ok, %{num_rows: 0}} -> :down
+      {:ok, %{num_rows: _num_rows}} -> :up
       other -> {:error, other}
     end
   end

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -175,8 +175,8 @@ defmodule Ecto.Adapters.Postgres do
     check_database_query = "SELECT datname FROM pg_catalog.pg_database WHERE datname = '#{database}'"
 
     case run_query(check_database_query, opts) do
-      {:ok, %Postgrex.Result{num_rows: 0}} -> :down
-      {:ok, %Postgrex.Result{num_rows: _num_rows}} -> :up
+      {:ok, %{num_rows: 0}} -> :down
+      {:ok, %{num_rows: _num_rows}} -> :up
       other -> {:error, other}
     end
   end


### PR DESCRIPTION
Was not able to be compiled when an application had **only one** database
library as it's dependency (either only `myxql` or only `postgres`).

It was happening because we were matching on the database library result
struct instead of matching only on the map. And since the struct is defined inside the adapter library, it could not expand. 😞

The error being raised:

![Screenshot 2019-11-11 14 12 35](https://user-images.githubusercontent.com/14015177/68606882-2cb2bd80-048e-11ea-977a-d9f0bd536175.png)

cc @wojtekmach @josevalim
