### PR TITLE
Problem: before_commit callback in migrations

### DIFF
--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -275,18 +275,17 @@ defmodule Ecto.Migration.Runner do
         module.after_begin()
       end
 
-      result = apply(module, operation, [])
+      apply(module, operation, [])
+      flush()
 
       if function_exported?(module, :before_commit, 0) do
         module.before_commit()
+        flush() # flush it again if `before_commit/0` queued anything up
       end
-
-      result
     else
       apply(module, operation, [])
+      flush()
     end
-
-    flush()
   end
 
   defp runner do


### PR DESCRIPTION
The documentation states the following:

```
In some rare cases, you may need to execute some common behavior after
beginning a migration transaction, or before commiting that transaction.
For instance, one might desire to set a lock_timeout for each lock in
the migration transaction.
```

However, it appears that if one is to have a migration that uses
commands (see example below), and define a `before_commit` callback,
then the callback will be executed before the commands are in fact
executed.

```elixir
def change do
  create table("units") do
    ...
  end
end
```

Solution: execute `before_commit` after flushing commands
and flush commands again if before_commit queued up some more

---

An alternative solution to this problem (without chaning ecto_sql's code) would be to indicate that `before_commit` callback should call `Ecto.Migration.Runner.flush()` to ensure queued up commands have been executed.