### PR TITLE
[WIP] Tds query improvements

### DIFF
--- a/integration_test/tds/constraints_test.exs
+++ b/integration_test/tds/constraints_test.exs
@@ -1,0 +1,158 @@
+defmodule Ecto.Integration.ConstraintsTest do
+  use ExUnit.Case, async: true
+
+  import Ecto.Migrator, only: [up: 4]
+  alias Ecto.Integration.PoolRepo
+
+  defmodule ConstraintMigration do
+    use Ecto.Migration
+
+    @table table(:constraints_test)
+
+    def change do
+      create @table do
+        add :price, :integer
+        add :from, :integer
+        add :to, :integer
+      end
+      create constraint(@table.name, :cannot_overlap, check: "[from] < [to]")
+      create constraint(@table.name, "positive_price", check: "[price] > 0")
+    end
+  end
+
+  defmodule ConstraintMigration2 do
+    use Ecto.Migration
+
+    def change do
+      opts = [with: "NOCHECK", check: "[from] < 200"]
+      create constraint(:constraints_test, "from_max", opts)
+    end
+  end
+
+  defmodule ConstraintMigration3 do
+    use Ecto.Migration
+
+    def change do
+      drop constraint(:constraints_test, "from_max")
+    end
+  end
+
+  defmodule Constraint do
+    use Ecto.Integration.Schema
+
+    schema "constraints_test" do
+      field :price, :integer
+      field :from, :integer
+      field :to, :integer
+    end
+  end
+
+  @base_migration 2_000_000
+
+  setup_all do
+    ExUnit.CaptureLog.capture_log(fn ->
+      num = @base_migration + System.unique_integer([:positive])
+      up(PoolRepo, num, ConstraintMigration, log: false)
+    end)
+
+    :ok
+  end
+
+  test "creating, using, and dropping an exclusion constraint" do
+    changeset = Ecto.Changeset.change(%Constraint{}, from: 0, to: 10)
+    {:ok, _} = PoolRepo.insert(changeset)
+
+    non_overlapping_changeset = Ecto.Changeset.change(%Constraint{}, from: 11, to: 12)
+    {:ok, _} = PoolRepo.insert(non_overlapping_changeset)
+
+    overlapping_changeset = Ecto.Changeset.change(%Constraint{}, from: 1900, to: 12)
+
+    exception =
+      assert_raise Ecto.ConstraintError, ~r/constraint error when attempting to insert struct/, fn ->
+        PoolRepo.insert(overlapping_changeset)
+      end
+    assert exception.message =~ "cannot_overlap (check_constraint)"
+    assert exception.message =~ "The changeset has not defined any constraint."
+    assert exception.message =~ "call `check_constraint/3`"
+
+    # Seems like below `Ecto.Changeset.check_constraint(:from)` is not valid for some reason,
+    # constrint name is mandatory and ecto raises ArgumentError
+
+    # message = ~r/constraint error when attempting to insert struct/
+    # exception =
+    #   assert_raise Ecto.ConstraintError, message, fn ->
+    #     overlapping_changeset
+    #     |> Ecto.Changeset.check_constraint(:from)
+    #     |> PoolRepo.insert()
+    #   end
+    # assert exception.message =~ "cannot_overlap (check_constraint)"
+
+    {:error, changeset} =
+      overlapping_changeset
+      |> Ecto.Changeset.check_constraint(:from, name: :cannot_overlap)
+      |> PoolRepo.insert()
+    assert changeset.errors == [from: {"is invalid", [constraint: :check, constraint_name: "cannot_overlap"]}]
+    assert changeset.data.__meta__.state == :built
+
+    ExUnit.CaptureLog.capture_log(fn ->
+      # migrate over existing data, it should pass since `with: NOCHECK` is set
+      num = @base_migration + System.unique_integer([:positive])
+      assert :ok == up(PoolRepo, num, ConstraintMigration2, log: false)
+    end)
+
+    # from is greated than max allowed by database, so check constrint should
+    # forbid insert
+    from_max_changeset = Ecto.Changeset.change(%Constraint{}, from: 300, to: 400)
+
+    exception =
+      assert_raise Ecto.ConstraintError, ~r/constraint error when attempting to insert struct/, fn ->
+        PoolRepo.insert(from_max_changeset)
+      end
+    assert exception.message =~ "from_max (check_constraint)"
+    assert exception.message =~ "The changeset has not defined any constraint."
+    assert exception.message =~ "call `check_constraint/3`"
+
+    ExUnit.CaptureLog.capture_log(fn ->
+      num = @base_migration + System.unique_integer([:positive])
+      assert :ok == up(PoolRepo, num, ConstraintMigration3, log: false)
+    end)
+  end
+
+  test "creating, using, and dropping a check constraint" do
+    # When the changeset doesn't expect the db error
+    changeset = Ecto.Changeset.change(%Constraint{}, price: -10)
+    exception =
+      assert_raise Ecto.ConstraintError, ~r/constraint error when attempting to insert struct/, fn ->
+        PoolRepo.insert(changeset)
+      end
+
+    assert exception.message =~ "positive_price (check_constraint)"
+    assert exception.message =~ "The changeset has not defined any constraint."
+    assert exception.message =~ "call `check_constraint/3`"
+
+    # When the changeset does expect the db error, but doesn't give a custom message
+    {:error, changeset} =
+      changeset
+      |> Ecto.Changeset.check_constraint(:price, name: :positive_price)
+      |> PoolRepo.insert()
+    assert changeset.errors == [price: {"is invalid", [constraint: :check, constraint_name: "positive_price"]}]
+    assert changeset.data.__meta__.state == :built
+
+    # When the changeset does expect the db error and gives a custom message
+    changeset = Ecto.Changeset.change(%Constraint{}, price: -10)
+    {:error, changeset} =
+      changeset
+      |> Ecto.Changeset.check_constraint(:price, name: :positive_price, message: "price must be greater than 0")
+      |> PoolRepo.insert()
+    assert changeset.errors == [price: {"price must be greater than 0", [constraint: :check, constraint_name: "positive_price"]}]
+    assert changeset.data.__meta__.state == :built
+
+    # When the change does not violate the check constraint
+    changeset = Ecto.Changeset.change(%Constraint{}, price: 10, from: 100, to: 200)
+    {:ok, changeset} =
+      changeset
+      |> Ecto.Changeset.check_constraint(:price, name: :positive_price, message: "price must be greater than 0")
+      |> PoolRepo.insert()
+    assert is_integer(changeset.id)
+  end
+end

--- a/integration_test/tds/migrations_test.exs
+++ b/integration_test/tds/migrations_test.exs
@@ -1,0 +1,119 @@
+defmodule Ecto.Integration.MigrationsTest do
+  use ExUnit.Case, async: true
+
+  alias Ecto.Integration.PoolRepo
+
+  # Avoid migration out of order warnings
+  @moduletag :capture_log
+  @base_migration 3_000_000
+
+  setup do
+    {:ok, migration_number: System.unique_integer([:positive]) + @base_migration}
+  end
+
+  defmodule AddColumnIfNotExistsMigration do
+    use Ecto.Migration
+
+    def up do
+      create table(:add_col_if_not_exists_migration)
+
+      alter table(:add_col_if_not_exists_migration) do
+        add_if_not_exists :value, :integer
+        add_if_not_exists :to_be_added, :integer
+      end
+
+      execute "INSERT INTO add_col_if_not_exists_migration (value, to_be_added) VALUES (1, 2)"
+    end
+
+    def down do
+      drop table(:add_col_if_not_exists_migration)
+    end
+  end
+
+  defmodule DropColumnIfExistsMigration do
+    use Ecto.Migration
+
+    def up do
+      create table(:drop_col_if_exists_migration) do
+        add :value, :integer
+        add :to_be_removed, :integer
+      end
+
+      execute "INSERT INTO drop_col_if_exists_migration (value, to_be_removed) VALUES (1, 2)"
+
+      alter table(:drop_col_if_exists_migration) do
+        remove_if_exists :to_be_removed, :integer
+      end
+    end
+
+    def down do
+      drop table(:drop_col_if_exists_migration)
+    end
+  end
+
+  defmodule DuplicateTableMigration do
+    use Ecto.Migration
+
+    def change do
+      create_if_not_exists table(:duplicate_table)
+      create_if_not_exists table(:duplicate_table)
+    end
+  end
+
+  defmodule NoErrorOnConditionalColumnMigration do
+    use Ecto.Migration
+
+    def up do
+      create table(:no_error_on_conditional_column_migration)
+
+      alter table(:no_error_on_conditional_column_migration) do
+        add_if_not_exists  :value, :integer
+        add_if_not_exists  :value, :integer
+
+        remove_if_exists :value, :integer
+        remove_if_exists :value, :integer
+      end
+    end
+
+    def down do
+      drop table(:no_error_on_conditional_column_migration)
+    end
+  end
+
+  import Ecto.Query, only: [from: 2]
+  import Ecto.Migrator, only: [up: 4, down: 4]
+
+  test "logs Postgres notice messages" do
+    # comparing to other db engines, in MSSQL there is no option in CREATE statement
+    # if_not_existis, instead we need to use if statement
+    # due this limitation, nothing will be logged in console
+    num = @base_migration + System.unique_integer([:positive])
+    up(PoolRepo, num, DuplicateTableMigration, log: false)
+
+    # check if first attempt in migration created table since seond yields nothing
+    # about skipping in logs
+    q = "SELECT COUNT(*) FROM [INFORMATION_SCHEMA].[TABLES] WHERE [TABLE_NAME] = @1"
+    p = ["duplicate_table"]
+    assert {:ok, %{rows: [[1]]}} = Ecto.Adapters.SQL.query(PoolRepo, q, p)
+  end
+
+  @tag :no_error_on_conditional_column_migration
+  test "add if not exists and drop if exists does not raise on failure", %{migration_number: num} do
+    assert :ok == up(PoolRepo, num, NoErrorOnConditionalColumnMigration, log: false)
+    assert :ok == down(PoolRepo, num, NoErrorOnConditionalColumnMigration, log: false)
+  end
+
+  @tag :add_column_if_not_exists
+  test "add column if not exists", %{migration_number: num} do
+    assert :ok == up(PoolRepo, num, AddColumnIfNotExistsMigration, log: false)
+    assert [2] == PoolRepo.all from p in "add_col_if_not_exists_migration", select: p.to_be_added
+    :ok = down(PoolRepo, num, AddColumnIfNotExistsMigration, log: false)
+  end
+
+  @tag :remove_column_if_exists
+  test "remove column when exists", %{migration_number: num} do
+    assert :ok == up(PoolRepo, num, DropColumnIfExistsMigration, log: false)
+    assert catch_error(PoolRepo.all from p in "drop_col_if_exists_migration", select: p.to_be_removed)
+    :ok = down(PoolRepo, num, DropColumnIfExistsMigration, log: false)
+  end
+end

