### PR TITLE
Add recommended Elixir x Erlang/OTP combinations to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
 
     strategy:
       matrix:
-        pg_version: ["9.4", "9.6", "11"]
+        pg_version: ["9.5", "9.6", "11"]
 
     steps:
       - name: Install PG Client

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,6 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
-    container: hexpm/elixir:1.10.4-erlang-23.0.3-ubuntu-bionic-20200630
-
     strategy:
       fail-fast: false
       matrix:
@@ -66,6 +64,11 @@ jobs:
           mysql --version
           mysql -e "SET GLOBAL net_write_timeout=30; SET GLOBAL max_allowed_packet=1024*1024*1024;"
       - uses: actions/checkout@v2.3.1
+      - name: Setup elixir
+        uses: actions/setup-elixir@v1.3.0
+        with:
+          otp-version: 23.0.3
+          elixir-version: 1.10.4
       - name: Install Dependencies
         run: |
           apt-get install -y git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           apt-get update
           apt-get install --allow-unauthenticated -y mysql-client
           mysql --version
-          mysql -e "SET GLOBAL net_write_timeout=30; SET GLOBAL max_allowed_packet=1024*1024*1024;"
+          mysql --user=root --password=root -e "SET GLOBAL net_write_timeout=30; SET GLOBAL max_allowed_packet=1024*1024*1024;"
       - uses: actions/checkout@v2.3.1
       - name: Install Dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,15 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
-    container: elixir:1.9-slim
+    container: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.otp }}-ubuntu-bionic-${{ matrix.bionic_version }}
 
     strategy:
       fail-fast: false
       matrix:
         mysql_version: ["5.7", "8.0"]
+        elixir: [1.10.4]
+        otp: [23.0.3]
+        bionic_version: [20200630]
 
     steps:
       - name: Install MySQL Client
@@ -75,6 +78,7 @@ jobs:
   
   test-mssql:
     runs-on: ubuntu-latest
+    container: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.otp }}-ubuntu-bionic-${{ matrix.bionic_version }}
 
     services:
       mssql:
@@ -89,8 +93,9 @@ jobs:
       fail-fast: false
       matrix:
         mssql_version: ["2017-latest", "2019-latest"]
-        otp: [23.0.3]
         elixir: [1.10.4]
+        otp: [23.0.3]
+        bionic_version: [20200630]
         
     env:
       ACCEPT_EULA: Y
@@ -103,11 +108,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y mssql-tools unixodbc-dev
       - uses: actions/checkout@v2.3.1
-      - name: Setup elixir
-        uses: actions/setup-elixir@v1.3.0
-        with:
-          otp-version: ${{matrix.otp}}
-          elixir-version: ${{matrix.elixir}}
       - name: Install Dependencies
         run: mix deps.get
       - run: |
@@ -126,12 +126,15 @@ jobs:
           POSTGRES_DB: postgres
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
-    container: elixir:1.9-slim
+    container: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.otp }}-ubuntu-bionic-${{ matrix.bionic_version }}
 
     strategy:
       fail-fast: false
       matrix:
         pg_version: ["9.5", "9.6", "11"]
+        elixir: [1.10.4]
+        otp: [23.0.3]
+        bionic_version: [20200630]
 
     steps:
       - name: Install PG Client

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,21 @@ on: [push, pull_request]
 jobs:
   test-elixir:
     runs-on: ubuntu-18.04
-    container: elixir:${{ matrix.elixir_version }}-slim
+    container: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.otp }}-ubuntu-bionic-20200403
 
     strategy:
       matrix:
-        elixir_version: [1.7, 1.9]
+        include:
+          - elixir: 1.7.4
+            otp: 19.3.6.13
+          - elixir: 1.8.2
+            otp: 20.3.8.26
+          - elixir: 1.9.4
+            otp: 20.3.8.26
+          - elixir: 1.10.3
+            otp: 21.3.8.16
+          - elixir: 1.10.3
+            otp: 23.0.2
 
     steps:
       - uses: actions/checkout@v2.3.1
@@ -31,7 +41,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
-    container: elixir:1.9-slim
+    container: hexpm/elixir:1.10.3-erlang-23.0.2-ubuntu-bionic-20200403
 
     strategy:
       matrix:
@@ -71,8 +81,8 @@ jobs:
     strategy:
       matrix:
         mssql_version: ["2017-latest", "2019-latest"]
-        otp: [22.1.7]
-        elixir: [1.9.4]
+        otp: [23.0.2]
+        elixir: [1.10.3]
         
     env:
       ACCEPT_EULA: Y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           apt-get update
           apt-get install --allow-unauthenticated -y mysql-client
           mysql --version
