### PR TITLE
migration: Add CASCADE option to DROP command

### DIFF
--- a/lib/ecto/adapter/migration.ex
+++ b/lib/ecto/adapter/migration.ex
@@ -16,8 +16,8 @@ defmodule Ecto.Adapter.Migration do
           | {:create, Table.t(), [table_subcommand]}
           | {:create_if_not_exists, Table.t(), [table_subcommand]}
           | {:alter, Table.t(), [table_subcommand]}
-          | {:drop, Table.t()}
-          | {:drop_if_exists, Table.t()}
+          | {:drop, Table.t(), :restrict | :cascade | nil}
+          | {:drop_if_exists, Table.t(), :restrict | :cascade | nil}
           | {:create, Index.t()}
           | {:create_if_not_exists, Index.t()}
           | {:drop, Index.t()}

--- a/lib/ecto/adapter/migration.ex
+++ b/lib/ecto/adapter/migration.ex
@@ -20,8 +20,8 @@ defmodule Ecto.Adapter.Migration do
           | {:drop_if_exists, Table.t(), :restrict | :cascade | nil}
           | {:create, Index.t()}
           | {:create_if_not_exists, Index.t()}
-          | {:drop, Index.t()}
-          | {:drop_if_exists, Index.t()}
+          | {:drop, Index.t(), :restrict | :cascade | nil}
+          | {:drop_if_exists, Index.t(), :restrict | :cascade | nil}
 
   @typedoc "All commands allowed within the block passed to `table/2`"
   @type table_subcommand ::

--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -151,7 +151,7 @@ if Code.ensure_loaded?(MyXQL) do
     def insert(_prefix, _table, _header, _rows, _on_conflict, _returning, _placeholders) do
       error!(nil, ":placeholders is not supported by MySQL")
     end
-    
+
     defp on_conflict({_, _, [_ | _]}, _header) do
       error!(nil, "The :conflict_target option is not supported in insert/insert_all by MySQL")
     end
@@ -755,24 +755,23 @@ if Code.ensure_loaded?(MyXQL) do
     def execute_ddl({:create, %Constraint{exclude: exclude}}) when is_binary(exclude),
       do: error!(nil, "MySQL adapter does not support exclusion constraints")
 
-    def execute_ddl({:drop, %Index{} = index}) do
+    def execute_ddl({:drop, %Index{}, :cascade}),
+      do: error!(nil, "MySQL adapter does not support cascade in drop index")
+
+    def execute_ddl({:drop, %Index{} = index, _}) do
       [["DROP INDEX ",
         quote_name(index.name),
         " ON ", quote_table(index.prefix, index.table),
         if_do(index.concurrently, " LOCK=NONE")]]
     end
 
-    def execute_ddl({:drop, %Index{}, :cascade}),
-      do: error!(nil, "MySQL adapter does not support cascade in drop index")
-
-
-    def execute_ddl({:drop, %Constraint{}}),
+    def execute_ddl({:drop, %Constraint{}, _}),
       do: error!(nil, "MySQL adapter does not support constraints")
 
-    def execute_ddl({:drop_if_exists, %Constraint{}}),
+    def execute_ddl({:drop_if_exists, %Constraint{}, _}),
       do: error!(nil, "MySQL adapter does not support constraints")
 
-    def execute_ddl({:drop_if_exists, %Index{}}),
+    def execute_ddl({:drop_if_exists, %Index{}, _}),
       do: error!(nil, "MySQL adapter does not support drop if exists for index")
 
     def execute_ddl({:rename, %Table{} = current_table, %Table{} = new_table}) do

--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -718,14 +718,14 @@ if Code.ensure_loaded?(MyXQL) do
         engine_expr(table.engine), options_expr(table.options)]]
     end
 
-    def execute_ddl({command, %Table{} = table}) when command in [:drop, :drop_if_exists] do
-      [["DROP TABLE ", if_do(command == :drop_if_exists, "IF EXISTS "),
-        quote_table(table.prefix, table.name)]]
+    def execute_ddl({command, %Table{} = table, :cascade}) when command in [:drop, :drop_if_exists] do
+      [cmd | _] = execute_ddl({command, %Table{} = table, nil})
+      [cmd ++ [" CASCADE"]]
     end
 
-    def execute_ddl({command, %Table{} = table, :cascade}) when command in [:drop, :drop_if_exists] do
-      [cmd | _] = execute_ddl({command, %Table{} = table})
-      [cmd ++ [" CASCADE"]]
+    def execute_ddl({command, %Table{} = table, _}) when command in [:drop, :drop_if_exists] do
+      [["DROP TABLE ", if_do(command == :drop_if_exists, "IF EXISTS "),
+        quote_table(table.prefix, table.name)]]
     end
 
     def execute_ddl({:alter, %Table{} = table, changes}) do

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -217,7 +217,7 @@ if Code.ensure_loaded?(Postgrex) do
 
         {:placeholder, placeholder_index}, counter ->
           {[?$ | placeholder_index], counter}
-          
+
         _, counter ->
           {[?$ | Integer.to_string(counter)], counter + 1}
       end)
@@ -826,14 +826,14 @@ if Code.ensure_loaded?(Postgrex) do
         comments_for_columns(table_name, columns)
     end
 
-    def execute_ddl({command, %Table{} = table}) when command in @drops do
-      [["DROP TABLE ", if_do(command == :drop_if_exists, "IF EXISTS "),
-        quote_table(table.prefix, table.name)]]
+    def execute_ddl({command, %Table{} = table, :cascade}) when command in @drops do
+      [cmd | _] = execute_ddl({command, table, nil})
+      [cmd ++ [" CASCADE"]]
     end
 
