### PR TITLE
Raise on unsupported exprs

### DIFF
--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -657,6 +657,10 @@ if Code.ensure_loaded?(MyXQL) do
       ["(0 + ", Float.to_string(literal), ?)]
     end
 
+    defp expr(expr, _sources, query) do
+      error!(query, "unsupported expression: #{inspect(expr)}")
+    end
+
     defp interval(count, "millisecond", sources, query) do
       ["INTERVAL (", expr(count, sources, query) | " * 1000) microsecond"]
     end

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -745,6 +745,10 @@ if Code.ensure_loaded?(Postgrex) do
       [Float.to_string(literal) | "::float"]
     end
 
+    defp expr(expr, _sources, query) do
+      error!(query, "unsupported expression: #{inspect(expr)}")
+    end
+
     defp type_unless_typed(%Ecto.Query.Tagged{}, _type), do: []
     defp type_unless_typed(_, type), do: [?:, ?: | type]
 


### PR DESCRIPTION
Instead of the unfriendly "no case clause matching", this raises an
error telling the user that the literal is not supported. This was
already done by tds adapter.

Related to issue https://github.com/elixir-ecto/ecto/issues/3784