### PR TITLE
Add format option for PostgreSQL explain

### DIFF
--- a/integration_test/pg/explain_test.exs
+++ b/integration_test/pg/explain_test.exs
@@ -26,4 +26,27 @@ defmodule Ecto.Integration.ExplainTest do
       TestRepo.explain(:all, Post, analyze: "1")
     end)
   end
+
+  test "explain JSON format" do
+    [explain] = TestRepo.explain(:all, Post, analyze: true, verbose: true, timeout: 20000, format: :json) |> Jason.decode!()
+    keys = explain["Plan"] |> Map.keys
+    assert Enum.member?(keys, "Actual Loops")
+    assert Enum.member?(keys, "Actual Rows")
+    assert Enum.member?(keys, "Actual Startup Time")
+  end
+
+  test "explain MAP format" do
+    [explain] = TestRepo.explain(:all, Post, analyze: true, verbose: true, timeout: 20000, format: :map)
+    keys = explain["Plan"] |> Map.keys
+    assert Enum.member?(keys, "Actual Loops")
+    assert Enum.member?(keys, "Actual Rows")
+    assert Enum.member?(keys, "Actual Startup Time")
+  end
+
+  test "explain YAML format" do
+    explain = TestRepo.explain(:all, Post, analyze: true, verbose: true, timeout: 20000, format: :yaml)
+    assert explain =~ ~r/Plan:/
+    assert explain =~ ~r/Node Type:/
+    assert explain =~ ~r/Relation Name:/
+  end
 end

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -281,8 +281,7 @@ defmodule Ecto.Adapters.SQL do
 
   Also note that:
 
-    * `FORMAT` isn't supported at the moment and the only possible output
-      is a textual format, so you may want to call `IO.puts/1` to display it;
+    * Currently `:json`, `:map`, `:yaml` and `:text` format options are supported for PostgreSQL
     * Any other value passed to `opts` will be forwarded to the underlying
       adapter query function, including Repo shared options such as `:timeout`;
     * Non built-in adapters may have specific behavior and you should consult


### PR DESCRIPTION
This PR adds JSON and YAML format outputs to `explain` for PostgreSQL databases:

```
Repo.explain(:all, Area, format: :json) |> Jason.decode!()

[
  %{
    "Plan" => %{
      "Alias" => "a0",
      "Node Type" => "Seq Scan",
      "Parallel Aware" => false,
      "Plan Rows" => 70,
      "Plan Width" => 1064,
      "Relation Name" => "areas",
      "Startup Cost" => 0.0,
      "Total Cost" => 10.7
    }
  }
]

Repo.explain(:all, Area, format: :yaml) |> IO.puts

- Plan:
    Node Type: "Seq Scan"
    Parallel Aware: false
    Relation Name: "areas"
    Alias: "a0"
    Startup Cost: 0.00
    Total Cost: 10.70
    Plan Rows: 70
    Plan Width: 1064
```

Especially the `json` format is useful because it can be used with [query visualizer tool](https://tatiyants.com/pev/#/plans/new) for some advanced debugging.


