### PR TITLE
Update Migration.rename/3 docs.

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -965,7 +965,9 @@ defmodule Ecto.Migration do
   end
 
   @doc """
-  Renames a column. Note that this occurs outside of the `alter` statement.
+  Renames a column.
+
+  Note that this occurs outside of the `alter` statement.
 
   ## Examples
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -965,7 +965,7 @@ defmodule Ecto.Migration do
   end
 
   @doc """
-  Renames a column outside of the `alter` statement.
+  Renames a column. Note that this occurs outside of the `alter` statement.
 
   ## Examples
 


### PR DESCRIPTION
Hello,

I was personally confused when I read the docs for rename/3 because I thought the wording implied that there was a way to rename a column while within an `alter` statement and went about trying to find that way (since I assumed it would be more idiomatic). As far as I can tell, there is no other way to rename a column, and this is the only way to do so. Is that correct? If so, I thought the wording could be improved slightly.

No worries if you don't think it's an improvement. Thank you so much for this great open source project! <3