### PR TITLE
Remove unused :migration_lock option on Postgres adapter

### DIFF
--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -99,9 +99,7 @@ defmodule Ecto.Adapters.Postgres do
   """
 
   # Inherit all behaviour from Ecto.Adapters.SQL
-  use Ecto.Adapters.SQL,
-    driver: :postgrex,
-    migration_lock: "FOR UPDATE"
+  use Ecto.Adapters.SQL, driver: :postgrex
 
   # And provide a custom storage implementation
   @behaviour Ecto.Adapter.Storage


### PR DESCRIPTION
While reviewing https://github.com/elixir-ecto/ecto_sql/pull/277, I noticed that the `migration_lock` wasn't removed for the Postgres adapter like it was for the MyXQL adapter. I don't believe this option is used anymore since [this PR was merged](https://github.com/elixir-ecto/ecto_sql/pull/277) and [this commit](https://github.com/elixir-ecto/ecto_sql/commit/bf80ce94a36538823712785e160332a58920e2f6).

I don't see anymore references to `:migration_lock`.