--- a/integration_test/tds/migrations_test.exs
+++ b/integration_test/tds/migrations_test.exs
@@ -83,7 +83,7 @@ defmodule Ecto.Integration.MigrationsTest do
   import Ecto.Query, only: [from: 2]
   import Ecto.Migrator, only: [up: 4, down: 4]
 
-  test "logs Postgres notice messages" do
+  test "logs MSSQL notice messages" do
     # comparing to other db engines, in MSSQL there is no option in CREATE statement
     # if_not_existis, instead we need to use if statement
     # due this limitation, nothing will be logged in console

--- a/integration_test/tds/tds_type_test.exs
+++ b/integration_test/tds/tds_type_test.exs
@@ -1,0 +1,22 @@
+defmodule Ecto.Integration.TdsTypeTest do
+  use ExUnit.Case, async: true
+
+  import Ecto.Type
+  alias Tds.Ecto.VarChar
+  alias Ecto.Adapters.Tds
+
+  @varchar_string "some string"
+
+  test "dumps through the adapter" do
+    assert adapter_dump(Tds, {:map, VarChar}, %{"a" => @varchar_string}) ==
+             {:ok, %{"a" => @varchar_string}}
+  end
+
+  test "loads through the adapter" do
+    assert adapter_load(Tds, {:map, VarChar}, %{"a" => {@varchar_string, :varchar}}) ==
+             {:ok, %{"a" => @varchar_string}}
+
+    assert adapter_load(Tds, {:map, VarChar}, %{"a" => @varchar_string}) ==
+             {:ok, %{"a" => @varchar_string}}
+  end
+end

--- a/integration_test/tds/test_helper.exs
+++ b/integration_test/tds/test_helper.exs
@@ -88,7 +88,7 @@ defmodule Ecto.Integration.TestRepo do
     otp_app: :ecto_sql,
     adapter: Ecto.Adapters.Tds
 
