### PR TITLE
Allow directly specifying string types for the postgresql adapter.

### DIFF
--- a/lib/ecto/adapter/migration.ex
+++ b/lib/ecto/adapter/migration.ex
@@ -25,12 +25,12 @@ defmodule Ecto.Adapter.Migration do
 
   @typedoc "All commands allowed within the block passed to `table/2`"
   @type table_subcommand ::
-          {:add, field :: atom, type :: Ecto.Type.t() | Reference.t(), Keyword.t()}
-          | {:add_if_not_exists, field :: atom, type :: Ecto.Type.t() | Reference.t(), Keyword.t()}
-          | {:modify, field :: atom, type :: Ecto.Type.t() | Reference.t(), Keyword.t()}
-          | {:remove, field :: atom, type :: Ecto.Type.t() | Reference.t(), Keyword.t()}
+          {:add, field :: atom, type :: Ecto.Type.t() | Reference.t() | binary(), Keyword.t()}
+          | {:add_if_not_exists, field :: atom, type :: Ecto.Type.t() | Reference.t() | binary(), Keyword.t()}
+          | {:modify, field :: atom, type :: Ecto.Type.t() | Reference.t() | binary(), Keyword.t()}
+          | {:remove, field :: atom, type :: Ecto.Type.t() | Reference.t() | binary(), Keyword.t()}
           | {:remove, field :: atom}
-          | {:remove_if_exists, type :: Ecto.Type.t() | Reference.t()}
+          | {:remove_if_exists, type :: Ecto.Type.t() | Reference.t() | binary()}
 
   @typedoc """
   A struct that represents a table or index in a database schema.

--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -1093,7 +1093,13 @@ if Code.ensure_loaded?(MyXQL) do
     defp ecto_to_db(:utc_datetime_usec, _query),   do: "datetime"
     defp ecto_to_db(:naive_datetime, _query),      do: "datetime"
     defp ecto_to_db(:naive_datetime_usec, _query), do: "datetime"
-    defp ecto_to_db(other, _query),                do: Atom.to_string(other)
+    defp ecto_to_db(atom, _query) when is_atom(atom),  do: Atom.to_string(atom)
+    defp ecto_to_db(str, _query)  when is_binary(str), do: str
+    defp ecto_to_db(type, _query) do
+      raise ArgumentError,
+            "unsupported type `#{inspect(type)}`. The type can either be an atom, a string " <>
+              "or a tuple of the form `{:map, t}` where `t` itself follows the same conditions."
+    end
 
     defp error!(nil, message) do
       raise ArgumentError, message

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -1251,7 +1251,13 @@ if Code.ensure_loaded?(Postgrex) do
     defp ecto_to_db(:utc_datetime_usec),   do: "timestamp"
     defp ecto_to_db(:naive_datetime),      do: "timestamp"
     defp ecto_to_db(:naive_datetime_usec), do: "timestamp"
-    defp ecto_to_db(other),                do: Atom.to_string(other)
+    defp ecto_to_db(atom) when is_atom(atom),  do: Atom.to_string(atom)
+    defp ecto_to_db(str)  when is_binary(str), do: str
+    defp ecto_to_db(type) do
+      raise ArgumentError,
+            "unsupported type `#{inspect(type)}`. The type can either be an atom, a string " <>
+              "or a tuple of the form `{:map, t}` or `{:array, t}` where `t` itself follows the same conditions."
+    end
 
     defp error!(nil, message) do
       raise ArgumentError, message

--- a/lib/ecto/adapters/tds/connection.ex
+++ b/lib/ecto/adapters/tds/connection.ex
@@ -1555,9 +1555,18 @@ if Code.ensure_loaded?(Tds) do
       "#{Atom.to_string(other)}(#{precision},#{scale || 0})"
     end
 
-    defp ecto_to_db(other, nil, nil, nil, _) do
-      Atom.to_string(other)
+    defp ecto_to_db(atom, nil, nil, nil, _) when is_atom(atom) do
+      Atom.to_string(atom)
     end
+
+    defp ecto_to_db(str, nil, nil, nil, _)  when is_binary(str), do: str
+
+    defp ecto_to_db(type, _, _, _, _) do
+      raise ArgumentError,
+            "unsupported type `#{inspect(type)}`. The type can either be an atom, a string " <>
+              "or a tuple of the form `{:map, t}` where `t` itself follows the same conditions."
+    end
+
 
     defp error!(nil, message) do
       raise ArgumentError, message

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -1008,8 +1008,8 @@ defmodule Ecto.Adapters.MyXQLTest do
                 {:add, :token, :binary, [size: 20, null: false]},
                 {:add, :price, :numeric, [precision: 8, scale: 2, default: {:fragment, "expr"}]},
                 {:add, :on_hand, :integer, [default: 0, null: true]},
-                {:add, :likes, :"smallint unsigned", [default: 0, null: false]},
-                {:add, :published_at, :"datetime(6)", [null: true]},
+                {:add, :likes, "smallint unsigned", [default: 0, null: false]},
+                {:add, :published_at, "datetime(6)", [null: true]},
                 {:add, :is_active, :boolean, [default: true]}]}
 
     assert execute_ddl(create) == ["""