-    def execute_ddl({command, %Table{} = table, :cascade}) when command in @drops do
-      [cmd | _] = execute_ddl({command, table})
-      [cmd ++ [" CASCADE"]]
+    def execute_ddl({command, %Table{} = table, _}) when command in @drops do
+      [["DROP TABLE ", if_do(command == :drop_if_exists, "IF EXISTS "),
+        quote_table(table.prefix, table.name)]]
     end
 
     def execute_ddl({:alter, %Table{} = table, changes}) do
@@ -866,16 +866,16 @@ if Code.ensure_loaded?(Postgrex) do
       queries ++ comments_on("INDEX", quote_table(index.prefix, index.name), index.comment)
     end
 
-    def execute_ddl({command, %Index{} = index}) when command in @drops do
+    def execute_ddl({command, %Index{} = index, :cascade}) when command in @drops do
+      [cmd | _] = execute_ddl({command, index, nil})
+      [cmd ++ [" CASCADE"]]
+    end
+
+    def execute_ddl({command, %Index{} = index, _}) when command in @drops do
       [["DROP INDEX ",
         if_do(index.concurrently, "CONCURRENTLY "),
         if_do(command == :drop_if_exists, "IF EXISTS "),
         quote_table(index.prefix, index.name)]]
-    end
-
-    def execute_ddl({command, %Index{} = index, :cascade}) when command in @drops do
-      [cmd | _] = execute_ddl({command, index})
-      [cmd ++ [" CASCADE"]]
     end
 
     def execute_ddl({:rename, %Table{} = current_table, %Table{} = new_table}) do
@@ -896,12 +896,12 @@ if Code.ensure_loaded?(Postgrex) do
       queries ++ comments_on("CONSTRAINT", constraint.name, constraint.comment, table_name)
     end
 
-    def execute_ddl({:drop, %Constraint{} = constraint}) do
+    def execute_ddl({:drop, %Constraint{} = constraint, _}) do
       [["ALTER TABLE ", quote_table(constraint.prefix, constraint.table),
         " DROP CONSTRAINT ", quote_name(constraint.name)]]
     end
 
-    def execute_ddl({:drop_if_exists, %Constraint{} = constraint}) do
+    def execute_ddl({:drop_if_exists, %Constraint{} = constraint, _}) do
       [["ALTER TABLE ", quote_table(constraint.prefix, constraint.table),
         " DROP CONSTRAINT IF EXISTS ", quote_name(constraint.name)]]
     end

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -831,6 +831,11 @@ if Code.ensure_loaded?(Postgrex) do
         quote_table(table.prefix, table.name)]]
     end
 
+    def execute_ddl({command, %Table{} = table, :cascade}) when command in @drops do
+      [cmd | _] = execute_ddl({command, table})
+      [cmd ++ [" CASCADE"]]
+    end
+
     def execute_ddl({:alter, %Table{} = table, changes}) do
       table_name = quote_table(table.prefix, table.name)
       query = ["ALTER TABLE ", table_name, ?\s,
@@ -866,6 +871,11 @@ if Code.ensure_loaded?(Postgrex) do
         if_do(index.concurrently, "CONCURRENTLY "),
         if_do(command == :drop_if_exists, "IF EXISTS "),
         quote_table(index.prefix, index.name)]]
+    end
+
+    def execute_ddl({command, %Index{} = index, :cascade}) when command in @drops do
+      [cmd | _] = execute_ddl({command, index})
+      [cmd ++ [" CASCADE"]]
     end
 
     def execute_ddl({:rename, %Table{} = current_table, %Table{} = new_table}) do

--- a/lib/ecto/adapters/tds/connection.ex
+++ b/lib/ecto/adapters/tds/connection.ex
@@ -999,7 +999,7 @@ if Code.ensure_loaded?(Tds) do
       ]
     end
 
-    def execute_ddl({command, %Table{} = table}) when command in [:drop, :drop_if_exists] do
+    def execute_ddl({command, %Table{} = table, _}) when command in [:drop, :drop_if_exists] do
       prefix = table.prefix
 
       [
@@ -1114,7 +1114,7 @@ if Code.ensure_loaded?(Tds) do
       ]
     end
 
-    def execute_ddl({command, %Index{} = index}) when command in [:drop, :drop_if_exists] do
+    def execute_ddl({command, %Index{} = index, _}) when command in [:drop, :drop_if_exists] do
       prefix = index.prefix
 
       [
@@ -1134,7 +1134,7 @@ if Code.ensure_loaded?(Tds) do
       ]
     end
 
-    def execute_ddl({command, %Constraint{} = constraint})
+    def execute_ddl({command, %Constraint{} = constraint, _})
         when command in [:drop, :drop_if_exists] do
       table_name = quote_table(constraint.prefix, constraint.table)
 

--- a/lib/ecto/adapters/tds/connection.ex
+++ b/lib/ecto/adapters/tds/connection.ex
@@ -999,6 +999,9 @@ if Code.ensure_loaded?(Tds) do
       ]
     end
 
+    def execute_ddl({command, %Table{}, :cascade}) when command in [:drop, :drop_if_exists],
+      do: error!(nil, "MSSQL does not support `CASCADE` in DROP TABLE commands")
+
     def execute_ddl({command, %Table{} = table, _}) when command in [:drop, :drop_if_exists] do
       prefix = table.prefix
 
@@ -1114,6 +1117,9 @@ if Code.ensure_loaded?(Tds) do
       ]
     end
 
+    def execute_ddl({command, %Index{}, :cascade}) when command in [:drop, :drop_if_exists],
+      do: error!(nil, "MSSQL does not support `CASCADE` in DROP INDEX commands")
+
     def execute_ddl({command, %Index{} = index, _}) when command in [:drop, :drop_if_exists] do
       prefix = index.prefix
 
