### PR TITLE
Add note to modify/3 docs about avoiding type mods in Postgres.

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1028,6 +1028,12 @@ defmodule Ecto.Migration do
 
   See `add/3` for more information on supported types.
 
+  If you want to modify a column without changing its type
+  (e.g., to add/drop a null constraint), and you are working with Postgres,
+  consider using `execute/2` with the appropriate column alterations.
+  Doing so will allow you to avoid a redundant type update (not all databases
+  support this).
+
   ## Examples
 
       alter table("posts") do

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1028,11 +1028,11 @@ defmodule Ecto.Migration do
 
   See `add/3` for more information on supported types.
 
-  If you want to modify a column without changing its type
-  (e.g., to add/drop a null constraint), and you are working with Postgres,
-  consider using `execute/2` with the appropriate column alterations.
-  Doing so will allow you to avoid a redundant type update (not all databases
-  support this).
+  If you want to modify a column without changing its type,
+  such as adding or dropping a null constraints, consider using
+  the `execute/2` command with the relevant SQL command instead
+  of `modify/3`, if supported by your database. This may avoid
+  redundant type updates and be more efficient.
 
   ## Examples
 


### PR DESCRIPTION
Hello, I was investigating why there was no modify/2 function that allowed options to be updated without type update as well. I found [this discussion](https://groups.google.com/g/elixir-ecto/c/rBwdS0bXl4U/m/LAoAICe0BgAJ) and thought I'd submit a doc update as @josevalim suggested there.

I am not sure if this documentation is still desired by the core team, but I would've found it helpful myself, so thought I'd submit.

Thank you for ecto_sql! Love the work yall do :D