### PR TITLE
Add telemetry_options to migration queries

### DIFF
--- a/integration_test/sql/migrator.exs
+++ b/integration_test/sql/migrator.exs
@@ -89,7 +89,7 @@ defmodule Ecto.Integration.MigratorTest do
     assert down(PoolRepo, 33, AnotherSchemaMigration, log: false) == :ok
   end
 
-  test "ecto-generated migration queries pass schema_migration to telemetry" do
+  test "ecto-generated migration queries pass schema_migration in telemetry options" do
     handler = fn _event_name, _measurements, metadata ->
       send(self(), metadata)
     end
@@ -97,12 +97,12 @@ defmodule Ecto.Integration.MigratorTest do
     # migration table creation
     Process.put(:telemetry, handler)
     migrated_versions(PoolRepo, log: false)
-    assert_received %{schema_migration: true}
+    assert_received %{options: [schema_migration: true]}
 
     # retrieving the migration versions
     Process.put(:telemetry, handler)
     migrated_versions(PoolRepo, migration_lock: false, skip_table_creation: true, log: false)
-    assert_received %{schema_migration: true}
+    assert_received %{options: [schema_migration: true]}
   end
 
   test "bad execute migration" do

--- a/integration_test/sql/migrator.exs
+++ b/integration_test/sql/migrator.exs
@@ -89,6 +89,22 @@ defmodule Ecto.Integration.MigratorTest do
     assert down(PoolRepo, 33, AnotherSchemaMigration, log: false) == :ok
   end
 
+  test "ecto-generated migration queries pass schema_migration to telemetry" do
+    handler = fn _event_name, _measurements, metadata ->
+      send(self(), metadata)
+    end
+
+    # migration table creation
+    Process.put(:telemetry, handler)
+    migrated_versions(PoolRepo, log: false)
+    assert_received %{schema_migration: true}
+
+    # retrieving the migration versions
+    Process.put(:telemetry, handler)
+    migrated_versions(PoolRepo, migration_lock: false, skip_table_creation: true, log: false)
+    assert_received %{schema_migration: true}
+  end
+
   test "bad execute migration" do
     assert catch_error(up(PoolRepo, 31, BadMigration, log: false))
   end

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1089,7 +1089,7 @@ defmodule Ecto.Adapters.SQL do
       query: query,
       source: source,
       stacktrace: stacktrace,
-      options: Keyword.get(opts, :telemetry_options, [])
+      options: telemetry_options(opts[:telemetry_options] || [], opts[:schema_migration])
     }
 
     if event_name = Keyword.get(opts, :telemetry_event, event_name) do
@@ -1117,6 +1117,12 @@ defmodule Ecto.Adapters.SQL do
 
     :ok
   end
+
+  defp telemetry_options(options, nil), do: options
+
+  defp telemetry_options(options, schema_migration),
+    do: Keyword.merge(options, schema_migration: schema_migration)
+
 
   defp log_measurements([{_, nil} | rest], total, acc),
     do: log_measurements(rest, total, acc)

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1089,7 +1089,7 @@ defmodule Ecto.Adapters.SQL do
       query: query,
       source: source,
       stacktrace: stacktrace,
-      options: telemetry_options(opts[:telemetry_options] || [], opts[:schema_migration])
+      options: Keyword.get(opts, :telemetry_options, [])
     }
 
     if event_name = Keyword.get(opts, :telemetry_event, event_name) do
@@ -1117,12 +1117,6 @@ defmodule Ecto.Adapters.SQL do
 
     :ok
   end
-
-  defp telemetry_options(options, nil), do: options
-
-  defp telemetry_options(options, schema_migration),
-    do: Keyword.merge(options, schema_migration: schema_migration)
-
 
   defp log_measurements([{_, nil} | rest], total, acc),
     do: log_measurements(rest, total, acc)

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1089,6 +1089,7 @@ defmodule Ecto.Adapters.SQL do
       query: query,
       source: source,
       stacktrace: stacktrace,
+      schema_migration: opts[:schema_migration],
       options: Keyword.get(opts, :telemetry_options, [])
     }
 

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1089,7 +1089,6 @@ defmodule Ecto.Adapters.SQL do
       query: query,
       source: source,
       stacktrace: stacktrace,
-      schema_migration: Keyword.get(opts, :schema_migration, false),
       options: Keyword.get(opts, :telemetry_options, [])
     }
 

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1089,7 +1089,7 @@ defmodule Ecto.Adapters.SQL do
       query: query,
       source: source,
       stacktrace: stacktrace,
-      schema_migration: opts[:schema_migration],
+      schema_migration: Keyword.get(opts, :schema_migration, false),
       options: Keyword.get(opts, :telemetry_options, [])
     }
 

--- a/lib/ecto/migration/schema_migration.ex
+++ b/lib/ecto/migration/schema_migration.ex
@@ -14,7 +14,12 @@ defmodule Ecto.Migration.SchemaMigration do
 
   # The migration flag is used to signal to the repository
   # we are in a migration operation.
-  @default_opts [timeout: :infinity, log: false, schema_migration: true]
+  @default_opts [
+    timeout: :infinity,
+    log: false,
+    schema_migration: true,
+    telemetry_options: [schema_migration: true]
+  ]
 
   def ensure_schema_migrations_table!(repo, config, opts) do
     {repo, source} = get_repo_and_source(repo, config)

--- a/lib/ecto/migration/schema_migration.ex
+++ b/lib/ecto/migration/schema_migration.ex
@@ -14,12 +14,7 @@ defmodule Ecto.Migration.SchemaMigration do
 
   # The migration flag is used to signal to the repository
   # we are in a migration operation.
-  @default_opts [
-    timeout: :infinity,
-    log: false,
-    schema_migration: true,
-    telemetry_options: [schema_migration: true]
-  ]
+  @default_opts [timeout: :infinity, log: false, schema_migration: true]
 
   def ensure_schema_migrations_table!(repo, config, opts) do
     {repo, source} = get_repo_and_source(repo, config)


### PR DESCRIPTION
**PR Changes**
Pass the `schema_migration` automatically generated by the Ecto migration queries to telemetry_options. This only affects creating the schema migration table and fetching/inserting/deleting the versions.

This is related to the discussion over on phoenix_ecto https://github.com/phoenixframework/phoenix_ecto/issues/152#issuecomment-1111968211.


**Sidetrack**
@josevalim Really sorry, I accidentally committed https://github.com/elixir-ecto/ecto_sql/commit/02beb19dd4a6876dbf1fb54beeba9bff4546a7d9 to here when I meant to do it on my fork. I'm not at home and don't have access to git CLI. If it's urgent and you're able to do it that would be great. If not I can do it when I get home in ~ 5 hours.