### PR TITLE
Proposal: Add :prepare option for Postgres Adapter

### DIFF
--- a/integration_test/pg/prepare_test.exs
+++ b/integration_test/pg/prepare_test.exs
@@ -1,0 +1,14 @@
+defmodule Ecto.Integration.CopyTest do
+  use Ecto.Integration.Case, async: true
+
+  alias Ecto.Integration.TestRepo
+  alias Ecto.Integration.Post
+
+  test "prepare option" do
+    one = TestRepo.insert!(%Post{title: "one"})
+    two = TestRepo.insert!(%Post{title: "two"})
+
+    assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
+    assert TestRepo.all(Post, prepare: :named) == [one, two]
+  end
+end

--- a/integration_test/pg/prepare_test.exs
+++ b/integration_test/pg/prepare_test.exs
@@ -1,4 +1,4 @@
-defmodule Ecto.Integration.CopyTest do
+defmodule Ecto.Integration.PrepareTest do
   use Ecto.Integration.Case, async: true
 
   alias Ecto.Integration.TestRepo

--- a/integration_test/pg/prepare_test.exs
+++ b/integration_test/pg/prepare_test.exs
@@ -8,6 +8,11 @@ defmodule Ecto.Integration.PrepareTest do
     one = TestRepo.insert!(%Post{title: "one"})
     two = TestRepo.insert!(%Post{title: "two"})
 
+    # Uncached
+    assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
+    assert TestRepo.all(Post, prepare: :named) == [one, two]
+
+    # Cached
     assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
     assert TestRepo.all(Post, prepare: :named) == [one, two]
   end

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -130,15 +130,14 @@ defmodule Ecto.Adapters.Postgres do
 
   @impl Ecto.Adapter.Queryable
   def execute(adapter_meta, query_meta, query, params, opts) do
-    opts = Keyword.put_new(opts, :prepare, @default_prepare_opt)
-    prepare = opts[:prepare]
+    prepare = Keyword.get(opts, :prepare, @default_prepare_opt)
 
     unless valid_prepare?(prepare) do
       raise ArgumentError,
         "expected option `:prepare` to be either `:named` or `:unnamed`, got: #{inspect(prepare)}"
     end
 
-    Ecto.Adapters.SQL.execute(adapter_meta, query_meta, query, params, opts)
+    Ecto.Adapters.SQL.execute(prepare, adapter_meta, query_meta, query, params, opts)
   end
 
   defp valid_prepare?(prepare) when prepare in [:named, :unnamed], do: true

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -21,6 +21,10 @@ defmodule Ecto.Adapters.Postgres do
       config :your_app, YourApp.Repo,
         ...
 
+  The `:prepare` option may be specified per operation:
+
+      YourApp.Repo.all(Queryable, prepare: :unnamed)
+
   ### Connection options
 
     * `:hostname` - Server hostname
@@ -126,21 +130,19 @@ defmodule Ecto.Adapters.Postgres do
 
   @impl Ecto.Adapter.Queryable
   def execute(adapter_meta, query_meta, query, params, opts) do
-    prepare = Keyword.get(opts, :prepare, @default_prepare_opt)
+    opts = Keyword.put_new(opts, :prepare, @default_prepare_opt)
+    prepare = opts[:prepare]
 
     unless valid_prepare?(prepare) do
       raise ArgumentError,
         "expected option `:prepare` to be either `:named` or `:unnamed`, got: #{inspect(prepare)}"
     end
 
-    Ecto.Adapters.SQL.execute(adapter_meta, query_meta, query, params, put_use_cache(opts, prepare))
+    Ecto.Adapters.SQL.execute(adapter_meta, query_meta, query, params, opts)
   end
 
   defp valid_prepare?(prepare) when prepare in [:named, :unnamed], do: true
   defp valid_prepare?(_), do: false
-
-  defp put_use_cache(opts, :named), do: Keyword.put(opts, :use_cache, true)
-  defp put_use_cache(opts, :unnamed), do: Keyword.put(opts, :use_cache, false)
 
   ## Storage API
 

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -67,7 +67,7 @@ if Code.ensure_loaded?(Postgrex) do
 
     @impl true
     def prepare_execute(conn, name, sql, params, opts) do