@@ -1133,6 +1139,9 @@ if Code.ensure_loaded?(Tds) do
         ]
       ]
     end
+
+    def execute_ddl({command, %Constraint{}, :cascade}) when command in [:drop, :drop_if_exists],
+      do: error!(nil, "MSSQL does not support `CASCADE` in DROP CONSTRAINT commands")
 
     def execute_ddl({command, %Constraint{} = constraint, _})
         when command in [:drop, :drop_if_exists] do

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -585,12 +585,7 @@ defmodule Ecto.Migration do
 
   """
   def drop(%{} = index_or_table_or_constraint, opts \\ []) when is_list(opts) do
-
-    if Keyword.get(opts, :cascade, false) do
-      Runner.execute {:drop, __prefix__(index_or_table_or_constraint), :cascade}
-    else
-      Runner.execute {:drop, __prefix__(index_or_table_or_constraint)}
-    end
+    Runner.execute {:drop, __prefix__(index_or_table_or_constraint), Keyword.get(opts, :mode)}
 
     index_or_table_or_constraint
   end
@@ -604,23 +599,18 @@ defmodule Ecto.Migration do
 
       drop_if_exists index("posts", [:name])
       drop_if_exists table("posts")
-      drop_if_exists index("posts, [:name]), cascade: true
-      drop_if_exists table("posts"), cascade: true
+      drop_if_exists index("posts, [:name]), mode: :cascade
+      drop_if_exists table("posts"), mode: :cascade
 
   ## Options
 
-    * `:cascade` - when `true`, automatically drop objects that depend
+    * `:mode` - when set to `:cascade`, automatically drop objects that depend
       - on the index, and in turn all objects that depend on those objects
       - on the table
-      Default is `false`
+      Default is `:restrict`
   """
   def drop_if_exists(%{} = index_or_table, opts \\ []) when is_list(opts) do
-
-    if Keyword.get(opts, :cascade, false) do
-      Runner.execute {:drop_if_exists, __prefix__(index_or_table), :cascade}
-    else
-      Runner.execute {:drop_if_exists, __prefix__(index_or_table)}
-    end
+    Runner.execute {:drop_if_exists, __prefix__(index_or_table), Keyword.get(opts, :mode)}
 
     index_or_table
   end

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -573,10 +573,25 @@ defmodule Ecto.Migration do
       drop index("posts", [:name])
       drop table("posts")
       drop constraint("products", "price_must_be_positive")
+      drop index("posts", [:name]), cascade: true
+      drop table("posts"), cascade: true
+
+  ## Options
+
+    * `:cascade` - when `true`, automatically drop objects that depend
+      - on the index, and in turn all objects that depend on those objects
+      - on the table
+      Default is `false`
 
   """
-  def drop(%{} = index_or_table_or_constraint) do
-    Runner.execute {:drop, __prefix__(index_or_table_or_constraint)}
+  def drop(%{} = index_or_table_or_constraint, opts \\ []) when is_list(opts) do
+
+    if Keyword.get(opts, :cascade, false) do
+      Runner.execute {:drop, __prefix__(index_or_table_or_constraint), :cascade}
+    else
+      Runner.execute {:drop, __prefix__(index_or_table_or_constraint)}
+    end
+
     index_or_table_or_constraint
   end
 
@@ -589,10 +604,24 @@ defmodule Ecto.Migration do
 
       drop_if_exists index("posts", [:name])
       drop_if_exists table("posts")
+      drop_if_exists index("posts, [:name]), cascade: true
+      drop_if_exists table("posts"), cascade: true
 
+  ## Options
+
+    * `:cascade` - when `true`, automatically drop objects that depend
+      - on the index, and in turn all objects that depend on those objects
+      - on the table
+      Default is `false`
   """
-  def drop_if_exists(%{} = index_or_table) do
-    Runner.execute {:drop_if_exists, __prefix__(index_or_table)}
+  def drop_if_exists(%{} = index_or_table, opts \\ []) when is_list(opts) do
+
+    if Keyword.get(opts, :cascade, false) do
+      Runner.execute {:drop_if_exists, __prefix__(index_or_table), :cascade}
+    else
+      Runner.execute {:drop_if_exists, __prefix__(index_or_table)}
+    end
+
     index_or_table
   end
 

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -363,8 +363,12 @@ defmodule Ecto.Migration.Runner do
     do: "alter table #{quote_name(table.prefix, table.name)}"
   defp command({:drop, %Table{} = table}),
     do: "drop table #{quote_name(table.prefix, table.name)}"
+  defp command({:drop, %Table{} = table, :cascade}),
+    do: command({:drop, table}) <> " cascade"
   defp command({:drop_if_exists, %Table{} = table}),
     do: "drop table if exists #{quote_name(table.prefix, table.name)}"
+  defp command({:drop_if_exists, %Table{} = table, :cascade}),
+    do: command({:drop_if_exists, table}) <> " cascade"
 
   defp command({:create, %Index{} = index}),
     do: "create index #{quote_name(index.prefix, index.name)}"
@@ -372,8 +376,12 @@ defmodule Ecto.Migration.Runner do
     do: "create index if not exists #{quote_name(index.prefix, index.name)}"
   defp command({:drop, %Index{} = index}),
     do: "drop index #{quote_name(index.prefix, index.name)}"
+  defp command({:drop, %Index{} = index, :cascade}),
+    do: command({:drop, index}) <> " cascade"
   defp command({:drop_if_exists, %Index{} = index}),
     do: "drop index if exists #{quote_name(index.prefix, index.name)}"
+  defp command({:drop_if_exists, %Index{} = index, :cascade}),
+    do: command({:drop_if_exists, index}) <> " cascade"
   defp command({:rename, %Table{} = current_table, %Table{} = new_table}),
     do: "rename table #{quote_name(current_table.prefix, current_table.name)} to #{quote_name(new_table.prefix, new_table.name)}"
   defp command({:rename, %Table{} = table, current_column, new_column}),
