### PR TITLE
Support after option for MySQL

### DIFF
--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -813,8 +813,14 @@ if Code.ensure_loaded?(MyXQL) do
     defp column_options(opts) do
       default = Keyword.fetch(opts, :default)
       null    = Keyword.get(opts, :null)
-      [default_expr(default), null_expr(null)]
+      after_column = Keyword.get(opts, :after)
+
+      [default_expr(default), null_expr(null), after_expr(after_column)]
     end
+
+    defp after_expr(nil), do: []
+    defp after_expr(column) when is_atom(column) or is_binary(column), do: " AFTER `#{column}`"
+    defp after_expr(_), do: []
 
     defp null_expr(false), do: " NOT NULL"
     defp null_expr(true), do: " NULL"

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -954,10 +954,16 @@ if Code.ensure_loaded?(Postgrex) do
     end
 
     defp column_options(type, opts) do
-      default = Keyword.fetch(opts, :default)
-      null    = Keyword.get(opts, :null)
-      [default_expr(default, type), null_expr(null)]
+      default      = Keyword.fetch(opts, :default)
+      null         = Keyword.get(opts, :null)
+      after_column = Keyword.get(opts, :after)
+
+      [default_expr(default, type), null_expr(null), after_expr(after_column)]
     end
+
+    defp after_expr(nil), do: []
+    defp after_expr(column) when is_atom(column) or is_binary(column), do: " AFTER \"#{column}\""
+    defp after_expr(_), do: []
 
     defp null_expr(false), do: " NOT NULL"
     defp null_expr(true), do: " NULL"

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -954,16 +954,11 @@ if Code.ensure_loaded?(Postgrex) do
     end
 
     defp column_options(type, opts) do
-      default      = Keyword.fetch(opts, :default)
-      null         = Keyword.get(opts, :null)
-      after_column = Keyword.get(opts, :after)
+      default = Keyword.fetch(opts, :default)
+      null    = Keyword.get(opts, :null)
 
-      [default_expr(default, type), null_expr(null), after_expr(after_column)]
+      [default_expr(default, type), null_expr(null)]
     end
-
-    defp after_expr(nil), do: []
-    defp after_expr(column) when is_atom(column) or is_binary(column), do: " AFTER \"#{column}\""
-    defp after_expr(_), do: []
 
     defp null_expr(false), do: " NOT NULL"
     defp null_expr(true), do: " NULL"

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -863,7 +863,8 @@ defmodule Ecto.Migration do
     * `:precision` - the precision for a numeric type. Required when `:scale` is
       specified.
     * `:scale` - the scale of a numeric type. Defaults to `0`.