-          mysql --user=root --password=root --host=mysql -e "SET GLOBAL net_write_timeout=30; SET GLOBAL max_allowed_packet=1024*1024*1024;"
+          mysql --user=root --password=root --host=mysql -e "SET GLOBAL net_read_timeout=28800; SET GLOBAL net_write_timeout=28800; SET GLOBAL max_allowed_packet=1024*1024*1024; SET GLOBAL wait_timeout = 28800; SET GLOBAL interactive_timeout = 28800"
       - uses: actions/checkout@v2.3.1
       - name: Install Dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
     container: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.otp }}-ubuntu-bionic-20200403
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - elixir: 1.7.4
@@ -44,6 +45,7 @@ jobs:
     container: hexpm/elixir:1.10.3-erlang-23.0.2-ubuntu-bionic-20200403
 
     strategy:
+      fail-fast: false
       matrix:
         mysql_version: ["5.7", "8.0"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,6 @@ jobs:
         run: |
           apt-get update
           apt-get install -y wget ca-certificates gnupg
-          mkdir ~/.gnupg
-          echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf
           apt-key adv --recv-keys --keyserver keys.gnupg.net 8C718D3B5072E1F5
           echo "deb http://repo.mysql.com/apt/debian/ stretch mysql-${{ matrix.mysql_version }}" >> /etc/apt/sources.list.d/mysql.list
           apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
-    container: hexpm/elixir:1.10.4-erlang-23.0.3-ubuntu-bionic-20200630
+    container: elixir:1.9-slim
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,12 @@ jobs:
     steps:
       - name: Install MsSql Client Tools
         run: |
-          sudo apt-get update
-          sudo apt-get install -y mssql-tools unixodbc-dev
+          apt-get update
+          apt-get install -y curl gnupg
+          curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+          curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | tee /etc/apt/sources.list.d/msprod.list
+          apt-get update
+          apt-get install -y mssql-tools unixodbc-dev
       - uses: actions/checkout@v2.3.1
       - name: Install Dependencies
         run: mix deps.get

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
           - 1433:1433
 
     strategy:
+      fail-fast: false
       matrix:
         mssql_version: ["2017-latest", "2019-latest"]
         otp: [23.0.3]
@@ -130,6 +131,7 @@ jobs:
     container: elixir:1.9-slim
 
     strategy:
+      fail-fast: false
       matrix:
         pg_version: ["9.5", "9.6", "11"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
         run: |
           apt-get update
           apt-get install -y wget ca-certificates gnupg
+          mkdir ~/.gnupg
+          echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf
           apt-key adv --recv-keys --keyserver keys.gnupg.net 8C718D3B5072E1F5
           echo "deb http://repo.mysql.com/apt/debian/ stretch mysql-${{ matrix.mysql_version }}" >> /etc/apt/sources.list.d/mysql.list
           apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
           apt-get update
           apt-get install --allow-unauthenticated -y mysql-client
           mysql --version
+          mysql -e "SET GLOBAL net_write_timeout=30; SET GLOBAL max_allowed_packet=1024*1024*1024;"
       - uses: actions/checkout@v2.3.1
       - name: Install Dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,11 @@ jobs:
           apt-get install -y mssql-tools unixodbc-dev
       - uses: actions/checkout@v2.3.1
       - name: Install Dependencies
-        run: mix deps.get
+        run: |
+          apt-get install -y git
+          mix local.rebar --force
+          mix local.hex --force
+          mix deps.get
       - run: |
           export PATH="/opt/mssql-tools/bin:$PATH"
           ECTO_ADAPTER=tds mix test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
+    container: hexpm/elixir:1.10.4-erlang-23.0.3-ubuntu-bionic-20200630
+
     strategy:
       fail-fast: false
       matrix:
@@ -64,11 +66,6 @@ jobs:
           mysql --version
           mysql -e "SET GLOBAL net_write_timeout=30; SET GLOBAL max_allowed_packet=1024*1024*1024;"
       - uses: actions/checkout@v2.3.1
-      - name: Setup elixir
-        uses: actions/setup-elixir@v1.3.0
-        with:
-          otp-version: 23.0.3
-          elixir-version: 1.10.4
       - name: Install Dependencies
         run: |
           apt-get install -y git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,6 @@ jobs:
           apt-get update
           apt-get install --allow-unauthenticated -y mysql-client
           mysql --version
-          mysql --user=root --password=root --host=mysql -e "SET GLOBAL net_read_timeout=28800; SET GLOBAL net_write_timeout=28800; SET GLOBAL max_allowed_packet=1024*1024*1024; SET GLOBAL wait_timeout = 28800; SET GLOBAL interactive_timeout = 28800"
       - uses: actions/checkout@v2.3.1
       - name: Install Dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: [push, pull_request]
 jobs:
   test-elixir:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.otp }}-ubuntu-bionic-${{ matrix.bionic_version }}
 
     strategy:
