### PR TITLE
Do not run MyXQL.lock_for_migrations inside of a transaction.

### DIFF
--- a/integration_test/myxql/migrations_test.exs
+++ b/integration_test/myxql/migrations_test.exs
@@ -25,7 +25,7 @@ defmodule Ecto.Integration.MigrationsTest do
     @version_insert ~s[INSERT INTO `schema_migrations`]
     @version_delete ~s[DELETE s0.* FROM `schema_migrations`]
 
-    test "logs locking commands" do
+    test "logs locking" do
       num = @base_migration + System.unique_integer([:positive])
 
       up_log =
@@ -37,11 +37,13 @@ defmodule Ecto.Integration.MigrationsTest do
           )
         end)
 
+      refute up_log =~ "begin []"
       assert up_log =~ @get_lock_command
       assert up_log =~ @create_table_sql
       assert up_log =~ @create_table_log
       assert up_log =~ @release_lock_command
       assert up_log =~ @version_insert
+      refute up_log =~ "commit []"
 
       down_log =
         capture_log(fn ->
@@ -52,11 +54,13 @@ defmodule Ecto.Integration.MigrationsTest do
           )
         end)
 
+      refute down_log =~ "begin []"
       assert down_log =~ @get_lock_command
       assert down_log =~ @drop_table_sql
       assert down_log =~ @drop_table_log
       assert down_log =~ @release_lock_command
       assert down_log =~ @version_delete
+      refute down_log =~ "commit []"
     end
 
     test "does not log sql when log is default" do
@@ -67,22 +71,26 @@ defmodule Ecto.Integration.MigrationsTest do
           Ecto.Migrator.up(PoolRepo, num, NormalMigration, log: :info)
         end)
 
+      refute up_log =~ "begin []"
       refute up_log =~ @get_lock_command
       refute up_log =~ @create_table_sql
       assert up_log =~ @create_table_log
       refute up_log =~ @release_lock_command
       refute up_log =~ @version_insert
+      refute up_log =~ "commit []"
 
       down_log =
         capture_log(fn ->
           Ecto.Migrator.down(PoolRepo, num, NormalMigration, log: :info)
         end)
 
+      refute down_log =~ "begin []"
       refute down_log =~ @get_lock_command
       refute down_log =~ @drop_table_sql
       assert down_log =~ @drop_table_log
       refute down_log =~ @release_lock_command
       refute down_log =~ @version_delete
+      refute down_log =~ "commit []"
     end
   end
 end

--- a/integration_test/myxql/migrations_test.exs
+++ b/integration_test/myxql/migrations_test.exs
@@ -25,62 +25,64 @@ defmodule Ecto.Integration.MigrationsTest do
     @version_insert ~s[INSERT INTO `schema_migrations`]
     @version_delete ~s[DELETE s0.* FROM `schema_migrations`]
 
-    test "logs locking and transaction commands" do
+    test "logs locking commands" do
       num = @base_migration + System.unique_integer([:positive])
+
       up_log =
         capture_log(fn ->
-          Ecto.Migrator.up(PoolRepo, num, NormalMigration, log_migrator_sql: :info, log_migrations_sql: :info, log: :info)
+          Ecto.Migrator.up(PoolRepo, num, NormalMigration,
+            log_migrator_sql: :info,
+            log_migrations_sql: :info,
+            log: :info
+          )
         end)
 
-      assert up_log =~ "begin []"
       assert up_log =~ @get_lock_command
       assert up_log =~ @create_table_sql
       assert up_log =~ @create_table_log
       assert up_log =~ @release_lock_command
       assert up_log =~ @version_insert
-      assert up_log =~ "commit []"
 
       down_log =
         capture_log(fn ->
-          Ecto.Migrator.down(PoolRepo, num, NormalMigration, log_migrator_sql: :info, log_migrations_sql: :info, log: :info)
+          Ecto.Migrator.down(PoolRepo, num, NormalMigration,
+            log_migrator_sql: :info,
+            log_migrations_sql: :info,
+            log: :info
+          )
         end)
 
-      assert down_log =~ "begin []"
       assert down_log =~ @get_lock_command
       assert down_log =~ @drop_table_sql
       assert down_log =~ @drop_table_log
       assert down_log =~ @release_lock_command
       assert down_log =~ @version_delete
-      assert down_log =~ "commit []"
     end
 
     test "does not log sql when log is default" do
       num = @base_migration + System.unique_integer([:positive])
+
       up_log =
         capture_log(fn ->
           Ecto.Migrator.up(PoolRepo, num, NormalMigration, log: :info)
         end)
 
-      refute up_log =~ "begin []"
       refute up_log =~ @get_lock_command
       refute up_log =~ @create_table_sql
       assert up_log =~ @create_table_log
       refute up_log =~ @release_lock_command
       refute up_log =~ @version_insert
-      refute up_log =~ "commit []"
 
       down_log =
         capture_log(fn ->
           Ecto.Migrator.down(PoolRepo, num, NormalMigration, log: :info)
         end)
 
-      refute down_log =~ "begin []"
       refute down_log =~ @get_lock_command
       refute down_log =~ @drop_table_sql
       assert down_log =~ @drop_table_log
       refute down_log =~ @release_lock_command
       refute down_log =~ @version_delete
-      refute down_log =~ "commit []"
     end
   end
 end

--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -233,17 +233,15 @@ defmodule Ecto.Adapters.MyXQL do
 
     opts = Keyword.put(opts, :timeout, :infinity)
 
-    {:ok, result} =
-      transaction(meta, opts, fn ->
-        lock_name = "\"ecto_#{inspect(repo)}\""
+    lock_name = "\"ecto_#{inspect(repo)}\""
 
-        try do
-          {:ok, _} = Ecto.Adapters.SQL.query(meta, "SELECT GET_LOCK(#{lock_name}, -1)", [], opts)
-          fun.()
-        after
-          {:ok, _} = Ecto.Adapters.SQL.query(meta, "SELECT RELEASE_LOCK(#{lock_name})", [], opts)
-        end
-      end)
+    result =
+      try do
+        {:ok, _} = Ecto.Adapters.SQL.query(meta, "SELECT GET_LOCK(#{lock_name}, -1)", [], opts)
+        fun.()
+      after
+        {:ok, _} = Ecto.Adapters.SQL.query(meta, "SELECT RELEASE_LOCK(#{lock_name})", [], opts)
+      end
 
     result
   end


### PR DESCRIPTION
This pull request removes the `transaction` call from `lock_for_migrations` inside of the MyXQL adapter. I _think_ this is an issue because `lock_for_migrations` surrounds the migrations that get run within `migrator.ex`.  The problem is this is that MySQL doesn't support DDL transactions, and we only check the `supports_ddl_transaction?` setting within `run_maybe_in_transaction`, but I think this `lock_for_migrations` function propagates down to this as well. I would love to hear your thoughts on this, thanks!