-  def uuid, do: Tds.Types.UUID
+  def uuid, do: Tds.Ecto.UUID
 
   def create_prefix(prefix) do
     """

--- a/integration_test/tds/test_helper.exs
+++ b/integration_test/tds/test_helper.exs
@@ -36,8 +36,10 @@ ExUnit.start(
     :union_with_literals,
     # inline queries can't use order by
     :inline_order_by,
-    # running destruction of PK columns requires that constraint is dropped first
+    # running destruction of PK columns requires that PK constraint is dropped first
     :alter_primary_key,
+    # running destruction of PK columns requires that PK constraint is dropped first
+    # accessing column. This is same issue as :alter_primary_key
     :modify_column_with_from,
     # below 2 exclusions (in theory) requires filtered unique index on permalinks table post_id column e.g.
     #   CREATE UNIQUE NONCLUSTERED INDEX idx_tbl_TestUnique_ID
@@ -142,7 +144,8 @@ end
 # :dbg.start()
 # :dbg.tracer()
 # :dbg.p(:all,:c)
-# :dbg.tpl(Ecto.Adapters.Tds.Connection, :prepare_execute, :x)
+# :dbg.tpl(Ecto.Adapters.Tds.Connection, :column_change, :x)
+# :dbg.tpl(Ecto.Adapters.Tds.Connection, :execute_ddl, :x)
 # :dbg.tpl(Ecto.Adapters.Tds.Connection, :all, :x)
 # :dbg.tpl(Tds.Parameter, :prepare_params, :x)
 # :dbg.tpl(Tds.Parameter, :prepared_params, :x)

--- a/integration_test/tds/test_helper.exs
+++ b/integration_test/tds/test_helper.exs
@@ -20,8 +20,6 @@ ExUnit.start(
     :uses_msec,
     # Unique index compares even NULL values for post_id, so below fails inserting permalinks without setting valid post_id
     :insert_cell_wise_defaults,
-    # SELECT NOT(t.bool_column) not supported
-    :select_not,
     # MSSQL does not support strings on text fields
     :text_type_as_string,
     # IDENTITY_INSERT ON/OFF  must be manually executed
@@ -140,6 +138,14 @@ defmodule Ecto.Integration.Case do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(TestRepo, [isolation_level: level])
   end
 end
+
+# :dbg.start()
+# :dbg.tracer()
+# :dbg.p(:all,:c)
+# :dbg.tpl(Ecto.Adapters.Tds.Connection, :prepare_execute, :x)
+# :dbg.tpl(Ecto.Adapters.Tds.Connection, :all, :x)
+# :dbg.tpl(Tds.Parameter, :prepare_params, :x)
+# :dbg.tpl(Tds.Parameter, :prepared_params, :x)
 
 {:ok, _} = Ecto.Adapters.Tds.ensure_all_started(TestRepo.config(), :temporary)
 

--- a/lib/ecto/adapters/tds.ex
+++ b/lib/ecto/adapters/tds.ex
@@ -58,7 +58,7 @@ defmodule Ecto.Adapters.Tds do
   ### UUIDs
 
   MSSQL server has slighlty different binary storage format for UUIDs (`uniqueidenitifer`).
-  If you use `:binary_id`, the proper choice is made. Otherwise you must use the `Tds.Types.UUID`
+  If you use `:binary_id`, the proper choice is made. Otherwise you must use the `Tds.Ecto.UUID`
   type. Avoid using `Ecto.UUID` since it may cause unpredictable application behaviour.
 
   ### SQL `Char`, `VarChar` and `Text` types
@@ -78,14 +78,14 @@ defmodule Ecto.Adapters.Tds do
       due increased logical reads in database.
 
     - You can't store VarChar codepoints encoded in one collation/codepage to column that
-      is encoded in different collation/codepage. You will always get wrong result. This is 
+      is encoded in different collation/codepage. You will always get wrong result. This is
       not adapter or driver limitation but rather how string encoding works for single byte
       encoded strings in MSSQL server. Don't be confused if you are always seeing latin1 chars,
       they are simply in each codepoint table.
 
   In particular, if a field has the type `:text`, only raw binaries will be allowed.
   To avoid above limitations always use `:string` (NVarChar) type for text if possible.
-  If you really need to use VarChar's column type, you can use the `Tds.Types.VarChar`
+  If you really need to use VarChar's column type, you can use the `Tds.Ecto.VarChar`
   Ecto type.
 
   ### JSON support
@@ -139,8 +139,8 @@ defmodule Ecto.Adapters.Tds do
   @behaviour Ecto.Adapter.Storage
 
   @doc false
-  def autogenerate(:binary_id), do: Tds.Types.UUID.bingenerate()
-  def autogenerate(:embed_id), do: Tds.Types.UUID.generate()
+  def autogenerate(:binary_id), do: Tds.Ecto.UUID.bingenerate()
+  def autogenerate(:embed_id), do: Tds.Ecto.UUID.generate()
   def autogenerate(type), do: super(type)
 
   @doc false
@@ -149,13 +149,13 @@ defmodule Ecto.Adapters.Tds do
   def loaders({:map, _}, type), do: [&json_decode/1, &Ecto.Adapters.SQL.load_embed(type, &1)]
   def loaders(:map, type), do: [&json_decode/1, type]
   def loaders(:boolean, type), do: [&bool_decode/1, type]
-  def loaders(:binary_id, type), do: [Tds.Types.UUID, type]
+  def loaders(:binary_id, type), do: [Tds.Ecto.UUID, type]
   def loaders(_, type), do: [type]
 
   @impl true
   def dumpers({:embed, _}, type), do: [&Ecto.Adapters.SQL.dump_embed(type, &1)]
   def dumpers({:map, _}, type), do: [&Ecto.Adapters.SQL.dump_embed(type, &1)]
-  def dumpers(:binary_id, type), do: [type, Tds.Types.UUID]
+  def dumpers(:binary_id, type), do: [type, Tds.Ecto.UUID]
   def dumpers(_, type), do: [type]
 
 

--- a/lib/ecto/adapters/tds/connection.ex
+++ b/lib/ecto/adapters/tds/connection.ex
@@ -779,7 +779,7 @@ if Code.ensure_loaded?(Tds) do
     defp expr(%Tagged{value: binary, type: :uuid}, _sources, _query) when is_binary(binary) do
       case binary do
         <<_::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96>> ->
-          {:ok, value} = Tds.Types.UUID.dump(binary)
+          {:ok, value} = Tds.Ecto.UUID.dump(binary)
           value
 
         any ->

--- a/lib/ecto/adapters/tds/types.ex
+++ b/lib/ecto/adapters/tds/types.ex
@@ -1,0 +1,322 @@
+if Code.ensure_loaded?(Tds) do
+  defmodule Tds.Ecto.UUID do
+    @moduledoc """
+    An TDS adapter type for UUIDs strings.
+
+    If you are using Tds adapter and UUIDs in your project, instead of `Ecto.UUID`
+    you should use Tds.Ecto.UUID to generate correct bytes that should be stored
+    in database.
+    """
+
+    use Ecto.Type
+
+    @typedoc """
+    A hex-encoded UUID string.
+    """
+    @type t :: <<_::288>>
+
+    @typedoc """
+    A raw binary represenation of a UUID.
+    """
+    @type raw :: <<_::128>>
+
+
+    @doc false
+    @impl true
+    def type(), do: :uuid
+
+    @doc """
+    Casts to UUID.
+    """
+    @impl true
+    @spec cast(t | raw | any) :: {:ok, t} | :error
+    def cast(<< a1, a2, a3, a4, a5, a6, a7, a8, ?-,
+                b1, b2, b3, b4, ?-,
+                c1, c2, c3, c4, ?-,
+                d1, d2, d3, d4, ?-,
+                e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12 >>) do
+      << c(a1), c(a2), c(a3), c(a4), c(a5), c(a6), c(a7), c(a8), ?-,
+        c(b1), c(b2), c(b3), c(b4), ?-,
+        c(c1), c(c2), c(c3), c(c4), ?-,
+        c(d1), c(d2), c(d3), c(d4), ?-,
+        c(e1), c(e2), c(e3), c(e4), c(e5), c(e6), c(e7), c(e8), c(e9), c(e10), c(e11), c(e12) >>
+    catch
+      :error -> :error
+    else
+      casted -> {:ok, casted}
+    end
+
+    def cast(<<bin::binary-size(16)>>), do: encode(bin)
+
+    def cast(_), do: :error
+
+    @doc """
+    Same as `cast/1` but raises `Ecto.CastError` on invalid arguments.
+    """
+    def cast!(value) do
+      case cast(value) do
+        {:ok, uuid} -> uuid
+        :error -> raise Ecto.CastError, type: __MODULE__, value: value
+      end
+    end
+
+    @compile {:inline, c: 1}
+
+    defp c(?0), do: ?0
+    defp c(?1), do: ?1
+    defp c(?2), do: ?2
+    defp c(?3), do: ?3
+    defp c(?4), do: ?4
+    defp c(?5), do: ?5
+    defp c(?6), do: ?6
+    defp c(?7), do: ?7
+    defp c(?8), do: ?8
+    defp c(?9), do: ?9
+    defp c(?A), do: ?a
+    defp c(?B), do: ?b
+    defp c(?C), do: ?c
+    defp c(?D), do: ?d
+    defp c(?E), do: ?e
+    defp c(?F), do: ?f
+    defp c(?a), do: ?a
+    defp c(?b), do: ?b
+    defp c(?c), do: ?c
+    defp c(?d), do: ?d
+    defp c(?e), do: ?e
+    defp c(?f), do: ?f
+    defp c(_),  do: throw(:error)
+
+    @doc """
+    Converts a string representing a UUID into a binary.
+    """
+    @impl true
+    @spec dump(t | any) :: {:ok, raw} | :error
+    def dump(<< a1, a2, a3, a4, a5, a6, a7, a8, ?-,
+                b1, b2, b3, b4, ?-,
+                c1, c2, c3, c4, ?-,
+                d1, d2, d3, d4, ?-,
+                e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12 >>) do
+      try do
+        << d(a7)::4, d(a8)::4, d(a5)::4, d(a6)::4,
+          d(a3)::4, d(a4)::4, d(a1)::4, d(a2)::4,
+          d(b3)::4, d(b4)::4, d(b1)::4, d(b2)::4,
+          d(c3)::4, d(c4)::4, d(c1)::4, d(c2)::4,
+          d(d1)::4, d(d2)::4, d(d3)::4, d(d4)::4,
+          d(e1)::4, d(e2)::4, d(e3)::4, d(e4)::4,
+          d(e5)::4, d(e6)::4, d(e7)::4, d(e8)::4,
+          d(e9)::4, d(e10)::4, d(e11)::4, d(e12)::4 >>
+      catch
+        :error -> :error
+      else
+        binary ->
+          {:ok, binary}
+      end
+    end
+
+    def dump(_), do: :error
+
+    def dump!(value) do
+      case dump(value) do
+        {:ok, binary} -> binary
+        :error -> raise ArgumentError, "Invalid uuid value #{inspect(value)}"
+      end
+    end
+
+    @compile {:inline, d: 1}
+
+    defp d(?0), do: 0
+    defp d(?1), do: 1
+    defp d(?2), do: 2
+    defp d(?3), do: 3
+    defp d(?4), do: 4
+    defp d(?5), do: 5
+    defp d(?6), do: 6
+    defp d(?7), do: 7
+    defp d(?8), do: 8
+    defp d(?9), do: 9
+    defp d(?A), do: 10
+    defp d(?B), do: 11
+    defp d(?C), do: 12
+    defp d(?D), do: 13
+    defp d(?E), do: 14
+    defp d(?F), do: 15
+    defp d(?a), do: 10
+    defp d(?b), do: 11
+    defp d(?c), do: 12
+    defp d(?d), do: 13
+    defp d(?e), do: 14
+    defp d(?f), do: 15
+    defp d(_),  do: throw(:error)
+
+    @doc """
+    Converts a binary UUID into a string.
+    """
+    @impl true
+    @spec load(raw | any) :: {:ok, t} | :error
+    def load(<<_::128>> = uuid) do
+      encode(uuid)
+    end
+
+    def load(<<_::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96>> = string) do
+      raise ArgumentError, "trying to load string UUID as Tds.Types.UUID: #{inspect string}. " <>
+                          "Maybe you wanted to declare :uuid as your database field?"
+    end
+
+    def load(_), do: :error
+
+    @doc """
+    Generates a version 4 (random) UUID.
+    """
+    @spec generate() :: t
+    def generate do
+      {:ok, uuid} = encode(bingenerate())
+      uuid
+    end
+
+    @doc """
+    Generates a version 4 (random) UUID in the binary format.
+    """
+    @spec bingenerate() :: raw
+    def bingenerate do
+      << a1::4, a2::4, a3::4, a4::4,
+        a5::4, a6::4, a7::4, a8::4,
+        b1::4, b2::4, b3::4, b4::4,
+        _ ::4, c2::4, c3::4, c4::4,
+        d1::4, d2::4, d3::4, d4::4,
+        e1::4, e2::4, e3::4, e4::4,
+        _ ::4, e6::4, e7::4, e8::4,
+        e9::4, e10::4, e11::4, e12::4 >> = :crypto.strong_rand_bytes(16)
+      << a7::4, a8::4, a5::4, a6::4,
+        a3::4, a4::4, a1::4, a2::4,
+        b3::4, b4::4, b1::4, b2::4,
+        c3::4, c4::4, 4 ::4, c2::4,
+        d1::4, d2::4, d3::4, d4::4,
+        e1::4, e2::4, e3::4, e4::4,
+        2 ::4, e6::4, e7::4, e8::4,
+        e9::4, e10::4, e11::4, e12::4 >>
+    end
+
+    # Callback invoked by autogenerate fields.
+    @doc false
+    def autogenerate, do: generate()
+
+    defp encode(<< a1::4, a2::4, a3::4, a4::4,
+                  a5::4, a6::4, a7::4, a8::4,
+                  b1::4, b2::4, b3::4, b4::4,
+                  c1::4, c2::4, c3::4, c4::4,
+                  d1::4, d2::4, d3::4, d4::4,
+                  e1::4, e2::4, e3::4, e4::4,
+                  e5::4, e6::4, e7::4, e8::4,
+                  e9::4, e10::4, e11::4, e12::4 >>) do
+      << e(a7), e(a8), e(a5), e(a6), e(a3), e(a4), e(a1), e(a2), ?-,
+        e(b3), e(b4), e(b1), e(b2), ?-,
+        e(c3), e(c4), e(c1), e(c2), ?-,
+        e(d1), e(d2), e(d3), e(d4), ?-,
+        e(e1), e(e2), e(e3), e(e4), e(e5), e(e6), e(e7), e(e8), e(e9), e(e10), e(e11), e(e12) >>
+    catch
+      :error -> :error
+    else
+      encoded -> {:ok, encoded}
+    end
+
+    @compile {:inline, e: 1}
+
+    defp e(0),  do: ?0
+    defp e(1),  do: ?1
+    defp e(2),  do: ?2
+    defp e(3),  do: ?3
+    defp e(4),  do: ?4
+    defp e(5),  do: ?5
+    defp e(6),  do: ?6
+    defp e(7),  do: ?7
+    defp e(8),  do: ?8
+    defp e(9),  do: ?9
+    defp e(10), do: ?a
+    defp e(11), do: ?b
+    defp e(12), do: ?c
+    defp e(13), do: ?d
+    defp e(14), do: ?e
+    defp e(15), do: ?f
+  end
+
+  defmodule Tds.Ecto.VarChar do
+    @moduledoc """
+    An Tds adatper Ecto Type that wrapps erlang string into tuple so TDS driver
+    can understand if erlang string should be encoded as NVarChar or Varchar.
+
+    Due some limitations in Ecto and Tds driver, it is not possible to
+    support collations other than the one that is set on connection during login.
+    Please be aware of this limitation if you plan to store varchar values in
+    your database using Ecto since you will probably lose some codepoints in
+    the value during encoding. Instead use `tds_encoding` library and first
+    encode value and then anotate it as `:binary` by calling `Ecto.Query.API.type/2`
+    in your query. This way all codepoints will be properly preserved during
+    insert to database.
+    """
+    use Ecto.Type
+
+    @typedoc """
+    A erlang string
+    """
+    @type t :: String.t
+
+    @typedoc """
+    A value annotated as varchar.
+    """
+    @type varchar :: {String.t, :varchar}
+
+
+    @doc false
+    @impl true
+    def type(), do: :varchar
+
+    @doc """
+    Casts to string
+    """
+    @spec cast(t | varchar | any) :: {:ok, t} | :error
+    @impl true
+    def cast({value, :varchar}) do
+      # In case we get already dumped value
+      {:ok, value}
+    end
+
+    def cast(value) when is_binary(value) do
+      {:ok, value}
+    end
+
+    def cast(_), do: :error
+
+    @doc """
+    Same as `cast/1` but raises `Ecto.CastError` on invalid arguments.
+    """
+    @spec cast!(t | varchar | any) :: t
+    def cast!(value) do
+      case cast(value) do
+        {:ok, uuid} -> uuid
+        :error -> raise Ecto.CastError, type: __MODULE__, value: value
+      end
+    end
+
+
+    @doc false
+    @impl true
+    @spec load(t | any) :: {:ok, t} | :error
+    def load(value) do
+      # what ever TDS returns just pass back to ecto. It is already a string
+      {:ok, value}
+    end
+
+    @doc """
+    Converts a string representing a VarChar into a tuple `{value, :varchar}`.
+
+    returns `:error` if value is not binary
+    """
+    @impl true
+    @spec dump(t | any) :: {:ok, varchar} | :error
+    def dump(value) when is_binary(value) do
+      {:ok, {value, :varchar}}
+    end
+
+    def dump(_), do: :error
+  end
+end

--- a/lib/ecto/adapters/tds/types.ex
+++ b/lib/ecto/adapters/tds/types.ex
@@ -158,7 +158,7 @@ if Code.ensure_loaded?(Tds) do
     end
 
     def load(<<_::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96>> = string) do
-      raise ArgumentError, "trying to load string UUID as Tds.Types.UUID: #{inspect string}. " <>
+      raise ArgumentError, "trying to load string UUID as Tds.Ecto.UUID: #{inspect string}. " <>
                           "Maybe you wanted to declare :uuid as your database field?"
     end
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -362,9 +362,10 @@ defmodule Ecto.Migration do
 
     To define a constraint in a migration, see `Ecto.Migration.constraint/3`.
     """
-    defstruct name: nil, table: nil, check: nil, exclude: nil, prefix: nil, comment: nil
+    defstruct name: nil, table: nil, check: nil, exclude: nil, prefix: nil, comment: nil, with: nil
     @type t :: %__MODULE__{name: atom, table: String.t, prefix: atom | nil,
-                           check: String.t | nil, exclude: String.t | nil, comment: String.t | nil}
+                           check: String.t | nil, exclude: String.t | nil, comment: String.t | nil,
+                           with: String.t | nil}
   end
 
   defmodule Command do
