### PR TITLE
Support multiple migration paths

### DIFF
--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -364,8 +364,8 @@ defmodule Ecto.Migrator do
   The second argument identifies where the migrations are sourced from.
   A list of binaries representing directories may be passed, in which case we will
   load all files following the "#{VERSION}_#{NAME}.exs" schema. The
-  `migration_source` may also be a list of a list of tuples that identify
-  the version number and migration modules to be run, for example:
+  `migration_source` may also be a list of tuples that identify the version
+  number and migration modules to be run, for example:
 
       Ecto.Migrator.run(Repo, [{0, MyApp.Migration1}, {1, MyApp.Migration2}, ...], :up, opts)
 
@@ -547,7 +547,8 @@ defmodule Ecto.Migrator do
   end
 
   defp migrations_for(migration_source) when is_list(migration_source) do
-    Enum.map(migration_source, fn
+    migration_source
+    |> Enum.flat_map(fn
       directory when is_binary(directory) ->
         Path.join([directory, "**", "*.exs"])
         |> Path.wildcard()
@@ -555,9 +556,8 @@ defmodule Ecto.Migrator do
         |> Enum.filter(& &1)
 
       {version, module} ->
-        {version, module, module}
+        [{version, module, module}]
     end)
-    |> List.flatten()
     |> Enum.sort()
   end
 

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -349,20 +349,20 @@ defmodule Ecto.Migrator do
 
   Equivalent to:
 
-      Ecto.Migrator.run(repo, Ecto.Migrator.migrations_path(repo), direction, opts)
+      Ecto.Migrator.run(repo, [Ecto.Migrator.migrations_path(repo)], direction, opts)
 
   See `run/4` for more information.
   """
   @spec run(Ecto.Repo.t, atom, Keyword.t) :: [integer]
   def run(repo, direction, opts) do
-    run(repo, migrations_path(repo), direction, opts)
+    run(repo, [migrations_path(repo)], direction, opts)
   end
 
   @doc ~S"""
   Apply migrations to a repository with a given strategy.
 
   The second argument identifies where the migrations are sourced from.
-  A binary representing a directory may be passed, in which case we will
+  A list of binaries representing directories may be passed, in which case we will
   load all files following the "#{VERSION}_#{NAME}.exs" schema. The
   `migration_source` may also be a list of a list of tuples that identify
   the version number and migration modules to be run, for example:
@@ -397,8 +397,10 @@ defmodule Ecto.Migrator do
       See `c:Ecto.Repo.put_dynamic_repo/1`.
 
   """
-  @spec run(Ecto.Repo.t, binary | [{integer, module}], atom, Keyword.t) :: [integer]
+  @spec run(Ecto.Repo.t, [String.t] | [{integer, module}], atom, Keyword.t) :: [integer]
   def run(repo, migration_source, direction, opts) do
+    migration_source = List.wrap(migration_source)
+
     pending =
       lock_for_migrations true, repo, opts, fn versions ->
         cond do
@@ -423,23 +425,25 @@ defmodule Ecto.Migrator do
 
   Equivalent to:
 
-      Ecto.Migrator.migrations(repo, Ecto.Migrator.migrations_path(repo))
+      Ecto.Migrator.migrations(repo, [Ecto.Migrator.migrations_path(repo)])
 
   """
   @spec migrations(Ecto.Repo.t) :: [{:up | :down, id :: integer(), name :: String.t}]
   def migrations(repo) do
-    migrations(repo, migrations_path(repo))
+    migrations(repo, [migrations_path(repo)])
   end
 
   @doc """
   Returns an array of tuples as the migration status of the given repo,
   without actually running any migrations.
   """
-  @spec migrations(Ecto.Repo.t, String.t) :: [{:up | :down, id :: integer(), name :: String.t}]
-  def migrations(repo, directory) do
+  @spec migrations(Ecto.Repo.t, [String.t]) :: [{:up | :down, id :: integer(), name :: String.t}]
+  def migrations(repo, directories) do
+    directories = List.wrap(directories)
+
     repo
     |> migrated_versions
-    |> collect_migrations(directory)
+    |> collect_migrations(directories)
     |> Enum.sort_by(fn {_, version, _} -> version end)
   end
 
@@ -542,18 +546,19 @@ defmodule Ecto.Migrator do
     |> Enum.reverse
   end
 
-  # This function will match directories passed into `Migrator.run`.
-  defp migrations_for(migration_source) when is_binary(migration_source) do
-    Path.join([migration_source, "**", "*.exs"])
-    |> Path.wildcard()
-    |> Enum.map(&extract_migration_info/1)
-    |> Enum.filter(& &1)
-    |> Enum.sort()
-  end
-
-  # This function will match specific version/modules passed into `Migrator.run`.
   defp migrations_for(migration_source) when is_list(migration_source) do
-    Enum.map migration_source, fn {version, module} -> {version, module, module} end
+    Enum.map(migration_source, fn
+      directory when is_binary(directory) ->
+        Path.join([directory, "**", "*.exs"])
+        |> Path.wildcard()
+        |> Enum.map(&extract_migration_info/1)
+        |> Enum.filter(& &1)
+
+      {version, module} ->
+        {version, module, module}
+    end)
+    |> List.flatten()
+    |> Enum.sort()
   end
 
   defp extract_migration_info(file) do

--- a/lib/mix/ecto_sql.ex
+++ b/lib/mix/ecto_sql.ex
@@ -2,17 +2,22 @@ defmodule Mix.EctoSQL do
   @moduledoc false
 
   @doc """
-  Ensures the given repository's migrations path exists on the file system.
+  Ensures the given repository's migrations paths exists on the file system.
   """
-  @spec ensure_migrations_path(Ecto.Repo.t, Keyword.t) :: String.t
-  def ensure_migrations_path(repo, opts) do
-    path = opts[:migrations_path] || Path.join(source_repo_priv(repo), "migrations")
+  @spec ensure_migrations_paths(Ecto.Repo.t, Keyword.t) :: String.t
+  def ensure_migrations_paths(repo, opts) do
+    paths = Keyword.get_values(opts, :migrations_path)
+    paths = if paths == [], do: [Path.join(source_repo_priv(repo), "migrations")], else: paths
 
-    if not Mix.Project.umbrella?() and not File.dir?(path) do
-      raise_missing_migrations(Path.relative_to_cwd(path), repo)
+    if not Mix.Project.umbrella?() do
+      for path <- paths do
+        if not File.dir?(path) do
+          raise_missing_migrations(Path.relative_to_cwd(path), repo)
+        end
+      end
     end
 
-    path
+    paths
   end
 
   defp raise_missing_migrations(path, repo) do

--- a/lib/mix/ecto_sql.ex
+++ b/lib/mix/ecto_sql.ex
@@ -10,10 +10,8 @@ defmodule Mix.EctoSQL do
     paths = if paths == [], do: [Path.join(source_repo_priv(repo), "migrations")], else: paths
 
     if not Mix.Project.umbrella?() do
-      for path <- paths do
-        if not File.dir?(path) do
-          raise_missing_migrations(Path.relative_to_cwd(path), repo)
-        end
+      for path <- paths, not File.dir?(path) do
+        raise_missing_migrations(Path.relative_to_cwd(path), repo)
       end
     end
 

--- a/lib/mix/tasks/ecto.migrations.ex
+++ b/lib/mix/tasks/ecto.migrations.ex
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.Ecto.Migrations do
     repo: [:keep, :string],
     no_compile: :boolean,
     no_deps_check: :boolean,
-    migrations_path: :string
+    migrations_path: :keep
   ]
 
   @moduledoc """
@@ -38,10 +38,18 @@ defmodule Mix.Tasks.Ecto.Migrations do
   ## Command line options
 
     * `-r`, `--repo` - the repo to obtain the status for
-    * `--no-compile` - does not compile applications before running
-    * `--no-deps-check` - does not check depedendencies before running
-    * `--migrations-path` - the path to run the migrations from
 
+    * `--no-compile` - does not compile applications before running
+
+    * `--no-deps-check` - does not check depedendencies before running
+
+    * `--migrations-path` - the path to run the migrations from, defaults to
+    `"priv/repo/migrations"`. This option may be given multiple times in which case the migrations
+    are loaded from all the given directories and sorted as if they were in the same one.
+
+      Note, if you have previously run migrations from e.g. paths `a/` and `b/`, and now run `mix
+      ecto.migrations --migrations-path a/` (omitting path `b/`), the migrations from the path
+      `b/` will be shown in the output as `** FILE NOT FOUND **`.
   """
 
   @impl true