@@ -1191,6 +1191,19 @@ defmodule Ecto.Adapters.MyXQLTest do
     `submitted_at` datetime(6))
     ENGINE = INNODB
     """ |> remove_newlines]
+  end
+
+  test "create table with an unsupported type" do
+    create = {:create, table(:posts),
+              [
+                {:add, :a, {:a, :b, :c}, [default: %{}]}
+              ]
+            }
+    assert_raise ArgumentError,
+                 "unsupported type `{:a, :b, :c}`. " <>
+                 "The type can either be an atom, a string or a tuple of the form " <>
+                 "`{:map, t}` where `t` itself follows the same conditions.",
+                 fn -> execute_ddl(create) end
   end
 
   test "drop table" do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1179,7 +1179,7 @@ defmodule Ecto.Adapters.PostgresTest do
               [{:add, :name, :string, [default: "Untitled", size: 20, null: false]},
                {:add, :price, :numeric, [precision: 8, scale: 2, default: {:fragment, "expr"}]},
                {:add, :on_hand, :integer, [default: 0, null: true]},
-               {:add, :published_at, :"time without time zone", [null: true]},
+               {:add, :published_at, "time without time zone", [null: true]},
                {:add, :is_active, :boolean, [default: true]},
                {:add, :tags, {:array, :string}, [default: []]},
                {:add, :languages, {:array, :string}, [default: ["pt", "es"]]},
@@ -1419,6 +1419,19 @@ defmodule Ecto.Adapters.PostgresTest do
                {:add, :submitted_at, :naive_datetime_usec, []}]}
 
     assert execute_ddl(create) == [~s|CREATE TABLE "posts" ("published_at" timestamp(3), "submitted_at" timestamp)|]
+  end
+
+  test "create table with an unsupported type" do
+    create = {:create, table(:posts),
+              [
+                {:add, :a, {:a, :b, :c}, [default: %{}]}
+              ]
+            }
+    assert_raise ArgumentError,
+                 "unsupported type `{:a, :b, :c}`. " <>
+                 "The type can either be an atom, a string or a tuple of the form " <>
+                 "`{:map, t}` or `{:array, t}` where `t` itself follows the same conditions.",
+                 fn -> execute_ddl(create) end
   end
 
   test "drop table" do

--- a/test/ecto/adapters/tds_test.exs
+++ b/test/ecto/adapters/tds_test.exs
@@ -1017,8 +1017,8 @@ defmodule Ecto.Adapters.TdsTest do
          {:add, :name, :string, [default: "Untitled", size: 20, null: false]},
          {:add, :price, :numeric, [precision: 8, scale: 2, default: {:fragment, "expr"}]},
          {:add, :on_hand, :integer, [default: 0, null: true]},
-         {:add, :likes, :"smallint unsigned", [default: 0, null: false]},
-         {:add, :published_at, :"datetime(6)", [null: true]},
+         {:add, :likes, "smallint unsigned", [default: 0, null: false]},
+         {:add, :published_at, "datetime(6)", [null: true]},
          {:add, :is_active, :boolean, [default: true]}
        ]}
 
@@ -1139,6 +1139,19 @@ defmodule Ecto.Adapters.TdsTest do
              [
                "CREATE TABLE [blobs] ([blob] varbinary(16) CONSTRAINT [DF__blobs_blob] DEFAULT (N'\\x666F6F')); "
              ]
+  end
+
+  test "create table with an unsupported type" do
+    create = {:create, table(:posts),
+              [
+                {:add, :a, {:a, :b, :c}, [default: %{}]}
+              ]
+            }
+    assert_raise ArgumentError,
+                 "unsupported type `{:a, :b, :c}`. " <>
+                 "The type can either be an atom, a string or a tuple of the form " <>
+                 "`{:map, t}` where `t` itself follows the same conditions.",
+                 fn -> execute_ddl(create) end
   end
 
   test "drop table" do


### PR DESCRIPTION
Fix #251.

I modified an existing test to use a string type instead of an atom.

I also added a bit more verbose error message for unsupported types with a test for it. If you think it's too much, I can remove it.
