### PR TITLE
Use proper locks on migration tables

### DIFF
--- a/integration_test/sql/migrator.exs
+++ b/integration_test/sql/migrator.exs
@@ -81,11 +81,9 @@ defmodule Ecto.Integration.MigratorTest do
     assert up(PoolRepo, 33, AnotherSchemaMigration, log: false) == :ok
     assert migrated_versions(PoolRepo) == [33]
 
-    assert capture_log(fn ->
-      catch_error(up(PoolRepo, 34, GoodMigration, log: false, prefix: "bad_schema_migrations"))
-      catch_error(PoolRepo.all("good_migration"))
-      catch_error(PoolRepo.all("good_migration", prefix: "bad_schema_migrations"))
-    end) =~ "Could not update schema migrations"
+    catch_error(up(PoolRepo, 34, GoodMigration, log: false, prefix: "bad_schema_migrations"))
+    catch_error(PoolRepo.all("good_migration"))
+    catch_error(PoolRepo.all("good_migration", prefix: "bad_schema_migrations"))
 
     assert down(PoolRepo, 33, AnotherSchemaMigration, log: false) == :ok
   end

--- a/integration_test/support/migration.exs
+++ b/integration_test/support/migration.exs
@@ -2,6 +2,9 @@ defmodule Ecto.Integration.Migration do
   use Ecto.Migration
 
   def change do
+    # IO.puts "TESTING MIGRATION LOCK"
+    # Process.sleep(10000)
+
     create table(:users, comment: "users table") do
       add :name, :string, comment: "name column"
       add :custom_id, :uuid

--- a/lib/ecto/adapter/migration.ex
+++ b/lib/ecto/adapter/migration.ex
@@ -56,7 +56,7 @@ defmodule Ecto.Adapter.Migration do
 
   It returns the result of calling the given function with a list of versions.
   """
-  @callback lock_for_migrations(adapter_meta, Ecto.Query.t(), options :: Keyword.t(), fun) ::
+  @callback lock_for_migrations(adapter_meta, options :: Keyword.t(), fun) ::
               result
-            when fun: (Ecto.Query.t() -> result), result: var
+            when fun: (() -> result), result: var
 end

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -200,6 +200,9 @@ defmodule Ecto.Adapters.Postgres do
 
       {:ok, result} =
         transaction(meta, opts, fn ->
+          # SHARE UPDATE EXCLUSIVE MODE is the first lock that locks
+          # itself but still allows updates to happen, see
+          # # https://www.postgresql.org/docs/9.4/explicit-locking.html
           source = Keyword.get(adapter_opts, :migration_source, "schema_migrations")
           {:ok, _} = Ecto.Adapters.SQL.query(meta, "LOCK TABLE \"#{source}\" IN SHARE UPDATE EXCLUSIVE MODE", [], opts)
           fun.()

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -189,7 +189,7 @@ defmodule Ecto.Adapters.Postgres do
 
   @impl true
   def lock_for_migrations(meta, opts, fun) do
-    %{opts: adapter_opts, repo: repo} = meta
+    %{opts: adapter_opts} = meta
 
     if Keyword.get(adapter_opts, :migration_lock, true) do
       if Keyword.fetch(adapter_opts, :pool_size) == {:ok, 1} do

--- a/lib/ecto/adapters/tds.ex
+++ b/lib/ecto/adapters/tds.ex
@@ -290,7 +290,7 @@ defmodule Ecto.Adapters.Tds do
       {:ok, result} =
         transaction(meta, opts, fn ->
           lock_name = "'ecto_#{inspect(repo)}'"
-          Ecto.Adapters.SQL.query!(meta, "sp_getapplock @Resource = #{lock_name}, @LockMode = 'Exclusive'", [], opts)
+          Ecto.Adapters.SQL.query!(meta, "sp_getapplock @Resource = #{lock_name}, @LockMode = 'Exclusive', @LockOwner = 'Transaction', @LockTimeout = -1", [], opts)
           fun.()
         end)
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -227,9 +227,9 @@ defmodule Ecto.Migration do
 
     * `:migration_lock` - By default, Ecto will lock the migration table. This allows
       multiple nodes to attempt to run migrations at the same time but only one will
-      succeed. You can disable the `migration_lock` by setting it to `nil`:
+      succeed. You can disable the `migration_lock` by setting it to `false`
 
-          config :app, App.Repo, migration_lock: nil
+          config :app, App.Repo, migration_lock: false
 
     * `:migration_default_prefix` - Ecto defaults to `nil` for the database prefix for
       migrations, but you can configure it via:

--- a/test/ecto/migrator_repo_test.exs
+++ b/test/ecto/migrator_repo_test.exs
@@ -39,7 +39,7 @@ defmodule Ecto.MigratorRepoTest do
   Application.put_env(:ecto_sql, MainRepo, [migration_repo: MigrationRepo])
 
   setup do
-    Process.put(:migrated_versions, [{1, nil}, {2, nil}, {3, nil}])
+    {:ok, _} = start_supervised({MigrationsAgent, [{1, nil}, {2, nil}, {3, nil}]})
     :ok
   end
 

--- a/test/ecto/tenant_migrator_test.exs
+++ b/test/ecto/tenant_migrator_test.exs
@@ -31,7 +31,7 @@ defmodule Ecto.TenantMigratorTest do
   end
 
   setup do
-    Process.put(:migrated_versions, [{1, nil}, {2, nil}, {3, nil}])
+    {:ok, _} = start_supervised({MigrationsAgent, [{1, nil}, {2, nil}, {3, nil}]})
     :ok
   end
 


### PR DESCRIPTION
Instead of locking rows, we lock the table resource
altogether, either using app locks or table locks.

Closes #276.