### PR TITLE
Remove compile-time dependency on Tds

### DIFF
--- a/lib/ecto/adapters/tds.ex
+++ b/lib/ecto/adapters/tds.ex
@@ -183,7 +183,7 @@ defmodule Ecto.Adapters.Tds do
       {:ok, _} ->
         :ok
 
-      {:error, %Tds.Error{mssql: %{number: 1801}}} ->
+      {:error, %{mssql: %{number: 1801}}} ->
         {:error, :already_up}
 
       {:error, error} ->
@@ -204,7 +204,7 @@ defmodule Ecto.Adapters.Tds do
       {:ok, _} ->
         :ok
 
-      {:error, %Tds.Error{mssql: %{number: 3701}}} ->
+      {:error, %{mssql: %{number: 3701}}} ->
         {:error, :already_down}
 
       {:error, error} ->


### PR DESCRIPTION
Otherwise, projects using ecto_sql won't compile without tds.
This is similar to how we do it on MyXQL.