@@ -38,7 +38,7 @@ jobs:
       - run: mix test.as_a_dep
 
   test-mysql:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     services:
       mysql:
@@ -117,7 +117,7 @@ jobs:
           ECTO_ADAPTER=tds mix test
           
   test-pg:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     services:
       pg:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,9 @@ jobs:
         otp: [23.0.3]
         bionic_version: [20200630]
 
+    env:
+      DEBIAN_FRONTEND: noninteractive
+
     steps:
       - name: Install PG Client
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,9 +144,9 @@ jobs:
       - name: Install PG Client
         run: |
           apt-get update
-          apt-get install -y wget ca-certificates gnupg
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-          echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main ${{ matrix.pg_version }}" >> /etc/apt/sources.list.d/pgdg.list
+          apt-get install -y curl gnupg
+          curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+          echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main ${{ matrix.pg_version }}" >> /etc/apt/sources.list.d/pgdg.list
           apt-get update
           apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-contrib-${{ matrix.pg_version }}
           psql --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,12 @@ jobs:
   
   test-mssql:
     runs-on: ubuntu-latest
-    container: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.otp }}-ubuntu-bionic-${{ matrix.bionic_version }}
+    container:
+      image: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.otp }}-ubuntu-bionic-${{ matrix.bionic_version }}
+      env:
+        ACCEPT_EULA: Y
+        MIX_ENV: test
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
 
     services:
       mssql:
@@ -97,11 +102,6 @@ jobs:
         otp: [23.0.3]
         bionic_version: [20200630]
         
-    env:
-      ACCEPT_EULA: Y
-      MIX_ENV: test
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     steps:
       - name: Install MsSql Client Tools
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         elixir_version: [1.7, 1.9]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2.3.1
       - name: Install Dependencies
         run: |
           apt-get update
@@ -47,7 +47,7 @@ jobs:
           apt-get update
           apt-get install --allow-unauthenticated -y mysql-client
           mysql --version
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2.3.1
       - name: Install Dependencies
         run: |
           apt-get install -y git
@@ -84,9 +84,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y mssql-tools unixodbc-dev
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.1
       - name: Setup elixir
-        uses: actions/setup-elixir@v1
+        uses: actions/setup-elixir@v1.3.0
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
@@ -124,7 +124,7 @@ jobs:
           apt-get update
           apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-contrib-${{ matrix.pg_version }}
           psql --version
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2.3.1
       - name: Install Dependencies
         run: |
           apt-get install -y git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,10 @@ jobs:
           POSTGRES_DB: postgres
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
-    container: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.otp }}-ubuntu-bionic-${{ matrix.bionic_version }}
+    container:
+      image: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.otp }}-ubuntu-bionic-${{ matrix.bionic_version }}
+      env:
+        DEBIAN_FRONTEND: noninteractive
 
     strategy:
       fail-fast: false
@@ -143,9 +146,6 @@ jobs:
         elixir: [1.10.4]
         otp: [23.0.3]
         bionic_version: [20200630]
-
-    env:
-      DEBIAN_FRONTEND: noninteractive
 
     steps:
       - name: Install PG Client

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
             otp: 20.3.8.26
           - elixir: 1.9.4
             otp: 20.3.8.26
-          - elixir: 1.10.3
+          - elixir: 1.10.4
             otp: 21.3.8.16
-          - elixir: 1.10.3
+          - elixir: 1.10.4
             otp: 23.0.2
 
     steps:
@@ -42,7 +42,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
-    container: hexpm/elixir:1.10.3-erlang-23.0.2-ubuntu-bionic-20200403
+    container: hexpm/elixir:1.10.4-erlang-23.0.2-ubuntu-bionic-20200403
 
     strategy:
       fail-fast: false
@@ -86,7 +86,7 @@ jobs:
       matrix:
         mssql_version: ["2017-latest", "2019-latest"]
         otp: [23.0.2]
-        elixir: [1.10.3]
+        elixir: [1.10.4]
         
     env:
       ACCEPT_EULA: Y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           apt-get update
           apt-get install --allow-unauthenticated -y mysql-client
           mysql --version
