### PR TITLE
to_exclusive

### DIFF
--- a/lib/mix/tasks/ecto.migrate.ex
+++ b/lib/mix/tasks/ecto.migrate.ex
@@ -14,6 +14,7 @@ defmodule Mix.Tasks.Ecto.Migrate do
     all: :boolean,
     step: :integer,
     to: :integer,
+    to_exclusive: :integer,
     quiet: :boolean,
     prefix: :string,
     pool_size: :integer,
@@ -102,6 +103,8 @@ defmodule Mix.Tasks.Ecto.Migrate do
 
     * `--to` - run all migrations up to and including version
 
+    * `--to-exclusive` - revert all migrations down to and excluding version
+
   """
 
   @impl true
@@ -110,7 +113,7 @@ defmodule Mix.Tasks.Ecto.Migrate do
     {opts, _} = OptionParser.parse! args, strict: @switches, aliases: @aliases
 
     opts =
-      if opts[:to] || opts[:step] || opts[:all],
+      if opts[:to] || opts[:to_exclusive] || opts[:step] || opts[:all],
         do: opts,
         else: Keyword.put(opts, :all, true)
 

--- a/lib/mix/tasks/ecto.rollback.ex
+++ b/lib/mix/tasks/ecto.rollback.ex
@@ -14,6 +14,7 @@ defmodule Mix.Tasks.Ecto.Rollback do
     all: :boolean,
     step: :integer,
     to: :integer,
+    to_exclusive: :integer,
     quiet: :boolean,
     prefix: :string,
     pool_size: :integer,
@@ -98,6 +99,8 @@ defmodule Mix.Tasks.Ecto.Rollback do
 
     * `--to` - revert all migrations down to and including version
 
+    * `--to-exclusive` - revert all migrations down to and excluding version
+
   """
 
   @impl true
@@ -106,7 +109,7 @@ defmodule Mix.Tasks.Ecto.Rollback do
     {opts, _} = OptionParser.parse!(args, strict: @switches, aliases: @aliases)
 
     opts =
-      if opts[:to] || opts[:step] || opts[:all],
+      if opts[:to] || opts[:to_exclusive] || opts[:step] || opts[:all],
         do: opts,
         else: Keyword.put(opts, :step, 1)
 

--- a/test/mix/tasks/ecto.migrate_test.exs
+++ b/test/mix/tasks/ecto.migrate_test.exs
@@ -135,4 +135,15 @@ defmodule Mix.Tasks.Ecto.MigrateTest do
     run ["-r", to_string(Repo), "--migrations-path", path1, "--migrations-path", path2],
         fn Repo, [^path1, ^path2], _, _ -> [] end
   end
+
+  test "runs the migrator with --to_exclusive" do
+    run ["-r", to_string(Repo), "--to-exclusive", "12345"], fn repo, [path], direction, opts ->
+      assert repo == Repo
+      refute path =~ ~r/_build/
+      assert direction == :up
+      assert opts == [repo: "Elixir.Mix.Tasks.Ecto.MigrateTest.Repo", to_exclusive: 12345]
+      []
+    end
+    assert Process.get(:started)
+  end
 end

--- a/test/mix/tasks/ecto.rollback_test.exs
+++ b/test/mix/tasks/ecto.rollback_test.exs
@@ -99,4 +99,15 @@ defmodule Mix.Tasks.Ecto.RollbackTest do
     run ["-r", to_string(Repo), "--migrations-path", path1, "--migrations-path", path2],
         fn Repo, [^path1, ^path2], _, _ -> [] end
   end
+
+  test "runs the migrator with --to_exclusive" do
+    run ["-r", to_string(Repo), "--to-exclusive", "12345"], fn repo, [path], direction, opts ->
+      assert repo == Repo
+      refute path =~ ~r/_build/
+      assert direction == :down
+      assert opts == [repo: "Elixir.Mix.Tasks.Ecto.RollbackTest.Repo", to_exclusive: 12345]
+      []
+    end
+    assert Process.get(:started)
+  end
 end


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto_sql/issues/336.


Introduce `--to-exclusive` option for `mix.ecto.migrate` and `mix.ecto.rollback`. Chose this option instead of the ones mentioned in the issue for a couple reasons:

- Having both inclusive and exclusive options could be useful
- The wording is not ambiguous. `--target`/`--up-to` sound to me like it should include the version I'm specifying

It's a bit verbose but this one or `--to-excluding` are the ones that sounded the least ambiguous to me and also let you keep the existing `to` behaviour.