### PR TITLE
decode BIT columns when using MyXQL and :boolean type

### DIFF
--- a/integration_test/myxql/myxql_type_test.exs
+++ b/integration_test/myxql/myxql_type_test.exs
@@ -1,0 +1,20 @@
+defmodule Ecto.Integration.MyXQLTypeTest do
+  use ExUnit.Case, async: true
+
+  import Ecto.Type
+  alias Ecto.Adapters.MyXQL
+
+  test "evaluates MyXQL boolean bit values" do
+    assert adapter_load(MyXQL, :boolean, <<1>>) ==
+             {:ok, true}
+
+    assert adapter_load(MyXQL, :boolean, <<1::size(1)>>) ==
+             {:ok, true}
+
+    assert adapter_load(MyXQL, :boolean, <<0>>) ==
+             {:ok, false}
+
+    assert adapter_load(MyXQL, :boolean, <<0::size(1)>>) ==
+             {:ok, false}
+  end
+end

--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -141,7 +141,9 @@ defmodule Ecto.Adapters.MyXQL do
   def loaders(_, type),           do: [type]
 
   defp bool_decode(<<0>>), do: {:ok, false}
+  defp bool_decode(<<0::size(1)>>), do: {:ok, false}
   defp bool_decode(<<1>>), do: {:ok, true}
+  defp bool_decode(<<1::size(1)>>), do: {:ok, true}
   defp bool_decode(0), do: {:ok, false}
   defp bool_decode(1), do: {:ok, true}
   defp bool_decode(x), do: {:ok, x}


### PR DESCRIPTION
According to MyXQL [documentation](https://hexdocs.pm/myxql/readme.html#data-representation),  `BIT()` columns are represented as `<<1::size(1)>>` or `<<0::size(1)>>`