### PR TITLE
Fix possible breaking change on json_extract_path for boolean values

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -710,13 +710,7 @@ if Code.ensure_loaded?(Postgrex) do
     defp expr({:count, _, []}, _sources, _query), do: "count(*)"
 
     defp expr({:==, _, [{:json_extract_path, _, [expr, path]} = left, right]}, sources, query)
-         when is_boolean(right) or right in ["TRUE", "true", "FALSE", "false"] do
-      right = quote_boolean(right)
-      [maybe_paren(left, sources, query), " = " | maybe_paren(right, sources, query)]
-    end
-
-    defp expr({:==, _, [{:json_extract_path, _, [expr, path]} = left, right]}, sources, query)
-         when is_binary(right) or is_integer(right) do
+         when is_binary(right) or is_integer(right) or is_boolean(right) do
       case Enum.split(path, -1) do
         {path, [last]} when is_binary(last) ->
           extracted = json_extract_path(expr, path, sources, query)
@@ -1310,9 +1304,7 @@ if Code.ensure_loaded?(Postgrex) do
     # TRUE, ON, or 1 to enable the option, and FALSE, OFF, or 0 to disable it
     defp quote_boolean(nil), do: nil
     defp quote_boolean(true), do: "TRUE"
-    defp quote_boolean(value) when value in ["TRUE", "true"], do: "TRUE"
     defp quote_boolean(false), do: "FALSE"
-    defp quote_boolean(value) when value in ["FALSE", "false"], do: "FALSE"
     defp quote_boolean(value), do: error!(nil, "bad boolean value #{value}")
 
     defp format_to_sql(:text), do: "FORMAT TEXT"
@@ -1361,6 +1353,9 @@ if Code.ensure_loaded?(Postgrex) do
     defp escape_json(value) when is_integer(value) do
       Integer.to_string(value)
     end
+
+    defp escape_json(true), do: ["true"]
+    defp escape_json(false), do: ["false"]
 
     defp ecto_to_db({:array, t}),          do: [ecto_to_db(t), ?[, ?]]
     defp ecto_to_db(:id),                  do: "integer"

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -617,18 +617,13 @@ defmodule Ecto.Adapters.PostgresTest do
 
     query = Schema |> where([s], s.meta[0] == "123") |> select(true) |> plan()
     assert all(query) == ~s|SELECT TRUE FROM "schema" AS s0 WHERE ((s0.\"meta\"#>'{0}') = '123')|
+
+    query = Schema |> where([s], s.meta["enabled"] == true) |> select(true) |> plan()
+    assert all(query) == ~s|SELECT TRUE FROM "schema" AS s0 WHERE ((s0."meta"@>'{"enabled": true}'))|
+
+    query = Schema |> where([s], s.meta["extra"][0]["enabled"] == false) |> select(true) |> plan()
+    assert all(query) == ~s|SELECT TRUE FROM "schema" AS s0 WHERE (((s0."meta"#>'{"extra",0}')@>'{"enabled": false}'))|
   end
-
-   test "json_extract_path for boolean values" do
-     query = Schema |> where([s], s.meta["enabled"] == "true") |> select(true) |> plan()
-     assert all(query) == ~s|SELECT TRUE FROM "schema" AS s0 WHERE ((s0."meta"#>'{"enabled"}') = 'TRUE')|
-
-     query = Schema |> where([s], s.meta["enabled"] == true) |> select(true) |> plan()
-     assert all(query) == ~s|SELECT TRUE FROM "schema" AS s0 WHERE ((s0."meta"#>'{"enabled"}') = 'TRUE')|
-
-     query = Schema |> where([s], s.meta["audit"]["enabled"] == "true") |> select(true) |> plan()
-     assert all(query) == ~s|SELECT TRUE FROM "schema" AS s0 WHERE ((s0."meta"#>'{"audit","enabled"}') = 'TRUE')|
-   end
 
   test "nested expressions" do
     z = 123


### PR DESCRIPTION
The commit https://github.com/elixir-ecto/ecto_sql/commit/96f70b5017f7b271a1c0b9a7b84d94016385cac6 may have introduced a breaking change when dealing with boolean values.

Given the schema https://github.com/elixir-ecto/ecto_sql/blob/c22115b00737b98faa78f2c62e4daae41a360ab4/test/ecto/adapters/postgres_test.exs#L9-L26 and considering a record with `meta` stored as `{"enabled": true}` on v3.7.2 one could write the following query:

```elixir
     query = Schema |> where([s], s.meta["enabled"] == "true") |> select(true) |> plan()
     assert all(query) == ~s|SELECT TRUE FROM "schema" AS s0 WHERE ((s0."meta"#>'{"enabled"}') = 'true')|
```

Note that you can't write `s.meta["enabled"] == true` as that would generate the following invalid query, either on v3.7.2 or v3.8.1:

```elixir
     query = Schema |> where([s], s.meta["enabled"] == true) |> select(true) |> plan()
     assert all(query) == ~s|SELECT TRUE FROM "schema" AS s0 WHERE ((s0."meta"#>'{"enabled"}') = TRUE)|
```

So far, so good.

On v3.8.1 the same query `s.meta["enabled"] == "true"` is now generated as:

```elixir
     query = Schema |> where([s], s.meta["enabled"] == "true") |> select(true) |> plan()
     assert all(query) == ~s|SELECT TRUE FROM "schema" AS s0 WHERE ((s0."meta"@>'{"enabled": "true"}'))|
```

And turns out that query won't return the expected records, see a live example at https://dbfiddle.uk/?rdbms=postgres_13&fiddle=9987baf6c8972988319559cb0fafb655

In order to make it work the query should be `"meta"@>'{"enabled": true}'` (an actual boolean instead of a string) or using the `#>` operator as before.

### Proposed solution

AFAIK boolean values are expected to be transformed to their text representation https://github.com/elixir-ecto/ecto_sql/blob/c22115b00737b98faa78f2c62e4daae41a360ab4/lib/ecto/adapters/postgres/connection.ex#L758-L759  so using the `@>` wouldn't work or would introduce a new behavior, right?  So the proposed solution is to revert to the old query for bool expr _and_ also deal with `true/false` to make `s.meta["enabled"] == true` work.

I'm not sure if we should check for `right in ["TRUE", "true", "FALSE", "false"]` but I'm concerned because without such guard it will generate the query using `@>` which would fail to return the expected results _silently_.