### PR TITLE
Handle aliased Ecto.Query.Tagged type expression

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -750,6 +750,17 @@ if Code.ensure_loaded?(Postgrex) do
       ["'\\x", Base.encode16(binary, case: :lower) | "'::bytea"]
     end
 
+    defp expr(
+           %Ecto.Query.Tagged{
+             value: {{:., [type: type], [_, field]}, [], []} = other,
+             type: {{{:., _, [_, :count_alias!]}, _, _}, field}
+           },
+           sources,
+           query
+         ) do
+      [maybe_paren(other, sources, query), ?:, ?: | tagged_to_db(type)]
+    end
+
     defp expr(%Ecto.Query.Tagged{value: other, type: type}, sources, query) do
       [maybe_paren(other, sources, query), ?:, ?: | tagged_to_db(type)]
     end

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -109,6 +109,19 @@ defmodule Ecto.Adapters.PostgresTest do
     assert all(query) == ~s{SELECT s0."x", s0."z" FROM (SELECT ss0."x" AS "x", ss0."z" AS "z" FROM (SELECT ssp0."x" AS "x", ssp0."y" AS "z" FROM "posts" AS ssp0) AS ss0) AS s0}
   end
 
+  test "select cast to named column type" do
+    named_typed_column = from(Schema, as: :s) |> select([s: s], type(s.x, s.x)) |> plan()
+    assert all(named_typed_column) == ~s{SELECT s0."x"::bigint FROM "schema" AS s0}
+
+    named_typed_column_joined =
+      from(Schema2, as: :s2)
+      |> join(:inner, [s2: s2], assoc(s2, :post), as: :s)
+      |> select([s: s], type(s.x, s.x))
+      |> plan()
+
+    assert all(named_typed_column_joined) =~ ~s{SELECT s1."x"::bigint}
+  end
+
   test "CTE" do
     initial_query =
       "categories"


### PR DESCRIPTION
Fixes:
Unable to cast a value when specifying its type is a name-bound column in a `select/3` expression. #400