### PR TITLE
format_tuple_list/1 function

### DIFF
--- a/integration_test/sql/sql.exs
+++ b/integration_test/sql/sql.exs
@@ -151,4 +151,17 @@ defmodule Ecto.Integration.SQLTest do
     assert Ecto.Adapters.SQL.format_table(%{columns: ["test"], rows: []}) == "+------+\n| test |\n+------+\n+------+"
     assert Ecto.Adapters.SQL.format_table(%{columns: ["test"], rows: nil}) == "+------+\n| test |\n+------+\n+------+"
   end
+
+  test "format_tuple_list a filled result" do
+    assert Ecto.Adapters.SQL.format_tuple_list(%{columns: ["name", "number"], rows: [["Joe", 1], ["Kate", nil]]})  == [[{"name", "Joe"}, {"number", 1}], [{"name", "Kate"}, {"number", nil}]]
+  end
+
+  test "format_tuple_list edge cases" do
+    assert Ecto.Adapters.SQL.format_tuple_list(nil) == []
+    assert Ecto.Adapters.SQL.format_tuple_list(%{columns: nil, rows: nil}) == []
+    assert Ecto.Adapters.SQL.format_tuple_list(%{columns: [], rows: []}) == []
+    assert Ecto.Adapters.SQL.format_tuple_list(%{columns: [], rows: [["test"]]}) == []
+    assert Ecto.Adapters.SQL.format_tuple_list(%{columns: ["test"], rows: []}) == []
+    assert Ecto.Adapters.SQL.format_tuple_list(%{columns: ["test"], rows: nil}) == []
+  end
 end

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -458,7 +458,7 @@ defmodule Ecto.Adapters.SQL do
       +---------------+---------+--------+
 
   """
-  @spec format_table(%{columns: [String.t] | nil, rows: [term()] | nil}) :: String.t
+  @spec format_table(%{columns: [String.t] | nil, rows: [term()] | nil} | nil) :: String.t
   def format_table(result)
 
   def format_table(nil), do: ""
@@ -488,6 +488,38 @@ defmodule Ecto.Adapters.SQL do
     |> IO.iodata_to_binary()
   end
 
+  @doc """
+  Returns a tuple list for a given query `result`.
+  It's useful when reading the result of a query with a lot of columns,
+  a situation when `format_table/1` has little use.
+
+
+  ## Examples
+
+      iex> Ecto.Adapters.SQL.format_tuple_list(query)
+      [
+        [
+          {"title", "My Post Title"},
+          {"counter", 1},
+          {"public", nil},
+        ]
+      ]
+
+  """
+  @spec format_tuple_list(%{columns: [String.t] | nil, rows: [term()] | nil} | nil) :: list()
+  def format_tuple_list(result)
+
+  def format_tuple_list(nil), do: []
+  def format_tuple_list(%{columns: nil}), do: []
+  def format_tuple_list(%{columns: []}), do: []
+  def format_tuple_list(%{rows: nil}), do: []
+  def format_tuple_list(%{rows: []}), do: []
+
+  def format_tuple_list(%{columns: columns, rows: rows}) do
+    Enum.map(rows, fn row ->
+      Enum.zip(columns, row)
+    end)
+  end
 
   defp binary_length(nil), do: 4 # NULL
   defp binary_length(binary) when is_binary(binary), do: String.length(binary)


### PR DESCRIPTION
Adds a new function, `format_tuple_list/1`, that helps reading results that are too big for `format_table/1` to be of any use.