### PR TITLE
Human readable UUID logs

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -165,6 +165,16 @@ if Code.ensure_loaded?(Postgrex) do
        values, on_conflict(on_conflict, header) | returning(returning)]
     end
 
+    @impl true
+    def parse_log_param({binary, Postgrex.Extensions.UUID}) do
+      case Ecto.UUID.load(binary) do
+        {:ok, uuid} -> uuid
+        :error -> binary
+      end
+    end
+
+    def parse_log_param({param, _type}), do: param
+
     defp insert_as({%{sources: sources}, _, _}) do
       {_expr, name, _schema} = create_name(sources, 0, [])
       [" AS " | name]

--- a/lib/ecto/adapters/sql/connection.ex
+++ b/lib/ecto/adapters/sql/connection.ex
@@ -126,4 +126,11 @@ defmodule Ecto.Adapters.SQL.Connection do
   Returns a queryable to check if the given `table` exists.
   """
   @callback table_exists_query(table :: String.t) :: {iodata, [term]}
+
+  @doc """
+  Returns a format of a query param to display in logs output.
+  """
+  @callback parse_log_param(param_data :: tuple) :: String.t
+
+  @optional_callbacks parse_log_param: 1
 end


### PR DESCRIPTION
This PR is related to https://github.com/elixir-ecto/ecto/pull/3531

It improves logs output for Ecto.UUID values:

before:

<img width="563" alt="image" src="https://user-images.githubusercontent.com/1131944/103351754-7a302680-4aa4-11eb-9155-b784c0b3e555.png">

after:

<img width="561" alt="image" src="https://user-images.githubusercontent.com/1131944/103351762-7e5c4400-4aa4-11eb-9999-13844fb79936.png">

Edit: I'm not sure about this implementation because it leaks the adapter details. Feedback appreciated. 