-          mysql --user=root --password=root -e "SET GLOBAL net_write_timeout=30; SET GLOBAL max_allowed_packet=1024*1024*1024;"
+          mysql --user=root --password=root --host=mysql -e "SET GLOBAL net_write_timeout=30; SET GLOBAL max_allowed_packet=1024*1024*1024;"
       - uses: actions/checkout@v2.3.1
       - name: Install Dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           mkdir ~/.gnupg
           echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf
           apt-key adv --recv-keys --keyserver keys.gnupg.net 8C718D3B5072E1F5
-          echo "deb http://repo.mysql.com/apt/debian/ stretch mysql-${3 matrix.mysql_version }}" >> /etc/apt/sources.list.d/mysql.list
+          echo "deb http://repo.mysql.com/apt/debian/ stretch mysql-${{ matrix.mysql_version }}" >> /etc/apt/sources.list.d/mysql.list
           apt-get update
           apt-get install --allow-unauthenticated -y mysql-client
           mysql --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   test-elixir:
     runs-on: ubuntu-18.04
-    container: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.otp }}-ubuntu-bionic-20200403
+    container: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.otp }}-ubuntu-bionic-${{ matrix.bionic_version }}
 
     strategy:
       fail-fast: false
@@ -11,14 +11,19 @@ jobs:
         include:
           - elixir: 1.7.4
             otp: 19.3.6.13
+            bionic_version: 20200403
           - elixir: 1.8.2
             otp: 20.3.8.26
+            bionic_version: 20200403
           - elixir: 1.9.4
             otp: 20.3.8.26
+            bionic_version: 20200403
           - elixir: 1.10.4
-            otp: 21.3.8.16
+            otp: 21.3.8.17
+            bionic_version: 20200630
           - elixir: 1.10.4
-            otp: 23.0.2
+            otp: 23.0.3
+            bionic_version: 20200630
 
     steps:
       - uses: actions/checkout@v2.3.1
@@ -42,7 +47,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
-    container: hexpm/elixir:1.10.4-erlang-23.0.2-ubuntu-bionic-20200403
+    container: hexpm/elixir:1.10.4-erlang-23.0.3-ubuntu-bionic-20200630
 
     strategy:
       fail-fast: false
@@ -57,7 +62,7 @@ jobs:
           mkdir ~/.gnupg
           echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf
           apt-key adv --recv-keys --keyserver keys.gnupg.net 8C718D3B5072E1F5
-          echo "deb http://repo.mysql.com/apt/debian/ stretch mysql-${{ matrix.mysql_version }}" >> /etc/apt/sources.list.d/mysql.list
+          echo "deb http://repo.mysql.com/apt/debian/ stretch mysql-${3 matrix.mysql_version }}" >> /etc/apt/sources.list.d/mysql.list
           apt-get update
           apt-get install --allow-unauthenticated -y mysql-client
           mysql --version
@@ -85,7 +90,7 @@ jobs:
     strategy:
       matrix:
         mssql_version: ["2017-latest", "2019-latest"]
-        otp: [23.0.2]
+        otp: [23.0.3]
         elixir: [1.10.4]
         
     env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM hexpm/elixir:1.10.4-erlang-23.0.3-ubuntu-bionic-20200630
+
+# RUN apt-get update
+# RUN apt-get install -y curl gnupg
+# RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+# RUN curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | tee /etc/apt/sources.list.d/msprod.list
+# RUN apt-get update
+# ENV ACCEPT_EULA Y
+# RUN apt-get install -y mssql-tools unixodbc-dev
+
+RUN apt-get update
+RUN apt-get install -y curl gnupg
+RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main 9.5" >> /etc/apt/sources.list.d/pgdg.list
+RUN apt-get update
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get install -y postgresql-9.5 postgresql-contrib-9.5
+RUN psql --version

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -1,5 +1,5 @@
 defmodule Ecto.Adapters.MyXQLTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   import Ecto.Query
 

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -1,5 +1,5 @@
 defmodule Ecto.Adapters.MyXQLTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   import Ecto.Query
 


### PR DESCRIPTION
Quoting @josevalim:
> I would still advise folks to go with:
> * For each Elixir version, add a run with earliest supported Erlang/OTP
> * For the last Elixir version, also test the latest supported Erlang/OTP

Please refer to the original discussion on https://github.com/dashbitco/broadway/pull/188 for the full rationale.

Please refer to [Yet another Elixir and Erlang docker image - Chat / Discussions - Elixir Forum](https://elixirforum.com/t/yet-another-elixir-and-erlang-docker-image/28740) for the rationale behing Elixir images by [Hexpm's Bob](https://github.com/hexpm/bob#docker-images).