-    * `:after` - positions field after the specified one (only for MySQL)
+    * `:after` - positions field after the specified one. Only supported on MySQL,
+      it is ignored by other databases.
 
   """
   def add(column, type, opts \\ []) when is_atom(column) and is_list(opts) do

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -863,6 +863,7 @@ defmodule Ecto.Migration do
     * `:precision` - the precision for a numeric type. Required when `:scale` is
       specified.
     * `:scale` - the scale of a numeric type. Defaults to `0`.
+    * `:after` - positions field after the specified one (only for MySQL)
 
   """
   def add(column, type, opts \\ []) when is_atom(column) and is_list(opts) do

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -1164,9 +1164,9 @@ defmodule Ecto.Adapters.MyXQLTest do
   test "alter table" do
     alter = {:alter, table(:posts),
                [{:add, :title, :string, [default: "Untitled", size: 100, null: false]},
-                {:add, :author_id, %Reference{table: :author}, []},
+                {:add, :author_id, %Reference{table: :author}, [after: :title]},
                 {:add_if_not_exists, :subtitle, :string, [size: 100, null: false]},
-                {:add_if_not_exists, :editor_id, %Reference{table: :editor}, []},
+                {:add_if_not_exists, :editor_id, %Reference{table: :editor}, [after: :subtitle]},
                 {:modify, :price, :numeric, [precision: 8, scale: 2, null: true]},
                 {:modify, :cost, :integer, [null: false, default: nil]},
                 {:modify, :permalink_id, %Reference{table: :permalinks}, null: false},
@@ -1181,10 +1181,10 @@ defmodule Ecto.Adapters.MyXQLTest do
 
     assert execute_ddl(alter) == ["""
     ALTER TABLE `posts` ADD `title` varchar(100) DEFAULT 'Untitled' NOT NULL,
-    ADD `author_id` BIGINT UNSIGNED,
+    ADD `author_id` BIGINT UNSIGNED AFTER `title`,
     ADD CONSTRAINT `posts_author_id_fkey` FOREIGN KEY (`author_id`) REFERENCES `author`(`id`),
     ADD IF NOT EXISTS `subtitle` varchar(100) NOT NULL,
-    ADD IF NOT EXISTS `editor_id` BIGINT UNSIGNED,
+    ADD IF NOT EXISTS `editor_id` BIGINT UNSIGNED AFTER `subtitle`,
     ADD CONSTRAINT `posts_editor_id_fkey` FOREIGN KEY IF NOT EXISTS (`editor_id`) REFERENCES `editor`(`id`),
     MODIFY `price` numeric(8,2) NULL, MODIFY `cost` integer DEFAULT NULL NOT NULL,
     MODIFY `permalink_id` BIGINT UNSIGNED NOT NULL,

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1387,9 +1387,9 @@ defmodule Ecto.Adapters.PostgresTest do
   test "alter table" do
     alter = {:alter, table(:posts),
              [{:add, :title, :string, [default: "Untitled", size: 100, null: false]},
-             {:add, :author_id, %Reference{table: :author}, []},
+             {:add, :author_id, %Reference{table: :author}, [after: :title]},
              {:add_if_not_exists, :subtitle, :string, [size: 100, null: false]},
-             {:add_if_not_exists, :editor_id, %Reference{table: :editor}, []},
+             {:add_if_not_exists, :editor_id, %Reference{table: :editor}, [after: :subtitle]},
               {:modify, :price, :numeric, [precision: 8, scale: 2, null: true]},
               {:modify, :cost, :integer, [null: false, default: nil]},
               {:modify, :permalink_id, %Reference{table: :permalinks}, null: false},
@@ -1405,9 +1405,9 @@ defmodule Ecto.Adapters.PostgresTest do
     assert execute_ddl(alter) == ["""
     ALTER TABLE "posts"
     ADD COLUMN "title" varchar(100) DEFAULT 'Untitled' NOT NULL,
-    ADD COLUMN "author_id" bigint CONSTRAINT "posts_author_id_fkey" REFERENCES "author"("id"),
+    ADD COLUMN "author_id" bigint AFTER "title" CONSTRAINT "posts_author_id_fkey" REFERENCES "author"("id"),
     ADD COLUMN IF NOT EXISTS "subtitle" varchar(100) NOT NULL,
-    ADD COLUMN IF NOT EXISTS "editor_id" bigint CONSTRAINT "posts_editor_id_fkey" REFERENCES "editor"("id"),
+    ADD COLUMN IF NOT EXISTS "editor_id" bigint AFTER "subtitle" CONSTRAINT "posts_editor_id_fkey" REFERENCES "editor"("id"),
     ALTER COLUMN "price" TYPE numeric(8,2),
     ALTER COLUMN "price" DROP NOT NULL,
     ALTER COLUMN "cost" TYPE integer,

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1387,9 +1387,9 @@ defmodule Ecto.Adapters.PostgresTest do
   test "alter table" do
     alter = {:alter, table(:posts),
              [{:add, :title, :string, [default: "Untitled", size: 100, null: false]},
-             {:add, :author_id, %Reference{table: :author}, [after: :title]},
+             {:add, :author_id, %Reference{table: :author}, []},
              {:add_if_not_exists, :subtitle, :string, [size: 100, null: false]},
-             {:add_if_not_exists, :editor_id, %Reference{table: :editor}, [after: :subtitle]},
+             {:add_if_not_exists, :editor_id, %Reference{table: :editor}, []},
               {:modify, :price, :numeric, [precision: 8, scale: 2, null: true]},
               {:modify, :cost, :integer, [null: false, default: nil]},
               {:modify, :permalink_id, %Reference{table: :permalinks}, null: false},
@@ -1405,9 +1405,9 @@ defmodule Ecto.Adapters.PostgresTest do
     assert execute_ddl(alter) == ["""
     ALTER TABLE "posts"
     ADD COLUMN "title" varchar(100) DEFAULT 'Untitled' NOT NULL,
-    ADD COLUMN "author_id" bigint AFTER "title" CONSTRAINT "posts_author_id_fkey" REFERENCES "author"("id"),
+    ADD COLUMN "author_id" bigint CONSTRAINT "posts_author_id_fkey" REFERENCES "author"("id"),
     ADD COLUMN IF NOT EXISTS "subtitle" varchar(100) NOT NULL,
-    ADD COLUMN IF NOT EXISTS "editor_id" bigint AFTER "subtitle" CONSTRAINT "posts_editor_id_fkey" REFERENCES "editor"("id"),
+    ADD COLUMN IF NOT EXISTS "editor_id" bigint CONSTRAINT "posts_editor_id_fkey" REFERENCES "editor"("id"),
     ALTER COLUMN "price" TYPE numeric(8,2),
     ALTER COLUMN "price" DROP NOT NULL,
     ALTER COLUMN "cost" TYPE integer,


### PR DESCRIPTION
I wanted to achieve certain look of my table so I tried adding column after another one, but I had to use `execute` function in migration directly.

Unfortunately, this option isn't supported in PostgreSQL, so it won't help me, but it might be of use to someone using MySQL.