### PR TITLE
Add possibility to overwrite default options during sql call

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -537,7 +537,7 @@ defmodule Ecto.Adapters.SQL do
   defp sql_call(adapter_meta, callback, args, params, opts) do
     %{pid: pool, telemetry: telemetry, sql: sql, opts: default_opts} = adapter_meta
     conn = get_conn_or_pool(pool)
-    opts = with_log(telemetry, params, opts ++ default_opts)
+    opts = with_log(telemetry, params, Keyword.merge(default_opts, opts))
     args = args ++ [params, opts]
     apply(sql, callback, [conn | args])
   end


### PR DESCRIPTION
Currently it is not possible to overwrite default options during sql call. High level example below.

For example i have configured repo:
```
config :my_app, Repo,
  database: "ecto_simple",
  username: "postgres",
  password: "postgres",
  hostname: "localhost",
  timeout: 3000
```

```
defmodule Repo do
  use Ecto.Repo,
    otp_app: :my_app,
    adapter: Ecto.Adapters.Postgres
end
```
and I am trying to overwrite `timeout` during repo call

```
from(p in Post, where: p.id < 10) |> MyRepo.delete_all(timeout: 10000)
```

It doesn't work now because default options are concatenated with options given in repo method execution. This PR fixes that situation.
