### PR TITLE
add logic to optionally skip schema migrations table checks

### DIFF
--- a/test/ecto/migrator_repo_test.exs
+++ b/test/ecto/migrator_repo_test.exs
@@ -79,7 +79,7 @@ defmodule Ecto.MigratorRepoTest do
         up(MainRepo, 0, Migration)
 
         assert_receive {:transaction, %{repo: MainRepo}, _}
-        assert_receive {:lock_for_migrations, %{repo: MigrationRepo}, _}
+        assert_receive {:lock_for_migrations, %{repo: MigrationRepo}, _, _}
       end
     end
   end

--- a/test/test_repo.exs
+++ b/test/test_repo.exs
@@ -59,8 +59,8 @@ defmodule EctoSQL.TestAdapter do
 
   ## Migrations
 
-  def lock_for_migrations(mod, query, _opts, fun) do
-    send test_process(), {:lock_for_migrations, mod, fun}
+  def lock_for_migrations(mod, query, opts, fun) do
+    send test_process(), {:lock_for_migrations, mod, fun, opts}
     fun.(query)
   end
 


### PR DESCRIPTION
When used with a user that does not have permissions to create tables (in Postgres, specifically), `Ecto.Migrator` cannot enumerate migrations because it fails trying to create the table.  Despite using `IF EXISTS`, the lack of permissions still causes it to fail.

Our services check that all migrations are applied before they will report themselves as "ready".  Adding this option allows the check to be done with read-only users.