### PR TITLE
Make `modify/3` with `:null` option reversible

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1017,7 +1017,8 @@ defmodule Ecto.Migration do
 
   ## Options
 
-    * `:null` - determines whether the column accepts null values.
+    * `:null` - determines whether the column accepts null values (the value will be negated
+       when run in reverse).
     * `:default` - changes the default value of the column.
     * `:from` - specifies the current type of the column.
     * `:size` - specifies the size of the type (for example, the number of characters).

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -253,8 +253,16 @@ defmodule Ecto.Migration.Runner do
   end
   defp table_reverse([{:modify, name, type, opts} | t], acc) do
     case opts[:from] do
-      nil -> false
-      from -> table_reverse(t, [{:modify, name, from, Keyword.put(opts, :from, type)} | acc])
+      nil ->
+        false
+
+      from ->
+        opts = Keyword.put(opts, :from, type)
+
+        case opts[:null] do
+          nil -> table_reverse(t, [{:modify, name, from, opts} | acc])
+          null -> table_reverse(t, [{:modify, name, from, Keyword.put(opts, :null, !null)} | acc])
+        end
     end
   end
   defp table_reverse([{:add, name, _type, _opts} | t], acc) do

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -698,12 +698,15 @@ defmodule Ecto.MigrationTest do
     alter table(:posts) do
       add :summary, :text
       modify :extension, :text, from: :string
+      modify :title, :string, null: false, from: :string
     end
     flush()
 
     assert last_command() ==
            {:alter, %Table{name: "posts"},
-              [{:modify, :extension, :string, from: :text}, {:remove, :summary}]}
+              [{:modify, :title, :string, null: true, from: :string},
+               {:modify, :extension, :string, from: :text},
+               {:remove, :summary}]}
 
     assert_raise Ecto.MigrationError, ~r/cannot reverse migration command/, fn ->
       alter table(:posts) do


### PR DESCRIPTION
`modify/3` has always accepted the null option, but it never properly
migrated it when it would be run backwards. Since modifying a column
only requires the `:null` option if it has to be changed, Ecto should be
safe to assume the opposite of the passed value is the reverse of it.

This doesn't yet contain any documentation updates, since it never
mentioned that `null` options wouldn't be reversed. I think it would
be helpful to add a notice, maybe:

```diff
-    * `:null` - determines whether the column accepts null values.
+    * `:null` - determines whether the column accepts null values (the value will be negated
+       when run in reverse).
```