@@ -51,9 +59,9 @@ defmodule Mix.Tasks.Ecto.Migrations do
 
     for repo <- repos do
       ensure_repo(repo, args)
-      path = ensure_migrations_path(repo, opts)
+      paths = ensure_migrations_paths(repo, opts)
 
-      case Ecto.Migrator.with_repo(repo, &migrations.(&1, path), [mode: :temporary]) do
+      case Ecto.Migrator.with_repo(repo, &migrations.(&1, paths), [mode: :temporary]) do
         {:ok, repo_status, _} ->
           puts.(
             """

--- a/test/mix/tasks/ecto.migrate_test.exs
+++ b/test/mix/tasks/ecto.migrate_test.exs
@@ -95,7 +95,7 @@ defmodule Mix.Tasks.Ecto.MigrateTest do
   end
 
   test "runs the migrator yielding the repository and migrations path" do
-    run ["-r", to_string(Repo), "--quiet", "--prefix", "foo"], fn repo, path, direction, opts ->
+    run ["-r", to_string(Repo), "--quiet", "--prefix", "foo"], fn repo, [path], direction, opts ->
       assert repo == Repo
       refute path =~ ~r/_build/
       assert direction == :up
@@ -108,7 +108,7 @@ defmodule Mix.Tasks.Ecto.MigrateTest do
   end
 
   test "runs the migrator with --step" do
-    run ["-r", to_string(Repo), "-n", "1"], fn repo, path, direction, opts ->
+    run ["-r", to_string(Repo), "-n", "1"], fn repo, [path], direction, opts ->
       assert repo == Repo
       refute path =~ ~r/_build/
       assert direction == :up
@@ -127,7 +127,12 @@ defmodule Mix.Tasks.Ecto.MigrateTest do
   end
 
   test "uses custom paths" do
-    run ["-r", to_string(Repo), "--migrations-path", "test/mix"],
-        fn Repo, "test/mix", _, _ -> [] end
+    path1 = Path.join([unquote(tmp_path()), inspect(Ecto.Migrate), "migrations_1"])
+    path2 = Path.join([unquote(tmp_path()), inspect(Ecto.Migrate), "migrations_2"])
+    File.mkdir_p!(path1)
+    File.mkdir_p!(path2)
+
+    run ["-r", to_string(Repo), "--migrations-path", path1, "--migrations-path", path2],
+        fn Repo, [^path1, ^path2], _, _ -> [] end
   end
 end

--- a/test/mix/tasks/ecto.migrations_test.exs
+++ b/test/mix/tasks/ecto.migrations_test.exs
@@ -89,7 +89,7 @@ defmodule Mix.Tasks.Ecto.MigrationsTest do
   test "does not run from _build" do
     Application.put_env(:ecto_sql, :ecto_repos, [Repo])
 
-    migrations = fn repo, path ->
+    migrations = fn repo, [path] ->
       assert repo == Repo
       refute path =~ ~r/_build/
       []
@@ -98,9 +98,14 @@ defmodule Mix.Tasks.Ecto.MigrationsTest do
     run [], migrations, fn _ -> :ok end
   end
 
-  test "uses custom path" do
-    run ["-r", to_string(Repo), "--migrations-path", "test/ecto"],
-        fn Repo, "test/ecto" -> [] end,
+  test "uses custom paths" do
+    path1 = Path.join([unquote(tmp_path()), inspect(Ecto.Migrate), "migrations_1"])
+    path2 = Path.join([unquote(tmp_path()), inspect(Ecto.Migrate), "migrations_2"])
+    File.mkdir_p!(path1)
+    File.mkdir_p!(path2)
+
+    run ["-r", to_string(Repo), "--migrations-path", path1, "--migrations-path", path2],
+        fn Repo, [^path1, ^path2] -> [] end,
         fn _ -> :ok end
   end
 end

--- a/test/mix/tasks/ecto.rollback_test.exs
+++ b/test/mix/tasks/ecto.rollback_test.exs
@@ -71,7 +71,7 @@ defmodule Mix.Tasks.Ecto.RollbackTest do
   end
 
   test "runs the migrator yielding the repository and migrations path" do
-    run ["-r", to_string(Repo), "--prefix", "foo"], fn repo, path, direction, opts ->
+    run ["-r", to_string(Repo), "--prefix", "foo"], fn repo, [path], direction, opts ->
       assert repo == Repo
       refute path =~ ~r/_build/
       assert direction == :down
@@ -91,7 +91,12 @@ defmodule Mix.Tasks.Ecto.RollbackTest do
   end
 
   test "uses custom paths" do
-    run ["-r", to_string(Repo), "--migrations-path", "test/mix"],
-        fn Repo, "test/mix", _, _ -> [] end
+    path1 = Path.join([unquote(tmp_path()), inspect(Ecto.Migrate), "migrations_1"])
+    path2 = Path.join([unquote(tmp_path()), inspect(Ecto.Migrate), "migrations_2"])
+    File.mkdir_p!(path1)
+    File.mkdir_p!(path2)
+
+    run ["-r", to_string(Repo), "--migrations-path", path1, "--migrations-path", path2],
+        fn Repo, [^path1, ^path2], _, _ -> [] end
   end
 end


### PR DESCRIPTION
In the Mix tasks, the `--migrations-path` option may now be given
multiple times.

In `Ecto.Migrator`, passing a single migration path is now
soft-deprecated (no warning emitted) in favour of passing a list of
paths.

Having multiple migrations paths is useful when you want to split up
your migrations into multiple groups and run some of or all of the
groups in different circumstances. This way, we have additional
flexibility but we also take advantage of underlying Ecto migration
features like that a given migration will only be run once, there's a
database lock on the migrations table, etc.

For example, you may want to split your migrations into two groups:

  1. DDL migrations in `priv/repo/migrations`
  2. data migrations into `priv/repo/data_migrations` (e.g. moving data
     from one table to another which can be very slow)

And then in production you'd automatically run just the DDL migrations,
since the default migration path is `priv/repo/migrations`. However, in
development (and test, CI, etc) you may want to always run them all and
you can do that for example with Mix aliases:

    defp aliases() do
      migration_args =
        "--migrations-path priv/repo/migrations " <>
          "--migrations-path priv/repo/data_migrations"

      [
        "ecto.migrate": "ecto.migrate #{migration_args}",
        "ecto.migrations": "ecto.migrations #{migration_args}",
        "ecto.rollback": "ecto.rollback #{migration_args}",
      ]
    end

When using migrations from multiple sources they're running in an order
as if they all were in the same directory.