@@ -389,8 +397,12 @@ defmodule Ecto.Migration.Runner do
     do: "create exclude constraint #{constraint.name} on table #{quote_name(constraint.prefix, constraint.table)}"
   defp command({:drop, %Constraint{} = constraint}),
     do: "drop constraint #{constraint.name} from table #{quote_name(constraint.prefix, constraint.table)}"
+  defp command({:drop, %Constraint{} = constraint, _}),
+    do: command({:drop, constraint})
   defp command({:drop_if_exists, %Constraint{} = constraint}),
     do: "drop constraint if exists #{constraint.name} from table #{quote_name(constraint.prefix, constraint.table)}"
+  defp command({:drop_if_exists, %Constraint{} = constraint, _}),
+    do: command({:drop_if_exists, constraint})
 
   defp quote_name(nil, name), do: quote_name(name)
   defp quote_name(prefix, name), do: quote_name(prefix) <> "." <> quote_name(name)

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -217,18 +217,18 @@ defmodule Ecto.Migration.Runner do
   end
 
   defp reverse({:create, %Index{} = index}),
-    do: {:drop, index}
+    do: {:drop, index, nil}
   defp reverse({:create_if_not_exists, %Index{} = index}),
-    do: {:drop_if_exists, index}
-  defp reverse({:drop, %Index{} = index}),
+    do: {:drop_if_exists, index, nil}
+  defp reverse({:drop, %Index{} = index, _}),
     do: {:create, index}
-  defp reverse({:drop_if_exists, %Index{} = index}),
+  defp reverse({:drop_if_exists, %Index{} = index, _}),
     do: {:create_if_not_exists, index}
 
   defp reverse({:create, %Table{} = table, _columns}),
-    do: {:drop, table}
+    do: {:drop, table, nil}
   defp reverse({:create_if_not_exists, %Table{} = table, _columns}),
-    do: {:drop_if_exists, table}
+    do: {:drop_if_exists, table, nil}
   defp reverse({:rename, %Table{} = table_current, %Table{} = table_new}),
     do: {:rename, table_new, table_current}
   defp reverse({:rename, %Table{} = table, current_column, new_column}),
@@ -242,9 +242,9 @@ defmodule Ecto.Migration.Runner do
   # It is not a good idea to reverse constraints because
   # we can't guarantee data integrity when applying them back.
   defp reverse({:create_if_not_exists, %Constraint{} = constraint}),
-    do: {:drop_if_exists, constraint}
+    do: {:drop_if_exists, constraint, nil}
   defp reverse({:create, %Constraint{} = constraint}),
-    do: {:drop, constraint}
+    do: {:drop, constraint, nil}
 
   defp reverse(_command), do: false
 
@@ -361,27 +361,27 @@ defmodule Ecto.Migration.Runner do
     do: "create table if not exists #{quote_name(table.prefix, table.name)}"
   defp command({:alter, %Table{} = table, _}),
     do: "alter table #{quote_name(table.prefix, table.name)}"
-  defp command({:drop, %Table{} = table}),
-    do: "drop table #{quote_name(table.prefix, table.name)}"
   defp command({:drop, %Table{} = table, :cascade}),
-    do: command({:drop, table}) <> " cascade"
-  defp command({:drop_if_exists, %Table{} = table}),
-    do: "drop table if exists #{quote_name(table.prefix, table.name)}"
+    do: command({:drop, table, nil}) <> " cascade"
+  defp command({:drop, %Table{} = table, _}),
+    do: "drop table #{quote_name(table.prefix, table.name)}"
   defp command({:drop_if_exists, %Table{} = table, :cascade}),
-    do: command({:drop_if_exists, table}) <> " cascade"
+    do: command({:drop_if_exists, table, nil}) <> " cascade"
+  defp command({:drop_if_exists, %Table{} = table, _}),
+    do: "drop table if exists #{quote_name(table.prefix, table.name)}"
 
   defp command({:create, %Index{} = index}),
     do: "create index #{quote_name(index.prefix, index.name)}"
   defp command({:create_if_not_exists, %Index{} = index}),
     do: "create index if not exists #{quote_name(index.prefix, index.name)}"
-  defp command({:drop, %Index{} = index}),
-    do: "drop index #{quote_name(index.prefix, index.name)}"
   defp command({:drop, %Index{} = index, :cascade}),
-    do: command({:drop, index}) <> " cascade"
-  defp command({:drop_if_exists, %Index{} = index}),
-    do: "drop index if exists #{quote_name(index.prefix, index.name)}"
+    do: command({:drop, index, nil}) <> " cascade"
+  defp command({:drop, %Index{} = index, _}),
+    do: "drop index #{quote_name(index.prefix, index.name)}"
   defp command({:drop_if_exists, %Index{} = index, :cascade}),
-    do: command({:drop_if_exists, index}) <> " cascade"
+    do: command({:drop_if_exists, index, nil}) <> " cascade"
+  defp command({:drop_if_exists, %Index{} = index, _}),
+    do: "drop index if exists #{quote_name(index.prefix, index.name)}"
   defp command({:rename, %Table{} = current_table, %Table{} = new_table}),
     do: "rename table #{quote_name(current_table.prefix, current_table.name)} to #{quote_name(new_table.prefix, new_table.name)}"
   defp command({:rename, %Table{} = table, current_column, new_column}),
@@ -395,14 +395,10 @@ defmodule Ecto.Migration.Runner do
     do: "create check constraint #{constraint.name} on table #{quote_name(constraint.prefix, constraint.table)}"
   defp command({:create, %Constraint{exclude: exclude} = constraint}) when is_binary(exclude),
     do: "create exclude constraint #{constraint.name} on table #{quote_name(constraint.prefix, constraint.table)}"
