### PR TITLE
Adds ability to skip the validation of PostgreSQL constraints on create

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -1029,10 +1029,10 @@ if Code.ensure_loaded?(Postgrex) do
     defp null_expr(_), do: []
 
     defp new_constraint_expr(%Constraint{check: check} = constraint) when is_binary(check) do
-      ["CONSTRAINT ", quote_name(constraint.name), " CHECK (", check, ")"]
+      ["CONSTRAINT ", quote_name(constraint.name), " CHECK (", check, ")", validate(constraint.validate)]
     end
     defp new_constraint_expr(%Constraint{exclude: exclude} = constraint) when is_binary(exclude) do
-      ["CONSTRAINT ", quote_name(constraint.name), " EXCLUDE USING ", exclude]
+      ["CONSTRAINT ", quote_name(constraint.name), " EXCLUDE USING ", exclude, validate(constraint.validate)]
     end
 
     defp default_expr({:ok, nil}, _type),    do: " DEFAULT NULL"

--- a/lib/ecto/adapters/tds/connection.ex
+++ b/lib/ecto/adapters/tds/connection.ex
@@ -1061,6 +1061,10 @@ if Code.ensure_loaded?(Tds) do
       error!(nil, msg)
     end
 
+    def execute_ddl({:create, %Constraint{validate: false}}) do
+      error!(nil, "`:validate` is not supported by the Tds adapter")
+    end
+
     def execute_ddl({:create, %Constraint{} = constraint}) do
       table_name = quote_table(constraint.prefix, constraint.table)
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -390,9 +390,9 @@ defmodule Ecto.Migration do
 
     To define a constraint in a migration, see `Ecto.Migration.constraint/3`.
     """
-    defstruct name: nil, table: nil, check: nil, exclude: nil, prefix: nil, comment: nil
+    defstruct name: nil, table: nil, check: nil, exclude: nil, prefix: nil, comment: nil, validate: true
     @type t :: %__MODULE__{name: atom, table: String.t, prefix: atom | nil,
-                           check: String.t | nil, exclude: String.t | nil, comment: String.t | nil}
+                           check: String.t | nil, exclude: String.t | nil, comment: String.t | nil, validate: boolean}
   end
 
   defmodule Command do
@@ -1165,6 +1165,9 @@ defmodule Ecto.Migration do
     * `:check` - A check constraint expression. Required when creating a check constraint.
     * `:exclude` - An exclusion constraint expression. Required when creating an exclusion constraint.
     * `:prefix` - The prefix for the table.
+    * `:validate` - Whether or not to validate the constraint on creation (true by default). Only
+       available in PostgreSQL, and should be followed by a command to validate the foreign key in
+       a following migration if false.
 
   """
   def constraint(table, name, opts \\ [])

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -1339,8 +1339,18 @@ defmodule Ecto.Adapters.MyXQLTest do
       assert execute_ddl(create)
     end
 
+    assert_raise ArgumentError, "MySQL adapter does not support check constraints", fn ->
+      create = {:create, constraint(:products, "foo", check: "price", validate: false)}
+      assert execute_ddl(create)
+    end
+
     assert_raise ArgumentError, "MySQL adapter does not support exclusion constraints", fn ->
       create = {:create, constraint(:products, "bar", exclude: "price")}
+      assert execute_ddl(create)
+    end
+
+    assert_raise ArgumentError, "MySQL adapter does not support exclusion constraints", fn ->
+      create = {:create, constraint(:products, "bar", exclude: "price", validate: false)}
       assert execute_ddl(create)
     end
   end

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1691,6 +1691,11 @@ defmodule Ecto.Adapters.PostgresTest do
     ~s|COMMENT ON CONSTRAINT "price_must_be_positive" ON "foo"."products" IS 'comment'|]
   end
 
+  test "create invalid constraint" do
+    create = {:create, constraint(:products, "price_must_be_positive", check: "price > 0", prefix: "foo", validate: false)}
+    assert execute_ddl(create) == [~s|ALTER TABLE "foo"."products" ADD CONSTRAINT "price_must_be_positive" CHECK (price > 0) NOT VALID|]
+  end
+
   test "drop constraint" do
     drop = {:drop, constraint(:products, "price_must_be_positive")}
     assert execute_ddl(drop) ==

--- a/test/ecto/adapters/tds_test.exs
+++ b/test/ecto/adapters/tds_test.exs
@@ -1253,6 +1253,14 @@ defmodule Ecto.Adapters.TdsTest do
              ]
   end
 
+  test "create check constraint with invalid validate opts" do
+    create = {:create, constraint(:products, "price_must_be_positive", check: "price > 0", validate: false)}
+
+    assert_raise ArgumentError, "`:validate` is not supported by the Tds adapter", fn ->
+      execute_ddl(create)
+    end
+  end
+
   test "drop constraint" do
     drop = {:drop, constraint(:products, "price_must_be_positive")}
 

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -114,13 +114,21 @@ defmodule Ecto.MigrationTest do
 
   test "creates a constraint" do
     assert constraint(:posts, :price_is_positive, check: "price > 0") ==
-           %Constraint{table: "posts", name: :price_is_positive, check: "price > 0"}
+           %Constraint{table: "posts", name: :price_is_positive, check: "price > 0", validate: true}
     assert constraint("posts", :price_is_positive, check: "price > 0") ==
-           %Constraint{table: "posts", name: :price_is_positive, check: "price > 0"}
+           %Constraint{table: "posts", name: :price_is_positive, check: "price > 0", validate: true}
     assert constraint(:posts, :exclude_price, exclude: "price") ==
-           %Constraint{table: "posts", name: :exclude_price, exclude: "price"}
+           %Constraint{table: "posts", name: :exclude_price, exclude: "price", validate: true}
     assert constraint("posts", :exclude_price, exclude: "price") ==
-           %Constraint{table: "posts", name: :exclude_price, exclude: "price"}
+           %Constraint{table: "posts", name: :exclude_price, exclude: "price", validate: true}
+    assert constraint(:posts, :price_is_positive, check: "price > 0", validate: false) ==
+           %Constraint{table: "posts", name: :price_is_positive, check: "price > 0", validate: false}
+    assert constraint("posts", :price_is_positive, check: "price > 0", validate: false) ==
+           %Constraint{table: "posts", name: :price_is_positive, check: "price > 0", validate: false}
+    assert constraint(:posts, :exclude_price, exclude: "price", validate: false) ==
+           %Constraint{table: "posts", name: :exclude_price, exclude: "price", validate: false}
+    assert constraint("posts", :exclude_price, exclude: "price", validate: false) ==
+           %Constraint{table: "posts", name: :exclude_price, exclude: "price", validate: false}
   end
 
   test "runs a reversible command" do


### PR DESCRIPTION
Validation of constraints in PostgreSQL can cause large tables to stay
locked for a long time (preventing writes, because it has to check all
rows in order to consider the constraint as valid.

PostgreSQL has a way to get around this by first creating constraints as
not valid. And then running a query to validate the constraint. The
validation query does not lock the table, i.e. it can be run while
allowing writes in parallel.

This commit implements the ability to skip validation of constraints. It
does not implement the validation query.

This was inspired by https://github.com/elixir-ecto/ecto_sql/pull/244.

https://www.postgresql.org/docs/current/sql-altertable.html