### PR TITLE
Use :async_integration_tests env var for sql tests

### DIFF
--- a/integration_test/sql/sql.exs
+++ b/integration_test/sql/sql.exs
@@ -1,5 +1,5 @@
 defmodule Ecto.Integration.SQLTest do
-  use Ecto.Integration.Case, async: true
+  use Ecto.Integration.Case, async: Application.compile_env(:ecto, :async_integration_tests, true)
 
   alias Ecto.Integration.PoolRepo
   alias Ecto.Integration.TestRepo


### PR DESCRIPTION
I noticed mssql integration tests periodically fail with deadlock errors. They always seem to come from this module. 

Example:
https://github.com/elixir-ecto/ecto_sql/runs/5967947251?check_suite_focus=true#step:4:787