-      name = if opts[:use_cache?], do: name, else: ""
+      name = if opts[:use_cache], do: name, else: ""
 
       case Postgrex.prepare_execute(conn, name, sql, params, opts) do
         {:error, %Postgrex.Error{postgres: %{pg_code: "22P02", message: message}} = error} ->

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -67,6 +67,8 @@ if Code.ensure_loaded?(Postgrex) do
 
     @impl true
     def prepare_execute(conn, name, sql, params, opts) do
+      name = prepared_name(name, opts[:prepare])
+
       case Postgrex.prepare_execute(conn, name, sql, params, opts) do
         {:error, %Postgrex.Error{postgres: %{pg_code: "22P02", message: message}} = error} ->
           context = """
@@ -85,6 +87,9 @@ if Code.ensure_loaded?(Postgrex) do
         end
 
     end
+
+    defp prepared_name(_, :unnamed), do: ""
+    defp prepared_name(name, _), do: name
 
     @impl true
     def query(conn, sql, params, opts) do

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -67,6 +67,8 @@ if Code.ensure_loaded?(Postgrex) do
 
     @impl true
     def prepare_execute(conn, name, sql, params, opts) do
+      name = if opts[:use_cache?], do: name, else: ""
+
       case Postgrex.prepare_execute(conn, name, sql, params, opts) do
         {:error, %Postgrex.Error{postgres: %{pg_code: "22P02", message: message}} = error} ->
           context = """

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -67,9 +67,9 @@ if Code.ensure_loaded?(Postgrex) do
 
     @impl true
     def prepare_execute(conn, name, sql, params, opts) do
-      name = prepared_name(name, opts[:prepare])
+      {prepare, opts} = Keyword.pop(opts, :prepare)
 
-      case Postgrex.prepare_execute(conn, name, sql, params, opts) do
+      case Postgrex.prepare_execute(conn, prepare_name(name, prepare), sql, params, opts) do
         {:error, %Postgrex.Error{postgres: %{pg_code: "22P02", message: message}} = error} ->
           context = """
           . If you are trying to query a JSON field, the parameter must be interpolated. Instead of
@@ -88,8 +88,8 @@ if Code.ensure_loaded?(Postgrex) do
 
     end
 
-    defp prepared_name(_, :unnamed), do: ""
-    defp prepared_name(name, _), do: name
+    defp prepare_name(_, :unnamed), do: ""
+    defp prepare_name(name, _), do: name
 
     @impl true
     def query(conn, sql, params, opts) do

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -67,7 +67,7 @@ if Code.ensure_loaded?(Postgrex) do
 
     @impl true
     def prepare_execute(conn, name, sql, params, opts) do
-      name = if opts[:use_cache], do: name, else: ""
+      name = if opts[:prepare] == :named, do: name, else: ""
 
       case Postgrex.prepare_execute(conn, name, sql, params, opts) do
         {:error, %Postgrex.Error{postgres: %{pg_code: "22P02", message: message}} = error} ->

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -67,8 +67,6 @@ if Code.ensure_loaded?(Postgrex) do
 
     @impl true
     def prepare_execute(conn, name, sql, params, opts) do
-      name = if opts[:prepare] == :named, do: name, else: ""
-
       case Postgrex.prepare_execute(conn, name, sql, params, opts) do
         {:error, %Postgrex.Error{postgres: %{pg_code: "22P02", message: message}} = error} ->
           context = """

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -67,9 +67,7 @@ if Code.ensure_loaded?(Postgrex) do
 
     @impl true
     def prepare_execute(conn, name, sql, params, opts) do
