### PR TITLE
Added missing word to mode/2 docs

### DIFF
--- a/lib/ecto/adapters/sql/sandbox.ex
+++ b/lib/ecto/adapters/sql/sandbox.ex
@@ -442,7 +442,7 @@ defmodule Ecto.Adapters.SQL.Sandbox do
       you can change the mode to `{:shared, pid}`, where pid is the process
       that owns the connection, most often `{:shared, self()}`. This makes it
       so all processes can use the same connection as the one owner by the
-      current process. This is the mode you will your sync tests in
+      current process. This is the mode you will run your sync tests in
 
   Whenever you change the mode to `:manual` or `:auto`, all existing
   connections are checked in. Therefore, it is recommend to set those


### PR DESCRIPTION
I was just reading through this documentation and noticed the missing word in `Ecto.Adapters.SQL.Sandbox.mode/2`.