### PR TITLE
Make sure formatter doesn't run.

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -25,5 +25,6 @@ locals_without_parens = [
   locals_without_parens: locals_without_parens,
   export: [
     locals_without_parens: locals_without_parens
-  ]
+  ],
+  inputs: []
 ]


### PR DESCRIPTION
Necessary since right now it gives the impression the code is formatted, which isn't true. 
This makes it possible to at least cancel it out until it's up to date. 

Related: https://github.com/elixir-ecto/ecto_sql/issues/235