### PR TITLE
Use `:socket_dir` connection params for `mix ecto.load` on Postgres

### DIFF
--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -343,7 +343,15 @@ defmodule Ecto.Adapters.Postgres do
     args =
       if port = opts[:port], do: ["-p", to_string(port)|args], else: args
 
-    host = opts[:socket] || opts[:socket_dir] || opts[:hostname] || System.get_env("PGHOST") || "localhost"
+    host = opts[:socket_dir] || opts[:hostname] || System.get_env("PGHOST") || "localhost"
+
+    if opts[:socket] do
+      IO.warn("""
+      Using `:socket` connection option is not supported by some operations on `Ecto.Adapters.Postgres`.
+      Trying to connect using fallback options...
+      """)
+    end
+
     args = ["--host", host|args]
     args = args ++ opt_args
     System.cmd(cmd, args, env: env, stderr_to_stdout: true)

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -346,10 +346,10 @@ defmodule Ecto.Adapters.Postgres do
     host = opts[:socket_dir] || opts[:hostname] || System.get_env("PGHOST") || "localhost"
 
     if opts[:socket] do
-      IO.warn("""
-      Using `:socket` connection option is not supported by some operations on `Ecto.Adapters.Postgres`.
-      Trying to connect using fallback options...
-      """)
+      IO.warn(
+        ":socket option is ignored when connecting in structure_load/2 and structure_dump/2," <>
+          " use :socket_dir or :hostname instead"
+      )
     end
 
     args = ["--host", host|args]

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -343,7 +343,7 @@ defmodule Ecto.Adapters.Postgres do
     args =
       if port = opts[:port], do: ["-p", to_string(port)|args], else: args
 
-    host = opts[:hostname] || System.get_env("PGHOST") || "localhost"
+    host = opts[:socket] || opts[:socket_dir] || opts[:hostname] || System.get_env("PGHOST") || "localhost"
     args = ["--host", host|args]
     args = args ++ opt_args
     System.cmd(cmd, args, env: env, stderr_to_stdout: true)


### PR DESCRIPTION
Operations using `psql` on Postgres adapter (i.e. `ecto.load`) now pass `:socket`/ `:socket_dir` as `--host` parameter if specified, mirroring behaviour of Postgrex.

Closes #306.