### PR TITLE
Support force dropping database introduced in PostgreSQL 13

### DIFF
--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -68,6 +68,8 @@ defmodule Ecto.Adapters.Postgres do
     * `:lc_collate` - the collation order
     * `:lc_ctype` - the character classification
     * `:dump_path` - where to place dumped structures
+    * `:force_drop` - force the database to be dropped even
+      if it has connections to it
 
   ### After connect callback
 

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -147,13 +147,15 @@ defmodule Ecto.Adapters.Postgres do
     end
   end
 
-  defp concat_if(content, nil, _fun),  do: content
+  defp concat_if(content, nil, _),  do: content
+  defp concat_if(content, false, _),  do: content
   defp concat_if(content, value, fun), do: content <> " " <> fun.(value)
 
   @impl true
   def storage_down(opts) do
     database = Keyword.fetch!(opts, :database) || raise ":database is nil in repository configuration"
-    command  = "DROP DATABASE \"#{database}\""
+    command = "DROP DATABASE \"#{database}\""
+              |> concat_if(opts[:force_drop], fn _ -> "WITH (FORCE)" end)
     maintenance_database = Keyword.get(opts, :maintenance_database, @default_maintenance_database)
     opts = Keyword.put(opts, :database, maintenance_database)
 

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -69,7 +69,7 @@ defmodule Ecto.Adapters.Postgres do
     * `:lc_ctype` - the character classification
     * `:dump_path` - where to place dumped structures
     * `:force_drop` - force the database to be dropped even
-      if it has connections to it
+      if it has connections to it (requires PostgreSQL 13+)
 
   ### After connect callback
 


### PR DESCRIPTION
I was getting annoyed by:
```
$ mix ecto.reset
** (Mix) The database for App.Repo couldn't be dropped: ERROR 55006 (object_in_use) database "app_dev" is being accessed by other users

There is 1 other session using the database.
```

So I searched online and found out that in PostgreSQL 13 there is a new `DROP DATABASE "db" WITH (FORCE)` syntax. 

https://www.postgresql.org/docs/current/sql-dropdatabase.html

Is this something that can be added? The PR is not fully done as I need some advice on how to do this properly 🙏 