### PR TITLE
Allow generating migrations from within umbrella app

### DIFF
--- a/lib/mix/tasks/ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto.gen.migration.ex
@@ -66,10 +66,6 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
     Enum.map repos, fn repo ->
       case OptionParser.parse!(args, strict: @switches, aliases: @aliases) do
         {opts, [name]} ->
-          unless opts[:migrations_path] do
-            no_umbrella!("ecto.gen.migration")
-          end
-
           ensure_repo(repo, args)
           path = opts[:migrations_path] || Path.join(source_repo_priv(repo), "migrations")
           base_name = "#{underscore(name)}.exs"

--- a/lib/mix/tasks/ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto.gen.migration.ex
@@ -61,12 +61,15 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
 
   @impl true
   def run(args) do
-    no_umbrella!("ecto.gen.migration")
     repos = parse_repo(args)
 
     Enum.map repos, fn repo ->
       case OptionParser.parse!(args, strict: @switches, aliases: @aliases) do
         {opts, [name]} ->
+          unless opts[:migrations_path] do
+            no_umbrella!("ecto.gen.migration")
+          end
+
           ensure_repo(repo, args)
           path = opts[:migrations_path] || Path.join(source_repo_priv(repo), "migrations")
           base_name = "#{underscore(name)}.exs"

--- a/test/mix/tasks/ecto.gen.migration_test.exs
+++ b/test/mix/tasks/ecto.gen.migration_test.exs
@@ -68,27 +68,4 @@ defmodule Mix.Tasks.Ecto.Gen.MigrationTest do
   test "raises when missing file" do
     assert_raise Mix.Error, fn -> run ["-r", to_string(Repo)] end
   end
-
-  test "generates migration within umbrella app without raising" do
-    # Turn the project into an umbrella app
-    project = Mix.ProjectStack.pop()
-    umbrella_project_config = Keyword.put(project.config, :apps_path, "apps/")
-    assert :ok == Mix.ProjectStack.push(project.name, umbrella_project_config, project.file)
-
-    # Turn the project back into the original app config once the test ends
-    on_exit(fn ->
-      Mix.ProjectStack.pop()
-      assert :ok == Mix.ProjectStack.push(project.name, project.config, project.file)
-    end)
-
-    assert Mix.Project.umbrella?()
-    [path] = run ["-r", to_string(Repo), "my_migration"]
-    assert Path.dirname(path) == @migrations_path
-    assert Path.basename(path) =~ ~r/^\d{14}_my_migration\.exs$/
-    assert_file path, fn file ->
-      assert file =~ "defmodule Mix.Tasks.Ecto.Gen.MigrationTest.Repo.Migrations.MyMigration do"
-      assert file =~ "use Ecto.Migration"
-      assert file =~ "def change do"
-    end
-  end
 end


### PR DESCRIPTION
While numerous ecto_sql tasks are allowed to run from the root of an umbrella app when given `--migrations-path`, the `ecto.gen.migration` task is still prevented to run due to a `no_umbrella!/1` check.

This PR moves the umbrella check under a missing `--migrations-path` check.

If the mix task is run without a `--migrations-path` option, then the `gen.migration` task will fail as always.
However, with a `--migrations-path` option set, the task is allowed to run