### PR TITLE
Fix opts in sql_call

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -340,7 +340,7 @@ defmodule Ecto.Adapters.SQL do
   defp sql_call(adapter_meta, callback, args, params, opts) do
     %{pid: pool, telemetry: telemetry, sql: sql, opts: default_opts} = adapter_meta
     conn = get_conn_or_pool(pool)
-    opts = with_log(telemetry, params, opts ++ default_opts)
+    opts = with_log(telemetry, params, Keyword.merge(default_opts, opts))
     args = args ++ [params, opts]
     apply(sql, callback, [conn | args])
   end


### PR DESCRIPTION
With the current code if you pass `timeout: 1` to `opts`, the callback will actually receive `[timeout: 1, timeout: 15000]` because it's adding the new opts to the default opts, but I suppose it should receive just a single `timeout`. Is that expected or a bug?