### PR TITLE
Improve documentation

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -784,13 +784,21 @@ defmodule Ecto.Migration do
 
   Reversible commands can be defined by calling `execute/2`.
 
+  Keyword commands exist for non-SQL adapters and are not used in most situations.
+
+  Supplying an anonymous function does allow for arbitrary code to execute as
+  part of the migration. This is especially useful in combination with `repo/0`
+  for a higher level api instead of raw sql queries.
+
   ## Examples
 
       execute "CREATE EXTENSION postgres_fdw"
 
       execute create: "posts", capped: true, size: 1024
 
-      execute(fn -> repo().query!("select 'Anonymous function query …';", [], [log: :info]) end)
+      execute(fn -> repo().query!("SELECT $1::integer + $2", [40, 2], [log: :info]) end)
+
+      execute(fn -> repo().update_all("posts", set: [published: true]) end)
   """
   def execute(command) when is_binary(command) or is_function(command, 0) or is_list(command) do
     Runner.execute command
@@ -804,6 +812,8 @@ defmodule Ecto.Migration do
   a PostgreSQL extension. The `execute/2` form avoids having to define
   separate `up/0` and `down/0` blocks that each contain an `execute/1`
   expression.
+
+  The allowed parameters are explained for `execute/1`.
 
   ## Examples
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -814,7 +814,7 @@ defmodule Ecto.Migration do
   separate `up/0` and `down/0` blocks that each contain an `execute/1`
   expression.
 
-  The allowed parameters are explained for `execute/1`.
+  The allowed parameters are explained in `execute/1`.
 
   ## Examples
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -782,13 +782,14 @@ defmodule Ecto.Migration do
   @doc """
   Executes arbitrary SQL, anonymous function or a keyword command.
 
-  Reversible commands can be defined by calling `execute/2`.
-
+  The argument is typically a string, containing the SQL command to be executed.
   Keyword commands exist for non-SQL adapters and are not used in most situations.
 
   Supplying an anonymous function does allow for arbitrary code to execute as
-  part of the migration. This is especially useful in combination with `repo/0`
-  for a higher level api instead of raw sql queries.
+  part of the migration. This is most often used in combination with `repo/0`
+  by library authors who want to create high-level migration helpers.
+
+  Reversible commands can be defined by calling `execute/2`.
 
   ## Examples
 


### PR DESCRIPTION
Close #257

I did modify the `query!` example to include parameters. This was a question of someone on the slack a few days ago. I also added an example for `update_all`, which can also be a good reason for wanting to use this over raw sql.

`repo/0` already has docs, I just mentioned them so people will know where to look. For the same reason I added the hint in `execute/2` to look at `execute/1` for docs on the allowed parameters.