### PR TITLE
Use SQL IF NOT EXIST when creating index with create_if_not_exists [Postgres]

### DIFF
--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1621,15 +1621,6 @@ defmodule Ecto.Adapters.PostgresTest do
       [~s|CREATE UNIQUE INDEX CONCURRENTLY "posts_permalink_index" ON "posts" ("permalink")|]
   end
 
-  test "create index if not exists concurrently" do
-    index = index(:posts, [:permalink])
-    create = {:create_if_not_exists, %{index | concurrently: true}}
-
-    assert_raise ArgumentError,
-                 "concurrent index and create_if_not_exists is not supported by the Postgres adapter",
-                 fn -> execute_ddl(create) end
-  end
-
   test "create an index using a different type" do
     create = {:create, index(:posts, [:permalink], using: :hash)}
     assert execute_ddl(create) ==


### PR DESCRIPTION
As discussed with @josevalim , I have aligned our way of dealing with this with how we are already handling this with tables and removed the special handling when used with `concurrent index` given we can disable the lock now.

Closes #247