### PR TITLE
Add :include option to support covering indexes

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -752,6 +752,7 @@ if Code.ensure_loaded?(Postgrex) do
 
     def execute_ddl({:create, %Index{} = index}) do
       fields = intersperse_map(index.columns, ", ", &index_expr/1)
+      include_fields = intersperse_map(index.include, ", ", &index_expr/1)
 
       queries = [["CREATE ",
                   if_do(index.unique, "UNIQUE "),
@@ -762,6 +763,7 @@ if Code.ensure_loaded?(Postgrex) do
                   quote_table(index.prefix, index.table),
                   if_do(index.using, [" USING " , to_string(index.using)]),
                   ?\s, ?(, fields, ?),
+                  if_do(include_fields != [], [" INCLUDE ", ?(, include_fields, ?)]),
                   if_do(index.where, [" WHERE ", to_string(index.where)])]]
 
       queries ++ comments_on("INDEX", quote_table(index.prefix, index.name), index.comment)

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -626,8 +626,10 @@ defmodule Ecto.Migration do
       concurrently.
     * `:using` - configures the index type.
     * `:prefix` - specify an optional prefix for the index.
-    * `:include` - specify fields for a covering index.
     * `:where` - specify conditions for a partial index.
+    * `:include` - specify fields for a covering index. This is not supported
+      by all databases. For more information on PostgreSQL support, please
+      [read the official docs](https://www.postgresql.org/docs/11/indexes-index-only-scans.html).
 
   ## Adding/dropping indexes concurrently
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -154,8 +154,8 @@ defmodule Ecto.Migration do
   terminates.
 
   However, in some situations you may want to guarantee that all of the
-  previous steps have been executed before continuing. This is useful when 
-  you need to apply a set of changes to the table before continuing with the 
+  previous steps have been executed before continuing. This is useful when
+  you need to apply a set of changes to the table before continuing with the
   migration. This can be done with `flush/0`:
 
       def up do
@@ -315,6 +315,7 @@ defmodule Ecto.Migration do
               unique: false,
               concurrently: false,
               using: nil,
+              include: [],
               where: nil,
               comment: nil,
               options: nil
@@ -327,6 +328,7 @@ defmodule Ecto.Migration do
       unique: boolean,
       concurrently: boolean,
       using: atom | String.t,
+      include: [atom | String.t],
       where: atom | String.t,
       comment: String.t | nil,
       options: String.t
@@ -624,6 +626,7 @@ defmodule Ecto.Migration do
       concurrently.
     * `:using` - configures the index type.
     * `:prefix` - specify an optional prefix for the index.
+    * `:include` - specify fields for a covering index.
     * `:where` - specify conditions for a partial index.
 
   ## Adding/dropping indexes concurrently
@@ -695,6 +698,9 @@ defmodule Ecto.Migration do
 
       # Partial indexes are created by specifying a :where option
       create index("products", [:user_id], where: "price = 0", name: :free_products_index)
+
+      # Covering indexes are created by specifying a :include option
+      create index("products", [:user_id], include: [:category_id])
 
   Indexes also support custom expressions. Some databases may require the
   index expression to be written between parentheses:

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1532,6 +1532,16 @@ defmodule Ecto.Adapters.PostgresTest do
       [~s|CREATE UNIQUE INDEX "posts_permalink_index" ON "posts" ("permalink") WHERE public|]
   end
 
+  test "create index with include fields" do
+    create = {:create, index(:posts, [:permalink], unique: true, include: [:public])}
+    assert execute_ddl(create) ==
+      [~s|CREATE UNIQUE INDEX "posts_permalink_index" ON "posts" ("permalink") INCLUDE ("public")|]
+
+    create = {:create, index(:posts, [:permalink], unique: true, include: [:public], where: "public IS TRUE")}
+    assert execute_ddl(create) ==
+      [~s|CREATE UNIQUE INDEX "posts_permalink_index" ON "posts" ("permalink") INCLUDE ("public") WHERE public IS TRUE|]
+  end
+
   test "create index concurrently" do
     index = index(:posts, [:permalink])
     create = {:create, %{index | concurrently: true}}


### PR DESCRIPTION
When specifying the :include option during index creation, the `CREATE INDEX` operation receives an additional option `INCLUDE` to specify non-key columns to include in the index.

I couldn't find anything related to `INCLUDE` in the MySQL docs, but MSSQL seems to support it. Do I need to add this to other adapters as well? Also, this option was only added in Postgres 11, which isn't mentioned right now. Is this something I should mention? Perhaps a documentation with link to [these docs][1], and a short explanation like the one for partial indexes.

[1]: https://www.postgresql.org/docs/11/indexes-index-only-scans.html