### PR TITLE
Change logged message: "Already up" -> "Migrations already up"

### DIFF
--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -610,7 +610,7 @@ defmodule Ecto.Migrator do
 
   defp migrate([], direction, _repo, opts) do
     level = Keyword.get(opts, :log, :info)
-    log(level, "Already #{direction}")
+    log(level, "Migrations already #{direction}")
     []
   end
 


### PR DESCRIPTION
And "Already down" -> "Migrations already down"

This output can be shown as part of a deploy without any further context making it clear that it's related to migrations.

For example, I just set up CI to deploy to Heroku and saw output like

```
remote: Verifying deploy... done.        
remote: Running release command...
remote: 
remote: 
remote: 17:40:12.828 [info]  Already up        
To https://git.heroku.com/foobar.git
```

I initially assumed the deploy had failed to run migrations, because nothing about the output made it clear.

"Migrations already up" and "Migrations already down" aren't super clear as far as messages go, but I wasn't sure what would be better, especially for the "down" case. This is IMO better than the current message, at least.

I made a companion PR to Phoenix docs where they reference this message: https://github.com/phoenixframework/phoenix/pull/3919