### PR TITLE
Allow a default on JSON columns in MySQL

### DIFF
--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -881,8 +881,11 @@ if Code.ensure_loaded?(MyXQL) do
       do: [" DEFAULT ", to_string(literal)]
     defp default_expr({:ok, {:fragment, expr}}),
       do: [" DEFAULT ", expr]
-    defp default_expr({:ok, value}) when is_map(value),
-      do: error!(nil, ":default is not supported for json columns by MySQL")
+    defp default_expr({:ok, value}) when is_map(value) do
+      library = Application.get_env(:myxql, :json_library, Jason)
+      expr = IO.iodata_to_binary(library.encode_to_iodata!(value))
+      [" DEFAULT ", ?(, ?', escape_string(expr), ?', ?)]
+    end
     defp default_expr(:error),
       do: []
 

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -1116,9 +1116,9 @@ defmodule Ecto.Adapters.MyXQLTest do
               ]
             }
 
-    assert_raise ArgumentError, ~r/:default is not supported for json columns by MySQL/, fn ->
-      execute_ddl(create)
-    end
+    assert execute_ddl(create) == ["""
+    CREATE TABLE `posts` (`a` json DEFAULT ('{\"baz\":\"boom\",\"foo\":\"bar\"}')) ENGINE = INNODB
+    """ |> remove_newlines]
   end
 
   test "create table with time columns" do


### PR DESCRIPTION
As of MySQL 8.0.13 (now 2 years old) defaults are actually allowed.