### PR TITLE
Add Tds support for :inner_lateral and :left_lateral

### DIFF
--- a/test/ecto/adapters/tds_test.exs
+++ b/test/ecto/adapters/tds_test.exs
@@ -914,7 +914,7 @@ defmodule Ecto.Adapters.TdsTest do
              ~s{SELECT CAST(1 as bit) FROM [prefix].[schema] AS s0 INNER JOIN [prefix].[schema2] AS s1 ON s0.[x] = s1.[z]}
   end
 
-  test "join with fragment" do
+  test "join with single line fragment" do
     query =
       Schema
       |> join(
@@ -932,6 +932,30 @@ defmodule Ecto.Adapters.TdsTest do
                ~s{WHERE ((s0.[id] > 0) AND (s0.[id] < @3))}
   end
 
+  test "join with multi-line fragment" do
+    query =
+      Schema
+      |> join(
+        :inner,
+        [p],
+        q in fragment(~S"""
+          SELECT *
+          FROM schema2 AS s2
+          WHERE s2.id = ? AND s2.field = ?
+        """, p.x, ^10)
+      )
+      |> select([p], {p.id, ^0})
+      |> where([p], p.id > 0 and p.id < ^100)
+      |> plan()
+
+    assert all(query) ==
+             ~s{SELECT s0.[id], @1 FROM [schema] AS s0 INNER JOIN } <>
+               ~s{(  SELECT *\n } <>
+               ~s{ FROM schema2 AS s2\n } <>
+               ~s{ WHERE s2.id = s0.[x] AND s2.field = @2\n} <>
+               ~s{) AS f1 ON 1 = 1 WHERE ((s0.[id] > 0) AND (s0.[id] < @3))}
+  end
+
   test "inner lateral join with fragment" do
     query = Schema
             |> join(:inner_lateral, [p], q in fragment("SELECT * FROM schema2 AS s2 WHERE s2.id = ? AND s2.field = ?", p.x, ^10))
@@ -940,7 +964,7 @@ defmodule Ecto.Adapters.TdsTest do
             |> plan()
     assert all(query) ==
            ~s{SELECT s0.[id], f1.[z] FROM [schema] AS s0 CROSS APPLY } <>
-           ~s{((SELECT * FROM schema2 AS s2 WHERE s2.id = s0.[x] AND s2.field = @1)) AS f1 } <>
+           ~s{(SELECT * FROM schema2 AS s2 WHERE s2.id = s0.[x] AND s2.field = @1) AS f1 } <>
            ~s{WHERE ((s0.[id] > 0) AND (s0.[id] < @2))}
   end
 
@@ -952,7 +976,7 @@ defmodule Ecto.Adapters.TdsTest do
             |> plan()
     assert all(query) ==
            ~s{SELECT s0.[id], f1.[z] FROM [schema] AS s0 OUTER APPLY } <>
-           ~s{((SELECT * FROM schema2 AS s2 WHERE s2.id = s0.[x] AND s2.field = @1)) AS f1 } <>
+           ~s{(SELECT * FROM schema2 AS s2 WHERE s2.id = s0.[x] AND s2.field = @1) AS f1 } <>
            ~s{WHERE ((s0.[id] > 0) AND (s0.[id] < @2))}
   end
 


### PR DESCRIPTION
This commit updates the TDS adapter to support the :inner_lateral
and :left_lateral joins, which map to OUTER APPLY and CROSS APPLY,
respectively.  For both of these joins, we don't need an ON clause.
Therefore, the join_on/4 function headers have been updated to omit
it.

Lastly, these require that the join contents be wrapped within
brackets ().  So, the join_expr function is added to wrap provided
join expression in brackets for these joins only.