### PR TITLE
Store repo in pool options

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -581,7 +581,7 @@ defmodule Ecto.Adapters.SQL do
   end
 
   @pool_opts [:timeout, :pool, :pool_size] ++
-               [:queue_target, :queue_interval, :ownership_timeout]
+               [:queue_target, :queue_interval, :ownership_timeout, :repo]
 
   @doc false
   def init(connection, driver, config) do


### PR DESCRIPTION
Useful as options are emitted with :db_connection telemetry events.

This would allow us to correlate telemetry events with the pool owner repo with ease.

Related to discussion in https://github.com/elixir-ecto/db_connection/issues/251