### PR TITLE
Update docs to have accurate default for ownership_timeout

### DIFF
--- a/lib/ecto/adapters/sql/sandbox.ex
+++ b/lib/ecto/adapters/sql/sandbox.ex
@@ -226,7 +226,7 @@ defmodule Ecto.Adapters.SQL.Sandbox do
         ownership_timeout: NEW_TIMEOUT_IN_MILLISECONDS
 
   The `:ownership_timeout` option is part of `DBConnection.Ownership`
-  and defaults to 60000ms. Timeouts are given as integers in milliseconds.
+  and defaults to 120000ms. Timeouts are given as integers in milliseconds.
 
   Alternately, if this is an issue for only a handful of long-running tests,
   you can pass an `:ownership_timeout` option when calling


### PR DESCRIPTION
Disclaimer: I am not entirely sure which is accurate, but I noticed a discrepancy between the docs for:
 - https://hexdocs.pm/db_connection/2.2.2/DBConnection.Ownership.html#module-options
 and
 - https://hexdocs.pm/ecto_sql/Ecto.Adapters.SQL.Sandbox.html#module-owner-timed-out-because-it-owned-the-connection-for-longer-than-nms

I am relatively sure the `120_000` is more up to date due to this line: https://github.com/elixir-ecto/db_connection/blob/436101ab9678f7173d8284086536ee27ad8c05c5/lib/db_connection/ownership/proxy.ex#L8

but feel free to disregard and close if I am wrong, thanks!