-      {prepare, opts} = Keyword.pop(opts, :prepare)
-
-      case Postgrex.prepare_execute(conn, prepare_name(name, prepare), sql, params, opts) do
+      case Postgrex.prepare_execute(conn, name, sql, params, opts) do
         {:error, %Postgrex.Error{postgres: %{pg_code: "22P02", message: message}} = error} ->
           context = """
           . If you are trying to query a JSON field, the parameter must be interpolated. Instead of
@@ -87,9 +85,6 @@ if Code.ensure_loaded?(Postgrex) do
         end
 
     end
-
-    defp prepare_name(_, :unnamed), do: ""
-    defp prepare_name(name, _), do: name
 
     @impl true
     def query(conn, sql, params, opts) do

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -129,7 +129,7 @@ defmodule Ecto.Adapters.SQL do
 
       @impl true
       def execute(adapter_meta, query_meta, query, params, opts) do
-        Ecto.Adapters.SQL.execute(adapter_meta, query_meta, query, params, opts)
+        Ecto.Adapters.SQL.execute(:named, adapter_meta, query_meta, query, params, opts)
       end
 
       @impl true
@@ -689,9 +689,7 @@ defmodule Ecto.Adapters.SQL do
   end
 
   @doc false
-  def execute(adapter_meta, query_meta, prepared, params, opts) do
-    prepare = Keyword.get(opts, :prepare, :named)
-
+  def execute(prepare, adapter_meta, query_meta, prepared, params, opts) do
     %{num_rows: num, rows: rows} =
       execute!(prepare, adapter_meta, prepared, params, put_source(opts, query_meta))
 

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -697,7 +697,7 @@ defmodule Ecto.Adapters.SQL do
   end
 
   defp execute!(prepare, adapter_meta, {:cache, update, {id, prepared}}, params, opts) do
-    name = prepare_name(id)
+    name = prepare_name(prepare, id)
 
     case sql_call(adapter_meta, :prepare_execute, [name, prepared], params, opts) do
       {:ok, query, result} ->
@@ -708,8 +708,8 @@ defmodule Ecto.Adapters.SQL do
     end
   end
 
-  defp execute!(:unnamed = _prepare, adapter_meta, {:cached, _update, _reset, {id, cached}}, params, opts) do
-    name = prepare_name(id)
+  defp execute!(:unnamed = prepare, adapter_meta, {:cached, _update, _reset, {id, cached}}, params, opts) do
+    name = prepare_name(prepare, id)
     prepared = String.Chars.to_string(cached)
 
     case sql_call(adapter_meta, :prepare_execute, [name, prepared], params, opts) do
@@ -742,7 +742,8 @@ defmodule Ecto.Adapters.SQL do
     end
   end
 
-  defp prepare_name(id), do: "ecto_" <> Integer.to_string(id)
+  defp prepare_name(:named, id), do: "ecto_" <> Integer.to_string(id)
+  defp prepare_name(:unnamed, _id), do: ""
 
   defp maybe_update_cache(:named = _prepare, update, value), do: update.(value)
   defp maybe_update_cache(:unnamed = _prepare, _update, _value), do: :noop


### PR DESCRIPTION
Because of the way Postgres generates plans for prepared statements, sometimes it is beneficial to disable them (i.e. use an unnamed prepared statement). See [this Postgrex issue for more details](https://github.com/elixir-ecto/postgrex/issues/497).

You can currently use unnamed prepared statements, but they are set at the Repo config level and would apply to all queries. This means the user can't pick and choose which queries benefit from this feature.

This proposal is to allow the Postgres adapter to recognize a `:prepare` option and to overwrite the Ecto-generated name with empty string. This is similar to what happens in Postgrex when `prepare: :unnamed` is configured on the connection. See this excerpt from [Postgrex.Protocol](https://github.com/elixir-ecto/postgrex/blob/master/lib/postgrex/protocol.ex):

```elixir 
def handle_prepare(%Query{} = query, opts, %{queries: nil} = s) do
  # always use unnamed if no cache
  handle_prepare(%Query{query | name: ""}, opts, s)
end
```

This way you still get the benefits of the Ecto cache but without the potentially harmful effects of the Postgres cache. One potential pitfall is that once you issue the query you can't change the `:prepare` option because the prepare step will be skipped. I think that's ok but let me know what you guys think.

The change is restricted to the Postgres adapter because I don't think the other adapters handle empty string names the same way. I could be mistaken though, since I'm not as familiar with them. Postgres will treat this as a "one shot" name and allow it to be re-defined without explicitly telling it that you're done with the old definition.

Note that this option is meant as a convenience. You can currently issue an unnamed query using `Ecto.Adapters.SQL.query` but then you don't get all the nice Ecto conveniences.

If you guys like this proposal then I think the following things also need to be done:
  - Update the Ecto docs to say this option exists
  - Add integration tests in Ecto to make sure the queries work the same when that option is specified
  - Maybe add an integration test in this repo. If I could create one that inspects the results from `Ecto.Adapters.Postgres.Connection.prepare_execute` then I could inspect the name of the query. 