### PR TITLE
Use one line per migration in the schema dump

### DIFF
--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -290,9 +290,7 @@ defmodule Ecto.Adapters.MyXQL do
   defp append_versions(table, versions, contents) do
     {:ok,
       contents <>
-      ~s[INSERT INTO `#{table}` (version) VALUES ] <>
-      Enum.map_join(versions, ", ", &"(#{&1})") <>
-      ~s[;\n\n]}
+      Enum.map_join(versions, &~s[INSERT INTO `#{table}` (version) VALUES (#{&1});\n])}
   end
 
   @impl true

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -222,9 +222,7 @@ defmodule Ecto.Adapters.Postgres do
   end
 
   defp append_versions(table, versions, path) do
-    sql =
-      ~s[INSERT INTO public."#{table}" (version) VALUES ] <>
-        Enum.map_join(versions, ", ", &"(#{&1})") <> ~s[;\n\n]
+    sql = Enum.map_join(versions, &~s[INSERT INTO public."#{table}" (version) VALUES (#{&1});\n])
 
     File.open!(path, [:append], fn file ->
       IO.write(file, sql)


### PR DESCRIPTION
Our team is forever getting merge conflicts on the single line that inserts migrations in a schema dump. If they're each on their own line, conflicts can be resolved more easily by simply taking every line.