### PR TITLE
Colorize stacktrace and use `:` before printing line number

### DIFF
--- a/integration_test/sql/logging.exs
+++ b/integration_test/sql/logging.exs
@@ -76,7 +76,7 @@ defmodule Ecto.Integration.LoggingTest do
 
     defp stacktrace_entry(line) do
       "↳ anonymous fn/0 in Ecto.Integration.LoggingTest.\"test logs includes stacktraces\"/1, " <>
-        "at: integration_test/sql/logging.exs##{line - 3}"
+        "at: integration_test/sql/logging.exs:#{line - 3}"
     end
 
     test "when some measurements are nil" do

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1178,6 +1178,7 @@ defmodule Ecto.Adapters.SQL do
     with [_ | _] <- stacktrace,
          {module, function, arity, info} <- last_non_ecto(Enum.reverse(stacktrace), repo, nil) do
       [
+        IO.ANSI.light_black(),
         ?\n,
         "↳ ",
         Exception.format_mfa(module, function, arity),
@@ -1189,7 +1190,7 @@ defmodule Ecto.Adapters.SQL do
   end
 
   defp log_stacktrace_info([file: file, line: line] ++ _) do
-    [", at: ", file, ?#, Integer.to_string(line)]
+    [", at: ", file, ?:, Integer.to_string(line)]
   end
 
   defp log_stacktrace_info(_) do


### PR DESCRIPTION
Hello

Here, Jose mentioned that it would be great to send some improvements present in https://github.com/fuelen/ecto_dev_logger to upstream: https://github.com/phoenixframework/phoenix_ecto/issues/152#issuecomment-1111968211

This is the first patch.

Changes:
* colorize stacktrace (returning to the original color is not needed, as this is the last part of the string) 
* use `:` before printing line number, as this format helps editors to open the file at the specified line