### PR TITLE
Telemetry: add `stacktrace` to metadata

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -920,7 +920,8 @@ defmodule Ecto.Adapters.SQL do
       params: params,
       query: query_string,
       source: source,
-      options: Keyword.get(opts, :telemetry_options, [])
+      options: Keyword.get(opts, :telemetry_options, []),
+      stacktrace: log_stacktrace(self())
     }
 
     if event_name = Keyword.get(opts, :telemetry_event, event_name) do
@@ -947,6 +948,13 @@ defmodule Ecto.Adapters.SQL do
     end
 
     :ok
+  end
+
+  defp log_stacktrace(pid) do
+    case Process.info(pid, :current_stacktrace) do
+      {:current_stacktrace, stacktrace} -> stacktrace
+      _ -> nil
+    end
   end
 
   defp log_measurements([{_, nil} | rest], total, acc),


### PR DESCRIPTION
### Purpose

Identify the source of slow-running queries by *line number* in code.

### Background

I have been struggling with slow queries in a large project. I know which parts of the application are slow in practice, but because the application is so large I'm having trouble connecting the dots. The query data is not enough. I need the line number in the code.

I discovered it's possible to [wrap Ecto functions](https://hackernoon.com/logging-slow-ecto-queries-adventures-in-metaprogramming-110f3472be33) in a new module with stacktraces, but this solution isn't practical because Ecto could change. Ideally something would be built into Ecto itself.

Then I discovered Elixir's telemetry system, and the path became more clear.

### Solution

When the `[:my_app, :repo, :query]` event is emitted, include a full stacktrace in the metadata.

Here is a full `metadata` map with stacktrace:

```elixir
%{
  type: :ecto_sql_query,
  source: "oauth_tokens",
  options: [],
  params: ["UkFAPtf5nyEHAq_mL6C0pz-ebMPGuIogwhm9uCwXLPw"],
  query:
    "SELECT o0.\"id\", o0.\"token\", o0.\"refresh_token\", o0.\"scopes\", o0.\"valid_until\", o0.\"user_id\", o0.\"app_id\", o0.\"inserted_at\", o0.\"updated_at\", a1.\"id\", a1.\"client_name\", a1.\"redirect_uris\", a1.\"scopes\", a1.\"website\", a1.\"client_id\", a1.\"client_secret\", a1.\"trusted\", a1.\"inserted_at\", a1.\"updated_at\" FROM \"oauth_tokens\" AS o0 INNER JOIN \"apps\" AS a1 ON a1.\"id\" = o0.\"app_id\" WHERE (o0.\"token\" = $1)",
  repo: Pleroma.Repo,
  result: {:ok, ...},
  stacktrace: [
    {Process, :info, 2, [file: 'lib/process.ex', line: 766]},
    {Ecto.Adapters.SQL, :log_stacktrace, 1, [file: 'lib/ecto/adapters/sql.ex', line: 954]},
    {Ecto.Adapters.SQL, :log, 4, [file: 'lib/ecto/adapters/sql.ex', line: 924]},
    {DBConnection, :log, 5, [file: 'lib/db_connection.ex', line: 1479]},
    {Ecto.Adapters.Postgres.Connection, :execute, 4,
     [file: 'lib/ecto/adapters/postgres/connection.ex', line: 80]},
    {Ecto.Adapters.SQL, :execute!, 4, [file: 'lib/ecto/adapters/sql.ex', line: 711]},
    {Ecto.Adapters.SQL, :execute, 5, [file: 'lib/ecto/adapters/sql.ex', line: 693]},
    {Ecto.Repo.Queryable, :execute, 4, [file: 'lib/ecto/repo/queryable.ex', line: 219]},
    {Ecto.Repo.Queryable, :all, 3, [file: 'lib/ecto/repo/queryable.ex', line: 19]},
    {Ecto.Repo.Queryable, :one, 3, [file: 'lib/ecto/repo/queryable.ex', line: 146]},
    {Pleroma.Web.Plugs.OAuthPlug, :fetch_app_and_token, 1,
     [file: 'lib/pleroma/web/plugs/o_auth_plug.ex', line: 67]},
    {Pleroma.Web.Plugs.OAuthPlug, :call, 2,
     [file: 'lib/pleroma/web/plugs/o_auth_plug.ex', line: 32]},
    {Pleroma.Web.Router, :authenticate, 2, []},
    {Pleroma.Web.Router, :base_api, 2, []},
    {Pleroma.Web.Router, :no_auth_or_privacy_expectations_api, 2, []},
    {Pleroma.Web.Router, :authenticated_api, 2, []},
    {Pleroma.Web.Router, :__pipe_through4__, 1, [file: 'lib/pleroma/web/router.ex', line: 5]},
    {Phoenix.Router, :__call__, 2, [file: 'lib/phoenix/router.ex', line: 347]},
    {Pleroma.Web.Endpoint, :plug_builder_call, 2, [file: 'lib/pleroma/web/endpoint.ex', line: 5]},
    {Pleroma.Web.Endpoint, :"call (overridable 3)", 2, [file: 'lib/plug/debugger.ex', line: 132]}
  ]
}
```

We can now pinpoint this query to our application code, at `lib/pleroma/web/plugs/o_auth_plug.ex:67`

This makes the output infinitely more useful. I am now able to capture the slowest queries and then identify *exactly* where they came from in code. This will allow slow queries to be acted upon instead of trying to guess where they come from.