-  defp command({:drop, %Constraint{} = constraint}),
-    do: "drop constraint #{constraint.name} from table #{quote_name(constraint.prefix, constraint.table)}"
   defp command({:drop, %Constraint{} = constraint, _}),
-    do: command({:drop, constraint})
-  defp command({:drop_if_exists, %Constraint{} = constraint}),
-    do: "drop constraint if exists #{constraint.name} from table #{quote_name(constraint.prefix, constraint.table)}"
+    do: "drop constraint #{constraint.name} from table #{quote_name(constraint.prefix, constraint.table)}"
   defp command({:drop_if_exists, %Constraint{} = constraint, _}),
-    do: command({:drop_if_exists, constraint})
+    do: "drop constraint if exists #{constraint.name} from table #{quote_name(constraint.prefix, constraint.table)}"
 
   defp quote_name(nil, name), do: quote_name(name)
   defp quote_name(prefix, name), do: quote_name(prefix) <> "." <> quote_name(name)

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -1213,12 +1213,12 @@ defmodule Ecto.Adapters.MyXQLTest do
   end
 
   test "drop table" do
-    drop = {:drop, table(:posts)}
+    drop = {:drop, table(:posts), nil}
     assert execute_ddl(drop) == [~s|DROP TABLE `posts`|]
   end
 
   test "drop table with prefixes" do
-    drop = {:drop, table(:posts, prefix: :foo)}
+    drop = {:drop, table(:posts, prefix: :foo), nil}
     assert execute_ddl(drop) == [~s|DROP TABLE `foo`.`posts`|]
   end
 

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -1224,13 +1224,13 @@ defmodule Ecto.Adapters.MyXQLTest do
 
   test "drop constraint" do
     assert_raise ArgumentError, ~r/MySQL adapter does not support constraints/, fn ->
-      execute_ddl({:drop, constraint(:products, "price_must_be_positive", prefix: :foo)})
+      execute_ddl({:drop, constraint(:products, "price_must_be_positive", prefix: :foo), nil})
     end
   end
 
   test "drop_if_exists constraint" do
     assert_raise ArgumentError, ~r/MySQL adapter does not support constraints/, fn ->
-      execute_ddl({:drop_if_exists, constraint(:products, "price_must_be_positive", prefix: :foo)})
+      execute_ddl({:drop_if_exists, constraint(:products, "price_must_be_positive", prefix: :foo), nil})
     end
   end
 
@@ -1368,12 +1368,12 @@ defmodule Ecto.Adapters.MyXQLTest do
   end
 
   test "drop index" do
-    drop = {:drop, index(:posts, [:id], name: "posts$main")}
+    drop = {:drop, index(:posts, [:id], name: "posts$main"), nil}
     assert execute_ddl(drop) == [~s|DROP INDEX `posts$main` ON `posts`|]
   end
 
   test "drop index with prefix" do
-    drop = {:drop, index(:posts, [:id], name: "posts$main", prefix: :foo)}
+    drop = {:drop, index(:posts, [:id], name: "posts$main", prefix: :foo), nil}
     assert execute_ddl(drop) == [~s|DROP INDEX `posts$main` ON `foo`.`posts`|]
   end
 

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1480,6 +1480,14 @@ defmodule Ecto.Adapters.PostgresTest do
     assert execute_ddl(drop) == [~s|DROP TABLE "foo"."posts"|]
   end
 
