### PR TITLE
Add MyXQL support for lateral joins

### DIFF
--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -359,11 +359,12 @@ if Code.ensure_loaded?(MyXQL) do
     defp join_on(_qual, expr, sources, query), do: [" ON " | expr(expr, sources, query)]
 
     defp join_qual(:inner, _), do: " INNER JOIN "
+    defp join_qual(:inner_lateral, _), do: " INNER JOIN LATERAL "
     defp join_qual(:left, _),  do: " LEFT OUTER JOIN "
+    defp join_qual(:left_lateral, _),  do: " LEFT OUTER JOIN LATERAL "
     defp join_qual(:right, _), do: " RIGHT OUTER JOIN "
     defp join_qual(:full, _),  do: " FULL OUTER JOIN "
     defp join_qual(:cross, _), do: " CROSS JOIN "
-    defp join_qual(mode, q),   do: error!(q, "join `#{inspect mode}` not supported by MySQL")
 
     defp where(%{wheres: wheres} = query, sources) do
       boolean(" WHERE ", wheres, sources, query)


### PR DESCRIPTION
Lateral joins were added to MySQL in v8.0.14: https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-14.html#mysqld-8-0-14-sql-syntax