### PR TITLE
use pid instead of process name in `allow` example

### DIFF
--- a/lib/ecto/adapters/sql/sandbox.ex
+++ b/lib/ecto/adapters/sql/sandbox.ex
@@ -93,7 +93,8 @@ defmodule Ecto.Adapters.SQL.Sandbox do
   to collaborate over the same connection. Let's give it a try:
 
       test "calls worker that runs a query" do
-        Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), MyApp.Worker)
+        allow = Process.whereis(MyApp.Worker)
+        Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), allow)
         GenServer.call(MyApp.Worker, :run_query)
       end
 


### PR DESCRIPTION
It seems like `allow/3` [expects](https://github.com/elixir-ecto/db_connection/blob/a588895d35ae8913ab1d86d734df9129f0c59855/lib/db_connection/ownership/manager.ex#L38) a pid to be given.