+  test "drop table with cascade" do
+    drop = {:drop, table(:posts), :cascade}
+    assert execute_ddl(drop) == [~s|DROP TABLE "posts" CASCADE|]
+
+    drop = {:drop, table(:posts, prefix: :foo), :cascade}
+    assert execute_ddl(drop) == [~s|DROP TABLE "foo"."posts" CASCADE|]
+  end
+
   test "alter table" do
     alter = {:alter, table(:posts),
              [{:add, :title, :string, [default: "Untitled", size: 100, null: false]},
@@ -1680,6 +1688,14 @@ defmodule Ecto.Adapters.PostgresTest do
     index = index(:posts, [:id], name: "posts$main")
     drop = {:drop, %{index | concurrently: true}}
     assert execute_ddl(drop) == [~s|DROP INDEX CONCURRENTLY "posts$main"|]
+  end
+
+  test "drop index with cascade" do
+    drop = {:drop, index(:posts, [:id], name: "posts$main"), :cascade}
+    assert execute_ddl(drop) == [~s|DROP INDEX "posts$main" CASCADE|]
+
+    drop = {:drop, index(:posts, [:id], name: "posts$main", prefix: :foo), :cascade}
+    assert execute_ddl(drop) == [~s|DROP INDEX "foo"."posts$main" CASCADE|]
   end
 
   test "create check constraint" do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1471,12 +1471,12 @@ defmodule Ecto.Adapters.PostgresTest do
   end
 
   test "drop table" do
-    drop = {:drop, table(:posts)}
+    drop = {:drop, table(:posts), nil}
     assert execute_ddl(drop) == [~s|DROP TABLE "posts"|]
   end
 
   test "drop table with prefix" do
-    drop = {:drop, table(:posts, prefix: :foo)}
+    drop = {:drop, table(:posts, prefix: :foo), nil}
     assert execute_ddl(drop) == [~s|DROP TABLE "foo"."posts"|]
   end
 
@@ -1675,18 +1675,18 @@ defmodule Ecto.Adapters.PostgresTest do
   end
 
   test "drop index" do
-    drop = {:drop, index(:posts, [:id], name: "posts$main")}
+    drop = {:drop, index(:posts, [:id], name: "posts$main"), nil}
     assert execute_ddl(drop) == [~s|DROP INDEX "posts$main"|]
   end
 
   test "drop index with prefix" do
-    drop = {:drop, index(:posts, [:id], name: "posts$main", prefix: :foo)}
+    drop = {:drop, index(:posts, [:id], name: "posts$main", prefix: :foo), nil}
     assert execute_ddl(drop) == [~s|DROP INDEX "foo"."posts$main"|]
   end
 
   test "drop index concurrently" do
     index = index(:posts, [:id], name: "posts$main")
-    drop = {:drop, %{index | concurrently: true}}
+    drop = {:drop, %{index | concurrently: true}, nil}
     assert execute_ddl(drop) == [~s|DROP INDEX CONCURRENTLY "posts$main"|]
   end
 
@@ -1728,21 +1728,21 @@ defmodule Ecto.Adapters.PostgresTest do
   end
 
   test "drop constraint" do
-    drop = {:drop, constraint(:products, "price_must_be_positive")}
+    drop = {:drop, constraint(:products, "price_must_be_positive"), nil}
     assert execute_ddl(drop) ==
       [~s|ALTER TABLE "products" DROP CONSTRAINT "price_must_be_positive"|]
 
-    drop = {:drop, constraint(:products, "price_must_be_positive", prefix: "foo")}
+    drop = {:drop, constraint(:products, "price_must_be_positive", prefix: "foo"), nil}
     assert execute_ddl(drop) ==
       [~s|ALTER TABLE "foo"."products" DROP CONSTRAINT "price_must_be_positive"|]
   end
 
   test "drop_if_exists constraint" do
-    drop = {:drop_if_exists, constraint(:products, "price_must_be_positive")}
+    drop = {:drop_if_exists, constraint(:products, "price_must_be_positive"), nil}
     assert execute_ddl(drop) ==
       [~s|ALTER TABLE "products" DROP CONSTRAINT IF EXISTS "price_must_be_positive"|]
 
-    drop = {:drop_if_exists, constraint(:products, "price_must_be_positive", prefix: "foo")}
+    drop = {:drop_if_exists, constraint(:products, "price_must_be_positive", prefix: "foo"), nil}
     assert execute_ddl(drop) ==
       [~s|ALTER TABLE "foo"."products" DROP CONSTRAINT IF EXISTS "price_must_be_positive"|]
   end

--- a/test/ecto/adapters/tds_test.exs
+++ b/test/ecto/adapters/tds_test.exs
@@ -1258,6 +1258,12 @@ defmodule Ecto.Adapters.TdsTest do
   test "drop table" do
     drop = {:drop, table(:posts), nil}
     assert execute_ddl(drop) == ["DROP TABLE [posts]; "]
+
+    drop_cascade = {:drop, table(:posts), :cascade}
+
+    assert_raise ArgumentError, ~r"MSSQL does not support `CASCADE` in DROP TABLE commands", fn ->
+      execute_ddl(drop_cascade)
+    end
   end
 
   test "drop table with prefixes" do
@@ -1376,6 +1382,12 @@ defmodule Ecto.Adapters.TdsTest do
 
     assert execute_ddl(drop) ==
              [~s|ALTER TABLE [foo].[products] DROP CONSTRAINT [price_must_be_positive]; |]
+
+    drop_cascade = {:drop, constraint(:products, "price_must_be_positive"), :cascade}
+
+    assert_raise ArgumentError, ~r"MSSQL does not support `CASCADE` in DROP CONSTRAINT commands", fn ->
+      execute_ddl(drop_cascade)
+    end
   end
 
   test "drop_if_exists constraint" do
@@ -1399,6 +1411,12 @@ defmodule Ecto.Adapters.TdsTest do
                  "AND [CONSTRAINT_SCHEMA] = N'foo') " <>
                  "ALTER TABLE [foo].[products] DROP CONSTRAINT [price_must_be_positive]; "
              ]
+
+    drop_cascade = {:drop_if_exists, constraint(:products, "price_must_be_positive"), :cascade}
+
+    assert_raise ArgumentError, ~r"MSSQL does not support `CASCADE` in DROP CONSTRAINT commands", fn ->
+      execute_ddl(drop_cascade)
+    end
   end
 
   test "rename table" do
@@ -1497,6 +1515,12 @@ defmodule Ecto.Adapters.TdsTest do
   test "drop index" do
     drop = {:drop, index(:posts, [:id], name: "posts$main"), nil}
     assert execute_ddl(drop) == [~s|DROP INDEX [posts$main] ON [posts]; |]
+
+    drop_cascade = {:drop, index(:posts, [:id], name: "posts$main"), :cascade}
+
+    assert_raise ArgumentError, ~r"MSSQL does not support `CASCADE` in DROP INDEX commands", fn ->
+      execute_ddl(drop_cascade)
+    end
   end
 
   test "drop index with prefix" do
@@ -1522,6 +1546,14 @@ defmodule Ecto.Adapters.TdsTest do
                |> remove_newlines
                |> Kernel.<>(" ")
              ]
+
+    drop_cascade =
+      {:drop_if_exists,
+      index(:posts, [:id], name: "posts_category_id_permalink_index", prefix: :foo), :cascade}
+
+    assert_raise ArgumentError, ~r"MSSQL does not support `CASCADE` in DROP INDEX commands", fn ->
+      execute_ddl(drop_cascade)
+    end
   end
 
   test "drop index asserting concurrency" do

--- a/test/ecto/adapters/tds_test.exs
+++ b/test/ecto/adapters/tds_test.exs
@@ -1256,12 +1256,12 @@ defmodule Ecto.Adapters.TdsTest do
   end
 
   test "drop table" do
