### PR TITLE
Improve documentation for `references`

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1048,7 +1048,9 @@ defmodule Ecto.Migration do
   end
 
   @doc ~S"""
-  Defines a foreign key.
+  Defines a foreign key. If you are using a non-default key setup
+  (e.g. using `uuid` type keys) you must ensure you set the options to
+  match your target key.
 
   ## Examples
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1048,9 +1048,12 @@ defmodule Ecto.Migration do
   end
 
   @doc ~S"""
-  Defines a foreign key. If you are using a non-default key setup
-  (e.g. using `uuid` type keys) you must ensure you set the options to
-  match your target key.
+  Defines a foreign key.
+
+  By default it assumes you are linking to the referenced table
+  via its primary key with name `:id`. If you are using a non-default
+  key setup (e.g. using `uuid` type keys) you must ensure you set the
+  options, such as `:name` and `:type`, to match your target key.
 
   ## Examples
 


### PR DESCRIPTION
Expand the docs for references to highlight you must set the appropriate options to match your target key.

This stems from a chat in the #ecto channel on the Elixir slack, as its not explicitly stated that you need matching options to the key you are referencing, it gets overlooked and Ecto will (rightly) generate SQL errors that can be a bit cryptic to newcomers.

As this particular doc is a bit sparse, I propose expanding the note to talk more about it. I'm happy for content suggestions and direction tweaks here, I'd just like to improve it :)