### PR TITLE
Add create_if_not_exists for constraints

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -540,13 +540,19 @@ defmodule Ecto.Migration do
   end
 
   @doc """
-  Creates an index or a table with only `:id` field if one does not yet exist.
+  Creates one of the following:
+
+    * an index
+    * a constraint
+    * a table with only `:id` field if one does not yet exist.
 
   ## Examples
 
       create_if_not_exists index("posts", [:name])
 
       create_if_not_exists table("version")
+
+      create_if_not_exists constraints(:posts, :price_is_positive, check: "price > 0")
 
   """
   def create_if_not_exists(%Index{} = index) do

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -553,6 +553,10 @@ defmodule Ecto.Migration do
     Runner.execute {:create_if_not_exists, __prefix__(index)}
   end
 
+  def create_if_not_exists(%Constraint{} = constraint) do
+    Runner.execute {:create_if_not_exists, __prefix__(constraint)}
+  end
+
   def create_if_not_exists(%Table{} = table) do
     do_create table, :create_if_not_exists
   end

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -804,6 +804,12 @@ defmodule Ecto.MigrationTest do
     assert {:create, %Index{}} = last_command()
   end
 
+  test "backward: creates a constraint if not exists" do
+    create_if_not_exists constraint(:posts, :price_is_positive, check: "price > 0")
+    flush()
+    assert {:drop_if_exists, %Constraint{}, _} = last_command()
+  end
+
   test "backward: drops a constraint" do
     assert_raise Ecto.MigrationError, ~r/cannot reverse migration command/, fn ->
       drop_if_exists constraint(:posts, :price)


### PR DESCRIPTION
Currently create_if_not_exists is not implemented for constraints. Migrations fail when running with the following error:

```
    Attempted function clauses (showing 2 out of 2):
    
        def create_if_not_exists(%Ecto.Migration.Index{} = index)
        def create_if_not_exists(%Ecto.Migration.Table{} = table)
```

- Implemented create_if_not_exists for constraints, updated docs
- Added test for create_if_not_exists in :backward as per existing tests for create_if_not_exists

If I am missing something please let me know. 