### PR TITLE
fix: parent_as when used at right side of a combining expression

### DIFF
--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -534,7 +534,7 @@ if Code.ensure_loaded?(MyXQL) do
     end
 
     defp expr(%Ecto.SubQuery{query: query}, sources, _query) do
-      query = put_in(query.aliases[@parent_as], sources)
+      query = put_parent_as_alias(query, sources)
       [?(, all(query, subquery_as_prefix(sources)), ?)]
     end
 
@@ -1080,6 +1080,14 @@ if Code.ensure_loaded?(MyXQL) do
     end
     defp error!(query, message) do
       raise Ecto.QueryError, query: query, message: message
+    end
+
+    defp put_parent_as_alias(query, sources) do
+      query = put_in(query.aliases[@parent_as], sources)
+      combinations = Enum.map(query.combinations, fn {type, combination_query} ->
+        {type, put_parent_as_alias(combination_query, sources)}
+      end)
+      %{query | combinations: combinations}
     end
   end
 end

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -624,7 +624,7 @@ if Code.ensure_loaded?(Postgrex) do
     end
 
     defp expr(%Ecto.SubQuery{query: query}, sources, _query) do
-      query = put_in(query.aliases[@parent_as], sources)
+      query = put_parent_as_alias(query, sources)
       [?(, all(query, subquery_as_prefix(sources)), ?)]
     end
 
@@ -1315,6 +1315,14 @@ if Code.ensure_loaded?(Postgrex) do
     end
     defp error!(query, message) do
       raise Ecto.QueryError, query: query, message: message
+    end
+
+    defp put_parent_as_alias(query, sources) do
+      query = put_in(query.aliases[@parent_as], sources)
+      combinations = Enum.map(query.combinations, fn {type, combination_query} ->
+        {type, put_parent_as_alias(combination_query, sources)}
+      end)
+      %{query | combinations: combinations}
     end
   end
 end

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -610,6 +610,17 @@ defmodule Ecto.Adapters.PostgresTest do
            ~s{WHERE (c0."post_id" IN (SELECT sp0."id" FROM "posts" AS sp0 WHERE (sp0."title" = c0."subtitle")))}
   end
 
+  test "subquery using parent_as at the right side of a union expression" do
+    comments = "comments" |> where([c], c.post_id == parent_as(:posts).id) |> select(:true)
+    query = "posts" |> from(as: :posts) |> where([p], exists(union(comments, ^comments))) |> select([p], p.id) |> plan()
+
+    assert all(query) == """
+    SELECT p0."id" FROM "posts" AS p0 \
+    WHERE (exists((SELECT TRUE FROM "comments" AS sc0 WHERE (sc0."post_id" = p0."id") \
+    UNION (SELECT TRUE FROM "comments" AS c0 WHERE (c0."post_id" = p0."id")))))\
+    """
+  end
+
   test "having" do
     query = Schema |> having([p], p.x == p.x) |> select([], true) |> plan()
     assert all(query) == ~s{SELECT TRUE FROM "schema" AS s0 HAVING (s0."x" = s0."x")}


### PR DESCRIPTION
_Notice: it depends on https://github.com/elixir-ecto/ecto/pull/3627_

This patch fixes a bug in which is impossible to compile and execute a
query using `parent_as` at the right side of a union expression (or
any other type of combination). As an example, consider the following
query:

```
  subquery = from(c in Comments, where: parent_as(:posts).id == c.post_id)
  from(p in Posts, where: exists(union_all(subquery, ^subquery)))
```

This query should fail to compile with the following error:

```
** (Ecto.SubQueryError) the following exception happened when compiling a subquery.
    ** (Ecto.QueryError) `parent_as(:post)` can only be used in subqueries in query:
```

After ecto is fixed and the queries compiles, there is a runtime
problem that occurs when you execute that query. It happens because
the alias can't be found when the query is actually
executed:

```
** (ArgumentError) argument error
  :erlang.element(1, nil)
  (ecto_sql 3.6.1) lib/ecto/adapters/postgres/connection.ex:1215: Ecto.Adapters.Postgres.Connection.quote_qualified_name/3
  (ecto_sql 3.6.1) lib/ecto/adapters/postgres/connection.ex:697: Ecto.Adapters.Postgres.Connection.expr/3
  ...
```

Similarly to what has been done in the ecto PR, we modify the code to
include the alias in all combining expressions related to the subquery.