@@ -1108,6 +1109,9 @@ defmodule Ecto.Migration do
     * `:check` - A check constraint expression. Required when creating a check constraint.
     * `:exclude` - An exclusion constraint expression. Required when creating an exclusion constraint.
     * `:prefix` - The prefix for the table.
+    * `:with` - Optional parameter for Tds adapter for create constrint.
+                Valid value is `"NOCHECK"` and it will prevent constraint checking
+                existing rows in the table, and allow for constrint to be added.
 
   """
   def constraint(table, name, opts \\ [])

--- a/test/ecto/adapters/tds_test.exs
+++ b/test/ecto/adapters/tds_test.exs
@@ -222,18 +222,17 @@ defmodule Ecto.Adapters.TdsTest do
       |> plan(:update_all)
 
     assert update_all(query) ==
-      ~s{WITH [target_rows] ([id]) AS } <>
-      ~s{(SELECT TOP(10) s0.[id] AS [id] FROM [schema] AS s0 ORDER BY s0.[id] OPTION (MERGE JOIN)) } <>
-      ~s{UPDATE s0 } <>
-      ~s{SET s0.[x] = 123 } <>
-      ~s{OUTPUT INSERTED.[id], INSERTED.[x], INSERTED.[y], INSERTED.[z], INSERTED.[w] } <>
-      ~s{FROM [schema] AS s0 } <>
-      ~s{INNER JOIN [target_rows] AS t1 ON t1.[id] = s0.[id]}
+             ~s{WITH [target_rows] ([id]) AS } <>
+               ~s{(SELECT TOP(10) s0.[id] AS [id] FROM [schema] AS s0 ORDER BY s0.[id] OPTION (MERGE JOIN)) } <>
+               ~s{UPDATE s0 } <>
+               ~s{SET s0.[x] = 123 } <>
+               ~s{OUTPUT INSERTED.[id], INSERTED.[x], INSERTED.[y], INSERTED.[z], INSERTED.[w] } <>
+               ~s{FROM [schema] AS s0 } <>
+               ~s{INNER JOIN [target_rows] AS t1 ON t1.[id] = s0.[id]}
   end
 
   test "CTE delete_all" do
-    cte_query =
-      from(x in Schema, order_by: [asc: :id], limit: 10, select: %{id: x.id})
+    cte_query = from(x in Schema, order_by: [asc: :id], limit: 10, select: %{id: x.id})
 
     query =
       Schema
@@ -243,12 +242,12 @@ defmodule Ecto.Adapters.TdsTest do
       |> plan(:delete_all)
 
     assert delete_all(query) ==
-      ~s{WITH [target_rows] ([id]) AS } <>
-      ~s{(SELECT TOP(10) s0.[id] AS [id] FROM [schema] AS s0 ORDER BY s0.[id]) } <>
-      ~s{DELETE s0 } <>
-      ~s{OUTPUT DELETED.[id], DELETED.[x], DELETED.[y], DELETED.[z], DELETED.[w] } <>
-      ~s{FROM [schema] AS s0 } <>
-      ~s{INNER JOIN [target_rows] AS t1 ON t1.[id] = s0.[id]}
+             ~s{WITH [target_rows] ([id]) AS } <>
+               ~s{(SELECT TOP(10) s0.[id] AS [id] FROM [schema] AS s0 ORDER BY s0.[id]) } <>
+               ~s{DELETE s0 } <>
+               ~s{OUTPUT DELETED.[id], DELETED.[x], DELETED.[y], DELETED.[z], DELETED.[w] } <>
+               ~s{FROM [schema] AS s0 } <>
+               ~s{INNER JOIN [target_rows] AS t1 ON t1.[id] = s0.[id]}
   end
 
   test "select" do
@@ -275,9 +274,12 @@ defmodule Ecto.Adapters.TdsTest do
 
   test "aggregate filters" do
     query = Schema |> select([r], count(r.x) |> filter(r.x > 10)) |> plan()
-    assert_raise Ecto.QueryError, ~r/Tds adapter does not support aggregate filters in query/, fn ->
-      all(query)
-    end
+
+    assert_raise Ecto.QueryError,
+                 ~r/Tds adapter does not support aggregate filters in query/,
+                 fn ->
+                   all(query)
+                 end
   end
 
   test "distinct" do
@@ -296,7 +298,9 @@ defmodule Ecto.Adapters.TdsTest do
     assert_raise Ecto.QueryError,
                  ~r"DISTINCT with multiple columns is not supported by MsSQL",
                  fn ->
-                   query = Schema |> distinct([r], [r.x, r.y]) |> select([r], {r.x, r.y}) |> plan()
+                   query =
+                     Schema |> distinct([r], [r.x, r.y]) |> select([r], {r.x, r.y}) |> plan()
+
                    all(query)
                  end
   end
@@ -343,7 +347,9 @@ defmodule Ecto.Adapters.TdsTest do
   end
 
   test "union and union all" do
-    base_query = Schema |> select([r], r.x) |> order_by(fragment("rand")) |> offset(10) |> limit(5)
+    base_query =
+      Schema |> select([r], r.x) |> order_by(fragment("rand")) |> offset(10) |> limit(5)
+
     union_query1 = Schema |> select([r], r.y) |> order_by([r], r.y) |> offset(20) |> limit(40)
     union_query2 = Schema |> select([r], r.z) |> order_by([r], r.z) |> offset(30) |> limit(60)
 
@@ -365,7 +371,9 @@ defmodule Ecto.Adapters.TdsTest do
   end
 
   test "except and except all" do
-    base_query = Schema |> select([r], r.x) |> order_by(fragment("rand")) |> offset(10) |> limit(5)
+    base_query =
+      Schema |> select([r], r.x) |> order_by(fragment("rand")) |> offset(10) |> limit(5)
+
     except_query1 = Schema |> select([r], r.y) |> order_by([r], r.y) |> offset(20) |> limit(40)
     except_query2 = Schema |> select([r], r.z) |> order_by([r], r.z) |> offset(30) |> limit(60)
 
@@ -387,7 +395,9 @@ defmodule Ecto.Adapters.TdsTest do
   end
 
   test "intersect and intersect all" do
-    base_query = Schema |> select([r], r.x) |> order_by(fragment("rand")) |> offset(10) |> limit(5)
+    base_query =
+      Schema |> select([r], r.x) |> order_by(fragment("rand")) |> offset(10) |> limit(5)
+
     intersect_query1 = Schema |> select([r], r.y) |> order_by([r], r.y) |> offset(20) |> limit(40)
     intersect_query2 = Schema |> select([r], r.z) |> order_by([r], r.z) |> offset(30) |> limit(60)
 
@@ -399,7 +409,8 @@ defmodule Ecto.Adapters.TdsTest do
                ~s{INTERSECT (SELECT s0.[z] FROM [schema] AS s0 ORDER BY s0.[z] OFFSET 30 ROW FETCH NEXT 60 ROWS ONLY) } <>
                ~s{ORDER BY rand OFFSET 10 ROW FETCH NEXT 5 ROWS ONLY}
 
-    query = base_query |> intersect_all(^intersect_query1) |> intersect_all(^intersect_query2) |> plan()
+    query =
+      base_query |> intersect_all(^intersect_query1) |> intersect_all(^intersect_query2) |> plan()
 
     assert all(query) ==
              ~s{SELECT s0.[x] FROM [schema] AS s0 } <>
@@ -419,7 +430,12 @@ defmodule Ecto.Adapters.TdsTest do
     end
 
     query =
-      Schema |> order_by([r], r.x) |> offset([r], 5) |> limit([r], 3) |> select([], true) |> plan()
+      Schema
+      |> order_by([r], r.x)
+      |> offset([r], 5)
+      |> limit([r], 3)
+      |> select([], true)
+      |> plan()
 
     assert all(query) ==
              ~s{SELECT CAST(1 as bit) FROM [schema] AS s0 ORDER BY s0.[x] OFFSET 5 ROW FETCH NEXT 3 ROWS ONLY}
@@ -446,8 +462,9 @@ defmodule Ecto.Adapters.TdsTest do
              ~s{SELECT CAST(1 as bit) FROM [schema] AS s0 WHERE (s0.[foo] = N'''--  ')}
 
     query = "schema" |> where(foo: "ok str '; select 1; --") |> select([], true) |> plan()
+
     assert all(query) ==
-      ~s{SELECT CAST(1 as bit) FROM [schema] AS s0 WHERE (s0.[foo] = N'ok str ''; select 1; --')}
+             ~s{SELECT CAST(1 as bit) FROM [schema] AS s0 WHERE (s0.[foo] = N'ok str ''; select 1; --')}
 
     query = "schema" |> where(foo: "'") |> select([], true) |> plan()
     assert all(query) == ~s{SELECT CAST(1 as bit) FROM [schema] AS s0 WHERE (s0.[foo] = N'''')}
@@ -515,8 +532,10 @@ defmodule Ecto.Adapters.TdsTest do
     query = "schema" |> where(foo: "abc") |> select([], true) |> plan()
     assert all(query) == ~s{SELECT CAST(1 as bit) FROM [schema] AS s0 WHERE (s0.[foo] = N'abc')}
 
-    query = "schema" |> where(foo: <<0,?a,?b,?c>>) |> select([], true) |> plan()
-    assert all(query) == ~s{SELECT CAST(1 as bit) FROM [schema] AS s0 WHERE (s0.[foo] = 0x00616263)}
+    query = "schema" |> where(foo: <<0, ?a, ?b, ?c>>) |> select([], true) |> plan()
+
+    assert all(query) ==
+             ~s{SELECT CAST(1 as bit) FROM [schema] AS s0 WHERE (s0.[foo] = 0x00616263)}
 
     query = "schema" |> where(foo: 123) |> select([], true) |> plan()
     assert all(query) == ~s{SELECT CAST(1 as bit) FROM [schema] AS s0 WHERE (s0.[foo] = 123)}
@@ -558,7 +577,9 @@ defmodule Ecto.Adapters.TdsTest do
     assert all(query) == ~s{SELECT 1 = ANY(foo) FROM [schema] AS s0}
 
     query = Schema |> select([e], e.x == ^0 or e.x in ^[1, 2, 3] or e.x == ^4) |> plan()
-    assert all(query) == ~s{SELECT ((s0.[x] = @1) OR s0.[x] IN (@2,@3,@4)) OR (s0.[x] = @5) FROM [schema] AS s0}
+
+    assert all(query) ==
+             ~s{SELECT ((s0.[x] = @1) OR s0.[x] IN (@2,@3,@4)) OR (s0.[x] = @5) FROM [schema] AS s0}
   end
 
   test "having" do
@@ -613,7 +634,8 @@ defmodule Ecto.Adapters.TdsTest do
     union = "schema1" |> select([m], {m.id, ^true}) |> where([], fragment("?", ^5))
     union_all = "schema2" |> select([m], {m.id, ^false}) |> where([], fragment("?", ^6))
 
-    query = "schema"
+    query =
+      "schema"
       |> with_cte("cte1", as: ^cte1)
       |> select([m], {m.id, ^true})
       |> join(:inner, [], Schema2, on: fragment("?", ^true))
@@ -633,27 +655,30 @@ defmodule Ecto.Adapters.TdsTest do
 
     result =
       ~s{WITH [cte1] ([id], [smth]) AS } <>
-      ~s{(SELECT s0.[id] AS [id], @1 AS [smth] FROM [schema1] AS s0 WHERE (@2)) } <>
-      ~s{SELECT s0.[id], @3 FROM [schema] AS s0 INNER JOIN [schema2] AS s1 ON @4 } <>
-      ~s{INNER JOIN [schema2] AS s2 ON @5 } <>
-      ~s{WHERE (@6) AND (@7) } <>
-      ~s{GROUP BY @8, @9 HAVING (@10) AND (@11) } <>
-      ~s{UNION (SELECT s0.[id], @12 FROM [schema1] AS s0 WHERE (@13)) } <>
-      ~s{UNION ALL (SELECT s0.[id], @14 FROM [schema2] AS s0 WHERE (@15)) } <>
-      ~s{ORDER BY @16 OFFSET @18 ROW FETCH NEXT @17 ROWS ONLY}
+        ~s{(SELECT s0.[id] AS [id], @1 AS [smth] FROM [schema1] AS s0 WHERE (@2)) } <>
+        ~s{SELECT s0.[id], @3 FROM [schema] AS s0 INNER JOIN [schema2] AS s1 ON @4 } <>
+        ~s{INNER JOIN [schema2] AS s2 ON @5 } <>
+        ~s{WHERE (@6) AND (@7) } <>
+        ~s{GROUP BY @8, @9 HAVING (@10) AND (@11) } <>
+        ~s{UNION (SELECT s0.[id], @12 FROM [schema1] AS s0 WHERE (@13)) } <>
+        ~s{UNION ALL (SELECT s0.[id], @14 FROM [schema2] AS s0 WHERE (@15)) } <>
+        ~s{ORDER BY @16 OFFSET @18 ROW FETCH NEXT @17 ROWS ONLY}
 
     assert all(query) == String.trim_trailing(result)
   end
 
   test "fragments allow ? to be escaped with backslash" do
     query =
-      plan  from(e in "schema",
-        where: fragment("? = \"query\\?\"", e.start_time),
-        select: true)
+      plan(
+        from(e in "schema",
+          where: fragment("? = \"query\\?\"", e.start_time),
+          select: true
+        )
+      )
 
     result =
       "SELECT CAST(1 as bit) FROM [schema] AS s0 " <>
-      "WHERE (s0.[start_time] = \"query?\")"
+        "WHERE (s0.[start_time] = \"query?\")"
 
     assert all(query) == String.trim(result)
   end
@@ -697,8 +722,9 @@ defmodule Ecto.Adapters.TdsTest do
 
   test "update all with returning" do
     query = from(m in Schema, update: [set: [x: 0]]) |> select([m], m) |> plan(:update_all)
+
     assert update_all(query) ==
-           ~s{UPDATE s0 SET s0.[x] = 0 OUTPUT INSERTED.[id], INSERTED.[x], INSERTED.[y], INSERTED.[z], INSERTED.[w] FROM [schema] AS s0}
+             ~s{UPDATE s0 SET s0.[x] = 0 OUTPUT INSERTED.[id], INSERTED.[x], INSERTED.[y], INSERTED.[z], INSERTED.[w] FROM [schema] AS s0}
   end
 
   test "update all with prefix" do
@@ -709,7 +735,9 @@ defmodule Ecto.Adapters.TdsTest do
              ~s{UPDATE s0 SET s0.[x] = 0 FROM [prefix].[schema] AS s0}
 
     query =
-      from(m in Schema, prefix: "first", update: [set: [x: 0]]) |> Map.put(:prefix, "prefix") |> plan(:update_all)
+      from(m in Schema, prefix: "first", update: [set: [x: 0]])
+      |> Map.put(:prefix, "prefix")
+      |> plan(:update_all)
 
     assert update_all(query) ==
              ~s{UPDATE s0 SET s0.[x] = 0 FROM [first].[schema] AS s0}
@@ -735,8 +763,10 @@ defmodule Ecto.Adapters.TdsTest do
   end
 
   test "delete all with returning" do
-    query = Schema |> Queryable.to_query |> select([m], m) |> plan()
-    assert delete_all(query) == ~s{DELETE s0 OUTPUT DELETED.[id], DELETED.[x], DELETED.[y], DELETED.[z], DELETED.[w] FROM [schema] AS s0}
+    query = Schema |> Queryable.to_query() |> select([m], m) |> plan()
+
+    assert delete_all(query) ==
+             ~s{DELETE s0 OUTPUT DELETED.[id], DELETED.[x], DELETED.[y], DELETED.[z], DELETED.[w] FROM [schema] AS s0}
   end
 
   test "delete all with prefix" do
@@ -750,7 +780,8 @@ defmodule Ecto.Adapters.TdsTest do
   ## Joins
 
   test "join" do
-    query = Schema |> join(:inner, [p], q in Schema2, on: p.x == q.z) |> select([], true) |> plan()
+    query =
+      Schema |> join(:inner, [p], q in Schema2, on: p.x == q.z) |> select([], true) |> plan()
 
     assert all(query) ==
              ~s{SELECT CAST(1 as bit) FROM [schema] AS s0 INNER JOIN [schema2] AS s1 ON s0.[x] = s1.[z]}
@@ -772,7 +803,8 @@ defmodule Ecto.Adapters.TdsTest do
            |> join(:inner, [p], q in Schema2, hints: ["USE INDEX FOO", "USE INDEX BAR"])
            |> select([], true)
            |> plan()
-           |> all() == ~s{SELECT CAST(1 as bit) FROM [schema] AS s0 INNER JOIN [schema2] AS s1 WITH (USE INDEX FOO, USE INDEX BAR) ON 1 = 1}
+           |> all() ==
+             ~s{SELECT CAST(1 as bit) FROM [schema] AS s0 INNER JOIN [schema2] AS s1 WITH (USE INDEX FOO, USE INDEX BAR) ON 1 = 1}
   end
 
   test "join with nothing bound" do
@@ -821,27 +853,31 @@ defmodule Ecto.Adapters.TdsTest do
   end
 
   test "join with fragment and on defined" do
-    query = Schema
-            |> join(:inner, [p], q in fragment("SELECT * FROM schema2"), on: q.id == p.id)
-            |> select([p], {p.id, ^0})
-            |> plan()
+    query =
+      Schema
+      |> join(:inner, [p], q in fragment("SELECT * FROM schema2"), on: q.id == p.id)
+      |> select([p], {p.id, ^0})
+      |> plan()
+
     assert all(query) ==
-           "SELECT s0.[id], @1 FROM [schema] AS s0 INNER JOIN (SELECT * FROM schema2) AS f1 ON f1.[id] = s0.[id]"
+             "SELECT s0.[id], @1 FROM [schema] AS s0 INNER JOIN (SELECT * FROM schema2) AS f1 ON f1.[id] = s0.[id]"
   end
 
   test "join with query interpolation" do
     inner = Ecto.Queryable.to_query(Schema2)
     query = from(p in Schema, left_join: c in ^inner, select: {p.id, c.id}) |> plan()
+
     assert all(query) ==
-           "SELECT s0.[id], s1.[id] FROM [schema] AS s0 LEFT OUTER JOIN [schema2] AS s1 ON 1 = 1"
+             "SELECT s0.[id], s1.[id] FROM [schema] AS s0 LEFT OUTER JOIN [schema2] AS s1 ON 1 = 1"
   end
 
   test "join produces correct bindings" do
     query = from(p in Schema, join: c in Schema2, on: true)
     query = from(p in query, join: c in Schema2, on: true, select: {p.id, c.id})
     query = plan(query)
+
     assert all(query) ==
-           "SELECT s0.[id], s2.[id] FROM [schema] AS s0 INNER JOIN [schema2] AS s1 ON 1 = 1 INNER JOIN [schema2] AS s2 ON 1 = 1"
+             "SELECT s0.[id], s2.[id] FROM [schema] AS s0 INNER JOIN [schema2] AS s1 ON 1 = 1 INNER JOIN [schema2] AS s2 ON 1 = 1"
   end
 
   ## Associations
@@ -888,8 +924,19 @@ defmodule Ecto.Adapters.TdsTest do
 
   test "insert with query" do
     select_query = from("schema", select: [:id]) |> plan(:all)
-    query = insert(nil, "schema", [:x, :y, :z], [[:x, {select_query, 2}, :z], [nil, nil, {select_query, 1}]], {:raise, [], []}, [])
-    assert query == ~s{INSERT INTO [schema] ([x], [y], [z]) VALUES (@1, (SELECT s0.[id] FROM [schema] AS s0), @4),(DEFAULT, DEFAULT, (SELECT s0.[id] FROM [schema] AS s0))}
+
+    query =
+      insert(
+        nil,
+        "schema",
+        [:x, :y, :z],
+        [[:x, {select_query, 2}, :z], [nil, nil, {select_query, 1}]],
+        {:raise, [], []},
+        []
+      )
+
+    assert query ==
+             ~s{INSERT INTO [schema] ([x], [y], [z]) VALUES (@1, (SELECT s0.[id] FROM [schema] AS s0), @4),(DEFAULT, DEFAULT, (SELECT s0.[id] FROM [schema] AS s0))}
   end
 
   test "update" do
@@ -916,8 +963,8 @@ defmodule Ecto.Adapters.TdsTest do
 
   ## DDL
 
-  import Ecto.Migration, only: [table: 1, table: 2, index: 2, index: 3,
-                                constraint: 2, constraint: 3]
+  import Ecto.Migration,
+    only: [table: 1, table: 2, index: 2, index: 3, constraint: 2, constraint: 3]
 
   test "executing a string during migration" do
     assert execute_ddl("example") == ["example"]
@@ -926,17 +973,20 @@ defmodule Ecto.Adapters.TdsTest do
   test "create empty table" do
     create = {:create, table(:posts), []}
 
-    assert execute_ddl(create) == ["CREATE TABLE [posts]"]
+    assert execute_ddl(create) == ["CREATE TABLE [posts]; "]
   end
 
   test "create table" do
-    create = {:create, table(:posts),
-               [{:add, :name, :string, [default: "Untitled", size: 20, null: false]},
-                {:add, :price, :numeric, [precision: 8, scale: 2, default: {:fragment, "expr"}]},
-                {:add, :on_hand, :integer, [default: 0, null: true]},
-                {:add, :likes, :"smallint unsigned", [default: 0, null: false]},
-                {:add, :published_at, :"datetime(6)", [null: true]},
-                {:add, :is_active, :boolean, [default: true]}]}
+    create =
+      {:create, table(:posts),
+       [
+         {:add, :name, :string, [default: "Untitled", size: 20, null: false]},
+         {:add, :price, :numeric, [precision: 8, scale: 2, default: {:fragment, "expr"}]},
+         {:add, :on_hand, :integer, [default: 0, null: true]},
+         {:add, :likes, :"smallint unsigned", [default: 0, null: false]},
+         {:add, :published_at, :"datetime(6)", [null: true]},
+         {:add, :is_active, :boolean, [default: true]}
+       ]}
 
     assert execute_ddl(create) == [
              """