-    drop = {:drop, table(:posts)}
+    drop = {:drop, table(:posts), nil}
     assert execute_ddl(drop) == ["DROP TABLE [posts]; "]
   end
 
   test "drop table with prefixes" do
-    drop = {:drop, table(:posts, prefix: :foo)}
+    drop = {:drop, table(:posts, prefix: :foo), nil}
     assert execute_ddl(drop) == ["DROP TABLE [foo].[posts]; "]
   end
 
@@ -1367,19 +1367,19 @@ defmodule Ecto.Adapters.TdsTest do
   end
 
   test "drop constraint" do
-    drop = {:drop, constraint(:products, "price_must_be_positive")}
+    drop = {:drop, constraint(:products, "price_must_be_positive"), nil}
 
     assert execute_ddl(drop) ==
              [~s|ALTER TABLE [products] DROP CONSTRAINT [price_must_be_positive]; |]
 
-    drop = {:drop, constraint(:products, "price_must_be_positive", prefix: "foo")}
+    drop = {:drop, constraint(:products, "price_must_be_positive", prefix: "foo"), nil}
 
     assert execute_ddl(drop) ==
              [~s|ALTER TABLE [foo].[products] DROP CONSTRAINT [price_must_be_positive]; |]
   end
 
   test "drop_if_exists constraint" do
-    drop = {:drop_if_exists, constraint(:products, "price_must_be_positive")}
+    drop = {:drop_if_exists, constraint(:products, "price_must_be_positive"), nil}
 
     assert execute_ddl(drop) ==
              [
@@ -1389,7 +1389,7 @@ defmodule Ecto.Adapters.TdsTest do
                  "ALTER TABLE [products] DROP CONSTRAINT [price_must_be_positive]; "
              ]
 
