### PR TITLE
Start ecto_sql app when running Mix tasks

### DIFF
--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -315,6 +315,7 @@ defmodule Ecto.Adapters.MyXQL do
   ## Helpers
 
   defp run_query(sql, opts) do
+    {:ok, _} = Application.ensure_all_started(:ecto_sql)
     {:ok, _} = Application.ensure_all_started(:myxql)
 
     opts =

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -245,6 +245,7 @@ defmodule Ecto.Adapters.Postgres do
   ## Helpers
 
   defp run_query(sql, opts) do
+    {:ok, _} = Application.ensure_all_started(:ecto_sql)
     {:ok, _} = Application.ensure_all_started(:postgrex)
 
     opts =


### PR DESCRIPTION
We need this because we rely on Ecto.Adapters.SQL.StorageSupervisor.