@@ -945,48 +995,63 @@ defmodule Ecto.Adapters.TdsTest do
              [on_hand] integer NULL CONSTRAINT [DF__posts_on_hand] DEFAULT (0),
              [likes] smallint unsigned NOT NULL CONSTRAINT [DF__posts_likes] DEFAULT (0),
              [published_at] datetime(6) NULL,
-             [is_active] bit CONSTRAINT [DF__posts_is_active] DEFAULT (1))
+             [is_active] bit CONSTRAINT [DF__posts_is_active] DEFAULT (1));
              """
              |> remove_newlines
+             |> Kernel.<>(" ")
            ]
   end
 
   test "create table with prefix" do
-    create = {:create, table(:posts, prefix: :foo),
-               [{:add, :category_0, %Reference{table: :categories}, []}]}
+    create =
+      {:create, table(:posts, prefix: :foo),
+       [{:add, :category_0, %Reference{table: :categories}, []}]}
 
-    assert execute_ddl(create) == ["""
-    CREATE TABLE [foo].[posts] ([category_0] BIGINT,
-    CONSTRAINT [posts_category_0_fkey] FOREIGN KEY ([category_0]) REFERENCES [foo].[categories]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION)
-    """ |> remove_newlines]
+    assert execute_ddl(create) == [
+             """
+             CREATE TABLE [foo].[posts] ([category_0] BIGINT,
+             CONSTRAINT [posts_category_0_fkey] FOREIGN KEY ([category_0]) REFERENCES [foo].[categories]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION);
+             """
+             |> remove_newlines
+             |> Kernel.<>(" ")
+           ]
   end
 
   test "create table with reference" do
-    create = {:create, table(:posts),
-               [{:add, :id, :serial, [primary_key: true]},
-                {:add, :category_0, %Reference{table: :categories}, []},
-                {:add, :category_1, %Reference{table: :categories, name: :foo_bar}, []},
-                {:add, :category_2, %Reference{table: :categories, on_delete: :nothing}, []},
-                {:add, :category_3, %Reference{table: :categories, on_delete: :delete_all}, [null: false]},
-                {:add, :category_4, %Reference{table: :categories, on_delete: :nilify_all}, []},
-                {:add, :category_5, %Reference{table: :categories, prefix: :foo, on_delete: :nilify_all}, []}]}
+    create =
+      {:create, table(:posts),
+       [
+         {:add, :id, :serial, [primary_key: true]},
+         {:add, :category_0, %Reference{table: :categories}, []},
+         {:add, :category_1, %Reference{table: :categories, name: :foo_bar}, []},
+         {:add, :category_2, %Reference{table: :categories, on_delete: :nothing}, []},
+         {:add, :category_3, %Reference{table: :categories, on_delete: :delete_all},
+          [null: false]},
+         {:add, :category_4, %Reference{table: :categories, on_delete: :nilify_all}, []},
+         {:add, :category_5, %Reference{table: :categories, prefix: :foo, on_delete: :nilify_all},
+          []}
+       ]}
 
-    assert execute_ddl(create) == ["""
-    CREATE TABLE [posts] ([id] int IDENTITY(1,1),
-    [category_0] BIGINT,
-    CONSTRAINT [posts_category_0_fkey] FOREIGN KEY ([category_0]) REFERENCES [categories]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION,
-    [category_1] BIGINT,
-    CONSTRAINT [foo_bar] FOREIGN KEY ([category_1]) REFERENCES [categories]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION,
-    [category_2] BIGINT,
-    CONSTRAINT [posts_category_2_fkey] FOREIGN KEY ([category_2]) REFERENCES [categories]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION,
-    [category_3] BIGINT NOT NULL,
-    CONSTRAINT [posts_category_3_fkey] FOREIGN KEY ([category_3]) REFERENCES [categories]([id]) ON DELETE CASCADE ON UPDATE NO ACTION,
-    [category_4] BIGINT,
-    CONSTRAINT [posts_category_4_fkey] FOREIGN KEY ([category_4]) REFERENCES [categories]([id]) ON DELETE SET NULL ON UPDATE NO ACTION,
-    [category_5] BIGINT,
-    CONSTRAINT [posts_category_5_fkey] FOREIGN KEY ([category_5]) REFERENCES [foo].[categories]([id]) ON DELETE SET NULL ON UPDATE NO ACTION,
-    CONSTRAINT [posts_pkey] PRIMARY KEY CLUSTERED ([id]))
-    """ |> remove_newlines]
+    assert execute_ddl(create) == [
+             """
+             CREATE TABLE [posts] ([id] int IDENTITY(1,1),
+             [category_0] BIGINT,
+             CONSTRAINT [posts_category_0_fkey] FOREIGN KEY ([category_0]) REFERENCES [categories]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION,
+             [category_1] BIGINT,
+             CONSTRAINT [foo_bar] FOREIGN KEY ([category_1]) REFERENCES [categories]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION,
+             [category_2] BIGINT,
+             CONSTRAINT [posts_category_2_fkey] FOREIGN KEY ([category_2]) REFERENCES [categories]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION,
+             [category_3] BIGINT NOT NULL,
+             CONSTRAINT [posts_category_3_fkey] FOREIGN KEY ([category_3]) REFERENCES [categories]([id]) ON DELETE CASCADE ON UPDATE NO ACTION,
+             [category_4] BIGINT,
+             CONSTRAINT [posts_category_4_fkey] FOREIGN KEY ([category_4]) REFERENCES [categories]([id]) ON DELETE SET NULL ON UPDATE NO ACTION,
+             [category_5] BIGINT,
+             CONSTRAINT [posts_category_5_fkey] FOREIGN KEY ([category_5]) REFERENCES [foo].[categories]([id]) ON DELETE SET NULL ON UPDATE NO ACTION,
+             CONSTRAINT [posts_pkey] PRIMARY KEY CLUSTERED ([id]));
+             """
+             |> remove_newlines
+             |> Kernel.<>(" ")
+           ]
   end
 
   test "create table with options" do
@@ -998,9 +1063,10 @@ defmodule Ecto.Adapters.TdsTest do
              [
                """
                CREATE TABLE [posts] ([id] int IDENTITY(1,1), [created_at] datetime,
-               CONSTRAINT [posts_pkey] PRIMARY KEY CLUSTERED ([id])) WITH FOO=BAR
+               CONSTRAINT [posts_pkey] PRIMARY KEY CLUSTERED ([id])) WITH FOO=BAR;
                """
                |> remove_newlines
+               |> Kernel.<>(" ")
              ]
   end
 
@@ -1016,36 +1082,39 @@ defmodule Ecto.Adapters.TdsTest do
     assert execute_ddl(create) == [
              """
              CREATE TABLE [posts] ([a] integer, [b] integer, [name] nvarchar(255),
-             CONSTRAINT [posts_pkey] PRIMARY KEY CLUSTERED ([a], [b]))
+             CONSTRAINT [posts_pkey] PRIMARY KEY CLUSTERED ([a], [b]));
              """
              |> remove_newlines
+             |> Kernel.<>(" ")
            ]
   end
 
   test "create table with binary column and UTF-8 default" do
-    create = {:create, table(:blobs),
-              [{:add, :blob, :binary, [default: "foo"]}]}
+    create = {:create, table(:blobs), [{:add, :blob, :binary, [default: "foo"]}]}
 
     assert execute_ddl(create) ==
-             ["CREATE TABLE [blobs] ([blob] varbinary(2000) CONSTRAINT [DF__blobs_blob] DEFAULT (N'foo'))"]
+             [
+               "CREATE TABLE [blobs] ([blob] varbinary(2000) CONSTRAINT [DF__blobs_blob] DEFAULT (N'foo')); "
+             ]
   end
 
   test "create table with binary column and hex bytea literal default" do
-    create = {:create, table(:blobs),
-              [{:add, :blob, :binary, [default: "\\x666F6F"]}]}
+    create = {:create, table(:blobs), [{:add, :blob, :binary, [default: "\\x666F6F"]}]}
 
     assert execute_ddl(create) ==
-             ["CREATE TABLE [blobs] ([blob] varbinary(2000) CONSTRAINT [DF__blobs_blob] DEFAULT (N'\\x666F6F'))"]
+             [
+               "CREATE TABLE [blobs] ([blob] varbinary(2000) CONSTRAINT [DF__blobs_blob] DEFAULT (N'\\x666F6F')); "
+             ]
   end
 
   test "drop table" do
     drop = {:drop, table(:posts)}
-    assert execute_ddl(drop) == ["DROP TABLE [posts]"]
+    assert execute_ddl(drop) == ["DROP TABLE [posts]; "]
   end
 
   test "drop table with prefixes" do
     drop = {:drop, table(:posts, prefix: :foo)}
-    assert execute_ddl(drop) == ["DROP TABLE [foo].[posts]"]
+    assert execute_ddl(drop) == ["DROP TABLE [foo].[posts]; "]
   end
 
   test "alter table" do
@@ -1057,6 +1126,10 @@ defmodule Ecto.Adapters.TdsTest do
          {:modify, :price, :numeric, [precision: 8, scale: 2, null: true]},
          {:modify, :cost, :integer, [null: true, default: nil]},
          {:modify, :permalink_id, %Reference{table: :permalinks}, null: false},
+         {:modify, :status, :string, from: :integer},
+         {:modify, :user_id, :integer, from: %Reference{table: :users}},
+         {:modify, :group_id, %Reference{table: :groups, column: :gid},
+          from: %Reference{table: :groups}},
          {:remove, :summary}
        ]}
 
@@ -1065,14 +1138,33 @@ defmodule Ecto.Adapters.TdsTest do
       ALTER TABLE [posts] ADD [title] nvarchar(100) NOT NULL CONSTRAINT [DF__posts_title] DEFAULT (N'Untitled');
       ALTER TABLE [posts] ADD [author_id] BIGINT;
       ALTER TABLE [posts] ADD CONSTRAINT [posts_author_id_fkey] FOREIGN KEY ([author_id]) REFERENCES [author]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION;
-      IF (OBJECT_ID(N'[DF__posts_price]', 'D') IS NOT NULL) BEGIN ALTER TABLE [posts] DROP CONSTRAINT [DF__posts_price];  END;
+      IF (OBJECT_ID(N'[DF__posts_price]', 'D') IS NOT NULL)
+      ALTER TABLE [posts] DROP CONSTRAINT [DF__posts_price];
       ALTER TABLE [posts] ALTER COLUMN [price] numeric(8,2) NULL;
-      IF (OBJECT_ID(N'[DF__posts_cost]', 'D') IS NOT NULL) BEGIN ALTER TABLE [posts] DROP CONSTRAINT [DF__posts_cost];  END;
+      IF (OBJECT_ID(N'[DF__posts_cost]', 'D') IS NOT NULL)
+      ALTER TABLE [posts] DROP CONSTRAINT [DF__posts_cost];
       ALTER TABLE [posts] ALTER COLUMN [cost] integer NULL;
       ALTER TABLE [posts] ADD CONSTRAINT [DF__posts_cost] DEFAULT (NULL) FOR [cost];
-      IF (OBJECT_ID(N'[posts_permalink_id_fkey]', 'F') IS NOT NULL) BEGIN ALTER TABLE [posts] DROP CONSTRAINT [posts_permalink_id_fkey];  END;
+      IF (OBJECT_ID(N'[posts_permalink_id_fkey]', 'F') IS NOT NULL)
+      ALTER TABLE [posts] DROP CONSTRAINT [posts_permalink_id_fkey];
       ALTER TABLE [posts] ALTER COLUMN [permalink_id] BIGINT NOT NULL;
-      ALTER TABLE [posts] ADD CONSTRAINT [posts_permalink_id_fkey] FOREIGN KEY ([permalink_id]) REFERENCES [permalinks]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION;
+      ALTER TABLE [posts] ADD CONSTRAINT [posts_permalink_id_fkey]
+      FOREIGN KEY ([permalink_id])
+      REFERENCES [permalinks]([id])
+      ON DELETE NO ACTION ON UPDATE NO ACTION;
+      IF (OBJECT_ID(N'[DF__posts_status]', 'D') IS NOT NULL)
+      ALTER TABLE [posts] DROP CONSTRAINT [DF__posts_status];
+      ALTER TABLE [posts] ALTER COLUMN [status] nvarchar(255);
+      IF (OBJECT_ID(N'[DF__posts_user_id]', 'D') IS NOT NULL)
+      ALTER TABLE [posts] DROP CONSTRAINT [DF__posts_user_id];
+      ALTER TABLE [posts] ALTER COLUMN [user_id] integer;
+      IF (OBJECT_ID(N'[posts_group_id_fkey]', 'F') IS NOT NULL)
+      ALTER TABLE [posts] DROP CONSTRAINT [posts_group_id_fkey];
+      ALTER TABLE [posts] ALTER COLUMN [group_id] BIGINT;
+      ALTER TABLE [posts] ADD CONSTRAINT [posts_group_id_fkey]
+      FOREIGN KEY ([group_id])
+      REFERENCES [groups]([gid])
+      ON DELETE NO ACTION ON UPDATE NO ACTION;
       ALTER TABLE [posts] DROP COLUMN [summary];
       """
       |> remove_newlines