-    drop = {:drop_if_exists, constraint(:products, "price_must_be_positive", prefix: "foo")}
+    drop = {:drop_if_exists, constraint(:products, "price_must_be_positive", prefix: "foo"), nil}
 
     assert execute_ddl(drop) ==
              [
@@ -1495,12 +1495,12 @@ defmodule Ecto.Adapters.TdsTest do
   end
 
   test "drop index" do
-    drop = {:drop, index(:posts, [:id], name: "posts$main")}
+    drop = {:drop, index(:posts, [:id], name: "posts$main"), nil}
     assert execute_ddl(drop) == [~s|DROP INDEX [posts$main] ON [posts]; |]
   end
 
   test "drop index with prefix" do
-    drop = {:drop, index(:posts, [:id], name: "posts_category_id_permalink_index", prefix: :foo)}
+    drop = {:drop, index(:posts, [:id], name: "posts_category_id_permalink_index", prefix: :foo), nil}
 
     assert execute_ddl(drop) ==
              [~s|DROP INDEX [posts_category_id_permalink_index] ON [foo].[posts]; |]
@@ -1509,7 +1509,7 @@ defmodule Ecto.Adapters.TdsTest do
   test "drop index with prefix if exists" do
     drop =
       {:drop_if_exists,
-       index(:posts, [:id], name: "posts_category_id_permalink_index", prefix: :foo)}
+       index(:posts, [:id], name: "posts_category_id_permalink_index", prefix: :foo), nil}
 
     assert execute_ddl(drop) ==
              [
@@ -1525,7 +1525,7 @@ defmodule Ecto.Adapters.TdsTest do
   end
 
   test "drop index asserting concurrency" do
-    drop = {:drop, index(:posts, [:id], name: "posts$main", concurrently: true)}
+    drop = {:drop, index(:posts, [:id], name: "posts$main", concurrently: true), nil}
     assert execute_ddl(drop) == [~s|DROP INDEX [posts$main] ON [posts] LOCK=NONE; |]
   end
 

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -397,26 +397,26 @@ defmodule Ecto.MigrationTest do
   test "forward: drops a table" do
     result = drop table(:posts)
     flush()
-    assert {:drop, %Table{}} = last_command()
+    assert {:drop, %Table{}, _} = last_command()
     assert result == table(:posts)
   end
 
   test "forward: drops a table if table exists" do
     result = drop_if_exists table(:posts)
     flush()
-    assert {:drop_if_exists, %Table{}} = last_command()
+    assert {:drop_if_exists, %Table{}, _} = last_command()
     assert result == table(:posts)
   end
 
   test "forward: drops a table with cascade" do
-    result = drop table(:posts), cascade: true
+    result = drop table(:posts), mode: :cascade
     flush()
     assert {:drop, %Table{}, :cascade} = last_command()
     assert result == table(:posts)
   end
 
   test "forward: drops a table if table exists with cascade" do
-    result = drop_if_exists table(:posts), cascade: true
+    result = drop_if_exists table(:posts), mode: :cascade
     flush()
     assert {:drop_if_exists, %Table{}, :cascade} = last_command()
     assert result == table(:posts)
@@ -455,11 +455,11 @@ defmodule Ecto.MigrationTest do
   test "forward: drops an index" do
     drop index(:posts, [:title])
     flush()
-    assert {:drop, %Index{}} = last_command()
+    assert {:drop, %Index{}, _} = last_command()
   end
 
   test "forward: drops an index with cascade" do
-    drop index(:posts, [:title]), cascade: true
+    drop index(:posts, [:title]), mode: :cascade
     flush()
     assert {:drop, %Index{}, :cascade} = last_command()
   end
@@ -467,13 +467,13 @@ defmodule Ecto.MigrationTest do
   test "forward: drops a constraint" do
     drop constraint(:posts, :price)
     flush()
-    assert {:drop, %Constraint{}} = last_command()
+    assert {:drop, %Constraint{}, _} = last_command()
   end
 
   test "forward: drops a constraint if constraint exists" do
     drop_if_exists constraint(:posts, :price)
     flush()
-    assert {:drop_if_exists, %Constraint{}} = last_command()
+    assert {:drop_if_exists, %Constraint{}, _} = last_command()
   end
 
   test "forward: renames a table" do
@@ -559,7 +559,7 @@ defmodule Ecto.MigrationTest do
   test "forward: drops a table with prefix from migration" do
     drop(table(:posts, prefix: "foo"))
     flush()
-    {:drop, table} = last_command()
+    {:drop, table, _} = last_command()
     assert table.prefix == "foo"
   end
 
@@ -567,7 +567,7 @@ defmodule Ecto.MigrationTest do
   test "forward: drops a table with prefix from manager" do
     drop(table(:posts))
     flush()
-    {:drop, table} = last_command()
+    {:drop, table, _} = last_command()
     assert table.prefix == "foo"
   end
 
@@ -575,7 +575,7 @@ defmodule Ecto.MigrationTest do
   test "forward: drops a table with prefix from configuration" do
     drop(table(:posts))
     flush()
-    {:drop, table} = last_command()
+    {:drop, table, _} = last_command()
     assert table.prefix == "baz"
   end
 
@@ -634,7 +634,7 @@ defmodule Ecto.MigrationTest do
   test "forward: drops an index with a prefix from migration" do
     drop index(:posts, [:title], prefix: "foo")
     flush()
-    {_, index} = last_command()
+    {_, index, _} = last_command()
     assert index.prefix == "foo"
   end
 
@@ -642,7 +642,7 @@ defmodule Ecto.MigrationTest do
   test "forward: drops an index with a prefix from manager" do
     drop index(:posts, [:title])
     flush()
-    {_, index} = last_command()
+    {_, index, _} = last_command()
     assert index.prefix == "foo"
   end
 
@@ -650,7 +650,7 @@ defmodule Ecto.MigrationTest do
   test "forward: drops an index with a prefix from configuration" do
     drop index(:posts, [:title])
     flush()
-    {_, index} = last_command()
+    {_, index, _} = last_command()
     assert index.prefix == "baz"
   end
 
@@ -694,7 +694,7 @@ defmodule Ecto.MigrationTest do
     end
     flush()
 
-    assert last_command() == {:drop, table}
+    assert last_command() == {:drop, table, nil}
   end
 
   test "backward: creates a table if not exists" do
@@ -704,14 +704,14 @@ defmodule Ecto.MigrationTest do
     end
     flush()
 
-    assert last_command() == {:drop_if_exists, table}
+    assert last_command() == {:drop_if_exists, table, nil}
   end
 
   test "backward: creates an empty table" do
     create table = table(:posts)
     flush()
 
-    assert last_command() == {:drop, table}
+    assert last_command() == {:drop, table, :nil}
   end
 
   test "backward: alters a table" do
@@ -783,13 +783,13 @@ defmodule Ecto.MigrationTest do
   test "backward: creates an index" do
     create index(:posts, [:title])
     flush()
-    assert {:drop, %Index{}} = last_command()
+    assert {:drop, %Index{}, _} = last_command()
   end
 
   test "backward: creates an index if not exists" do
     create_if_not_exists index(:posts, [:title])
     flush()
-    assert {:drop_if_exists, %Index{}} = last_command()
+    assert {:drop_if_exists, %Index{}, _} = last_command()
   end
 
   test "backward: drops an index" do

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -408,6 +408,20 @@ defmodule Ecto.MigrationTest do
     assert result == table(:posts)
   end
 
+  test "forward: drops a table with cascade" do
+    result = drop table(:posts), cascade: true
+    flush()
+    assert {:drop, %Table{}, :cascade} = last_command()
+    assert result == table(:posts)
+  end
+
+  test "forward: drops a table if table exists with cascade" do
+    result = drop_if_exists table(:posts), cascade: true
+    flush()
+    assert {:drop_if_exists, %Table{}, :cascade} = last_command()
+    assert result == table(:posts)
+  end
+
   test "forward: creates an index" do
     create index(:posts, [:title])
     flush()
@@ -442,6 +456,12 @@ defmodule Ecto.MigrationTest do
     drop index(:posts, [:title])
     flush()
     assert {:drop, %Index{}} = last_command()
+  end
+
+  test "forward: drops an index with cascade" do
+    drop index(:posts, [:title]), cascade: true
+    flush()
+    assert {:drop, %Index{}, :cascade} = last_command()
   end
 
   test "forward: drops a constraint" do


### PR DESCRIPTION
This PR provides the ability to add the `CASCADE` option to `DROP` commands in migrations, on tables and indexes.
The default option on all DROP commands is always `RESTRICT` (implied default)

PostgreSQL documentation: 
- https://www.postgresql.org/docs/current/sql-droptable.html
- https://www.postgresql.org/docs/current/sql-dropindex.html

MySQL documentation:
- https://dev.mysql.com/doc/refman/8.0/en/drop-table.html
- no support on `DROP INDEX` for `CASCADE` or `RESTRICT`

TDS/MSSQL:
- Does not support `CASCADE` | `RESTRICT` params for any `DROP` command.

Migration `drop` commands [will now support](https://github.com/elixir-ecto/ecto_sql/pull/298/files#diff-da3c3b102234918cbfd1348495384893ed67e47302c350051d1d78eeb1ecf6fc) `mode :cascade` option

Examples:
`drop table("users"), mode: :cascade` -> `DROP TABLE "users" CASCADE`
`drop_if_exists table("users"), mode: :cascade` -> `DROP TABLE IF EXISTS "users" CASCADE`
`drop index("posts", [:name]), mode: :cascade` -> `DROP INDEX posts_name_index CASCADE`
`drop_if_exists index("posts", [:name]), mode: :cascade` -> `DROP INDEX IF EXISTS posts_name_index CASCADE`