@@ -1095,10 +1187,18 @@ defmodule Ecto.Adapters.TdsTest do
     assert execute_ddl(alter) ==
              [
                """
-               ALTER TABLE [foo].[posts] ADD [title] nvarchar(100) NOT NULL CONSTRAINT [DF_foo_posts_title] DEFAULT (N'Untitled');
-               IF (OBJECT_ID(N'[DF_foo_posts_price]', 'D') IS NOT NULL) BEGIN ALTER TABLE [foo].[posts] DROP CONSTRAINT [DF_foo_posts_price];  END;
+               ALTER TABLE [foo].[posts]
+               ADD [title] nvarchar(100) NOT NULL CONSTRAINT [DF_foo_posts_title] DEFAULT (N'Untitled');
+               IF (OBJECT_ID(N'[DF_foo_posts_price]', 'D') IS NOT NULL)
+               ALTER TABLE [foo].[posts] DROP CONSTRAINT [DF_foo_posts_price];
                ALTER TABLE [foo].[posts] ALTER COLUMN [price] numeric(8,2);
-               IF (OBJECT_ID(N'[posts_permalink_id_fkey]', 'F') IS NOT NULL) BEGIN ALTER TABLE [foo].[posts] DROP CONSTRAINT [posts_permalink_id_fkey];  END; ALTER TABLE [foo].[posts] ALTER COLUMN [permalink_id] BIGINT NOT NULL; ALTER TABLE [foo].[posts] ADD CONSTRAINT [posts_permalink_id_fkey] FOREIGN KEY ([permalink_id]) REFERENCES [foo].[permalinks]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION;
+               IF (OBJECT_ID(N'[posts_permalink_id_fkey]', 'F') IS NOT NULL)
+               ALTER TABLE [foo].[posts] DROP CONSTRAINT [posts_permalink_id_fkey];
+               ALTER TABLE [foo].[posts] ALTER COLUMN [permalink_id] BIGINT NOT NULL;
+               ALTER TABLE [foo].[posts] ADD CONSTRAINT [posts_permalink_id_fkey]
+               FOREIGN KEY ([permalink_id])
+               REFERENCES [foo].[permalinks]([id])
+               ON DELETE NO ACTION ON UPDATE NO ACTION;
                ALTER TABLE [foo].[posts] DROP COLUMN [summary];
                """
                |> remove_newlines
@@ -1108,32 +1208,55 @@ defmodule Ecto.Adapters.TdsTest do
 
   test "create check constraint" do
     create = {:create, constraint(:products, "price_must_be_positive", check: "price > 0")}
-    assert execute_ddl(create) ==
-      [~s|ALTER TABLE [products] ADD CONSTRAINT [price_must_be_positive] CHECK (price > 0); |]
 
-    create = {:create, constraint(:products, "price_must_be_positive", check: "price > 0", prefix: "foo")}
     assert execute_ddl(create) ==
-      [~s|ALTER TABLE [foo].[products] ADD CONSTRAINT [price_must_be_positive] CHECK (price > 0); |]
+             [
+               ~s|ALTER TABLE [products] ADD CONSTRAINT [price_must_be_positive] CHECK (price > 0); |
+             ]
+
+    create =
+      {:create,
+       constraint(:products, "price_must_be_positive", check: "price > 0", prefix: "foo")}
+
+    assert execute_ddl(create) ==
+             [
+               ~s|ALTER TABLE [foo].[products] ADD CONSTRAINT [price_must_be_positive] CHECK (price > 0); |
+             ]
   end
 
   test "drop constraint" do
     drop = {:drop, constraint(:products, "price_must_be_positive")}
+
     assert execute_ddl(drop) ==
-      [~s|ALTER TABLE [products] DROP CONSTRAINT [price_must_be_positive]; |]
+             [~s|ALTER TABLE [products] DROP CONSTRAINT [price_must_be_positive]; |]
 
     drop = {:drop, constraint(:products, "price_must_be_positive", prefix: "foo")}
+
     assert execute_ddl(drop) ==
-      [~s|ALTER TABLE [foo].[products] DROP CONSTRAINT [price_must_be_positive]; |]
+             [~s|ALTER TABLE [foo].[products] DROP CONSTRAINT [price_must_be_positive]; |]
   end
 
   test "drop_if_exists constraint" do
     drop = {:drop_if_exists, constraint(:products, "price_must_be_positive")}
+
     assert execute_ddl(drop) ==
-      [~s|IF NOT EXISTS (SELECT * FROM [INFORMATION_SCHEMA].[CHECK_CONSTRAINTS] WHERE [CONSTRAINT_NAME] = N'price_must_be_positive') ALTER TABLE [products] DROP CONSTRAINT [price_must_be_positive]; |]
+             [
+               "IF NOT EXISTS (" <>
+                 "SELECT * FROM [INFORMATION_SCHEMA].[CHECK_CONSTRAINTS] " <>
+                 "WHERE [CONSTRAINT_NAME] = N'price_must_be_positive') " <>
+                 "ALTER TABLE [products] DROP CONSTRAINT [price_must_be_positive]; "
+             ]
 
     drop = {:drop_if_exists, constraint(:products, "price_must_be_positive", prefix: "foo")}
+
     assert execute_ddl(drop) ==
-      [~s|IF NOT EXISTS (SELECT * FROM [INFORMATION_SCHEMA].[CHECK_CONSTRAINTS] WHERE [CONSTRAINT_NAME] = N'price_must_be_positive' AND [CONSTRAINT_SCHEMA] = N'foo') ALTER TABLE [foo].[products] DROP CONSTRAINT [price_must_be_positive]; |]
+             [
+               "IF NOT EXISTS (" <>
+                 "SELECT * FROM [INFORMATION_SCHEMA].[CHECK_CONSTRAINTS] " <>
+                 "WHERE [CONSTRAINT_NAME] = N'price_must_be_positive' " <>
+                 "AND [CONSTRAINT_SCHEMA] = N'foo') " <>
+                 "ALTER TABLE [foo].[products] DROP CONSTRAINT [price_must_be_positive]; "
+             ]
   end
 
   test "rename table" do
@@ -1231,14 +1354,14 @@ defmodule Ecto.Adapters.TdsTest do
 
   test "drop index" do
     drop = {:drop, index(:posts, [:id], name: "posts$main")}
-    assert execute_ddl(drop) == [~s|DROP INDEX [posts$main] ON [posts];|]
+    assert execute_ddl(drop) == [~s|DROP INDEX [posts$main] ON [posts]; |]
   end
 
   test "drop index with prefix" do
     drop = {:drop, index(:posts, [:id], name: "posts_category_id_permalink_index", prefix: :foo)}
 
     assert execute_ddl(drop) ==
-             [~s|DROP INDEX [posts_category_id_permalink_index] ON [foo].[posts];|]
+             [~s|DROP INDEX [posts_category_id_permalink_index] ON [foo].[posts]; |]
   end
 
   test "drop index with prefix if exists" do
@@ -1255,15 +1378,16 @@ defmodule Ecto.Adapters.TdsTest do
                DROP INDEX [posts_category_id_permalink_index] ON [foo].[posts];
                """
                |> remove_newlines
+               |> Kernel.<>(" ")
              ]
   end
 
   test "drop index asserting concurrency" do
     drop = {:drop, index(:posts, [:id], name: "posts$main", concurrently: true)}
-    assert execute_ddl(drop) == [~s|DROP INDEX [posts$main] ON [posts] LOCK=NONE;|]
+    assert execute_ddl(drop) == [~s|DROP INDEX [posts$main] ON [posts] LOCK=NONE; |]
   end
 
-  defp remove_newlines(string) do
+  defp remove_newlines(string) when is_binary(string) do
     string |> String.trim() |> String.replace("\n", " ")
   end
 end

--- a/test/ecto/adapters/tds_test.exs
+++ b/test/ecto/adapters/tds_test.exs
@@ -527,7 +527,7 @@ defmodule Ecto.Adapters.TdsTest do
 
   test "tagged type" do
     query =
-      Schema |> select([], type(^"601d74e4-a8d3-4b6e-8365-eddb4c893327", Tds.Types.UUID)) |> plan()
+      Schema |> select([], type(^"601d74e4-a8d3-4b6e-8365-eddb4c893327", Tds.Ecto.UUID)) |> plan()
 
     assert all(query) == ~s{SELECT CAST(@1 AS uniqueidentifier) FROM [schema] AS s0}
   end

--- a/test/ecto/adapters/tds_test.exs
+++ b/test/ecto/adapters/tds_test.exs
@@ -1138,33 +1138,15 @@ defmodule Ecto.Adapters.TdsTest do
       ALTER TABLE [posts] ADD [title] nvarchar(100) NOT NULL CONSTRAINT [DF__posts_title] DEFAULT (N'Untitled');
       ALTER TABLE [posts] ADD [author_id] BIGINT;
       ALTER TABLE [posts] ADD CONSTRAINT [posts_author_id_fkey] FOREIGN KEY ([author_id]) REFERENCES [author]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION;
-      IF (OBJECT_ID(N'[DF__posts_price]', 'D') IS NOT NULL)
-      ALTER TABLE [posts] DROP CONSTRAINT [DF__posts_price];
       ALTER TABLE [posts] ALTER COLUMN [price] numeric(8,2) NULL;
-      IF (OBJECT_ID(N'[DF__posts_cost]', 'D') IS NOT NULL)
-      ALTER TABLE [posts] DROP CONSTRAINT [DF__posts_cost];
-      ALTER TABLE [posts] ALTER COLUMN [cost] integer NULL;
-      ALTER TABLE [posts] ADD CONSTRAINT [DF__posts_cost] DEFAULT (NULL) FOR [cost];
-      IF (OBJECT_ID(N'[posts_permalink_id_fkey]', 'F') IS NOT NULL)
-      ALTER TABLE [posts] DROP CONSTRAINT [posts_permalink_id_fkey];
+      IF (OBJECT_ID(N'[DF__posts_cost]', 'D') IS NOT NULL) ALTER TABLE [posts] DROP CONSTRAINT [DF__posts_cost]; ALTER TABLE [posts] ALTER COLUMN [cost] integer NULL;
       ALTER TABLE [posts] ALTER COLUMN [permalink_id] BIGINT NOT NULL;
-      ALTER TABLE [posts] ADD CONSTRAINT [posts_permalink_id_fkey]
-      FOREIGN KEY ([permalink_id])
-      REFERENCES [permalinks]([id])
-      ON DELETE NO ACTION ON UPDATE NO ACTION;
-      IF (OBJECT_ID(N'[DF__posts_status]', 'D') IS NOT NULL)
-      ALTER TABLE [posts] DROP CONSTRAINT [DF__posts_status];
-      ALTER TABLE [posts] ALTER COLUMN [status] nvarchar(255);
-      IF (OBJECT_ID(N'[DF__posts_user_id]', 'D') IS NOT NULL)
-      ALTER TABLE [posts] DROP CONSTRAINT [DF__posts_user_id];
+      ALTER TABLE [posts] ADD CONSTRAINT [posts_permalink_id_fkey] FOREIGN KEY ([permalink_id]) REFERENCES [permalinks]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION;
+      ALTER TABLE [posts] ALTER COLUMN [status] nvarchar(255); ALTER TABLE [posts] DROP CONSTRAINT [posts_user_id_fkey];
       ALTER TABLE [posts] ALTER COLUMN [user_id] integer;
-      IF (OBJECT_ID(N'[posts_group_id_fkey]', 'F') IS NOT NULL)
       ALTER TABLE [posts] DROP CONSTRAINT [posts_group_id_fkey];
       ALTER TABLE [posts] ALTER COLUMN [group_id] BIGINT;
-      ALTER TABLE [posts] ADD CONSTRAINT [posts_group_id_fkey]
-      FOREIGN KEY ([group_id])
-      REFERENCES [groups]([gid])
-      ON DELETE NO ACTION ON UPDATE NO ACTION;
+      ALTER TABLE [posts] ADD CONSTRAINT [posts_group_id_fkey] FOREIGN KEY ([group_id]) REFERENCES [groups]([gid]) ON DELETE NO ACTION ON UPDATE NO ACTION;
       ALTER TABLE [posts] DROP COLUMN [summary];
       """
       |> remove_newlines
@@ -1187,18 +1169,10 @@ defmodule Ecto.Adapters.TdsTest do
     assert execute_ddl(alter) ==
              [
                """
-               ALTER TABLE [foo].[posts]
-               ADD [title] nvarchar(100) NOT NULL CONSTRAINT [DF_foo_posts_title] DEFAULT (N'Untitled');
-               IF (OBJECT_ID(N'[DF_foo_posts_price]', 'D') IS NOT NULL)
-               ALTER TABLE [foo].[posts] DROP CONSTRAINT [DF_foo_posts_price];
+               ALTER TABLE [foo].[posts] ADD [title] nvarchar(100) NOT NULL CONSTRAINT [DF_foo_posts_title] DEFAULT (N'Untitled');
                ALTER TABLE [foo].[posts] ALTER COLUMN [price] numeric(8,2);
-               IF (OBJECT_ID(N'[posts_permalink_id_fkey]', 'F') IS NOT NULL)
-               ALTER TABLE [foo].[posts] DROP CONSTRAINT [posts_permalink_id_fkey];
                ALTER TABLE [foo].[posts] ALTER COLUMN [permalink_id] BIGINT NOT NULL;
-               ALTER TABLE [foo].[posts] ADD CONSTRAINT [posts_permalink_id_fkey]
-               FOREIGN KEY ([permalink_id])
-               REFERENCES [foo].[permalinks]([id])
-               ON DELETE NO ACTION ON UPDATE NO ACTION;
+               ALTER TABLE [foo].[posts] ADD CONSTRAINT [posts_permalink_id_fkey] FOREIGN KEY ([permalink_id]) REFERENCES [foo].[permalinks]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION;
                ALTER TABLE [foo].[posts] DROP COLUMN [summary];
                """
                |> remove_newlines

--- a/test/ecto/type_test.exs
+++ b/test/ecto/type_test.exs
@@ -16,7 +16,7 @@ defmodule Ecto.TypeTest do
     assert adapter_dump(Postgres, {:map, Ecto.UUID}, %{"a" => @uuid_string}) ==
            {:ok, %{"a" => @uuid_string}}
 
-    assert adapter_dump(Tds, {:map, Elixir.Tds.Types.UUID}, %{"a" => @uuid_string}) ==
+    assert adapter_dump(Tds, {:map, Elixir.Tds.Ecto.UUID}, %{"a" => @uuid_string}) ==
            {:ok, %{"a" => @uuid_string}}
   end
 
@@ -28,7 +28,7 @@ defmodule Ecto.TypeTest do
     assert adapter_load(Postgres, {:map, Ecto.UUID}, %{"a" => @uuid_binary}) ==
            {:ok, %{"a" => @uuid_string}}
 
-    assert adapter_load(Tds, {:map, Elixir.Tds.Types.UUID}, %{"a" => @mssql_uuid_binary}) ==
+    assert adapter_load(Tds, {:map, Elixir.Tds.Ecto.UUID}, %{"a" => @mssql_uuid_binary}) ==
            {:ok, %{"a" => @uuid_string}}
 
     assert adapter_load(MyXQL, {:map, Ecto.UUID}, %{"a" => @uuid_string}) ==
@@ -37,7 +37,7 @@ defmodule Ecto.TypeTest do
     assert adapter_load(Postgres, {:map, Ecto.UUID}, %{"a" => @uuid_string}) ==
            {:ok, %{"a" => @uuid_string}}
 
-    assert adapter_load(Tds, {:map, Elixir.Tds.Types.UUID}, %{"a" => @uuid_string}) ==
+    assert adapter_load(Tds, {:map, Elixir.Tds.Ecto.UUID}, %{"a" => @uuid_string}) ==
            {:ok, %{"a" => @uuid_string}}
   end
 end


### PR DESCRIPTION
Should solve #202 issues

* [x] Add if not exists and remove if not exists to MSSQL: 57b97e8219a0f4dd33ba2509a63d499429f46dde
* [x] Add typed remove: 1354185c107e272e83511ab672b562bd08d9848f
* [x] Support prefix option in references: b4031ca619a13e1efdfb3ee64bd156bc9f51a1e6
* [x] Support drop_if_exists for Ecto.Migration.Constraints: 7eea8b75cb6971a9fabc1f359a3ebe8f34e3ebaf
* [x] Support :from in modify: https://github.com/elixir-ecto/ecto/commit/4e6e4932318285267567a584e2057a37f96b84c8
* [x] Move TDS Ecto types to `ecto_sql` under name `Tds.Ecto.Varchar` and `Tds.Ecto.UUID`

Plus

- Supports negated values in select statement for bit columns so this works now `from u in Users, select: %{enabled: not(u.is_disabled)}`
- Query bound `Decimal` values now can keep precision, but some cases are known that still not work. For instance `dateatime_dd/3` still do can't accept decimal value.
- Check constraints are now supported like in postgresql but without `:exclude`. Since new constraints can be added after some data is inserted, there is new option that can be passed to `Ecto.Migration.constraint/3` named `:widh` so that user can pass `"NOCHECK"`  if it is expected that some existing data could violate check condition. Docs are very clear that it is TDS adapter optional parameter.