### PR TITLE
Fix Invalid Syntax in Documentation

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -306,7 +306,7 @@ defmodule Ecto.Migration do
             use Ecto.Migration
 
             def after_begin() do
-              repo().query! "SET lock_timeout TO '5s'", "SET lock_timeout TO '10s'"
+              repo().query! "SET lock_timeout TO '5s'"
             end
           end
         end


### PR DESCRIPTION
The current example gives the following error:

```
** (FunctionClauseError) no function clause matching in Postgrex.DefaultTypes.encode_params/3    
    
    The following arguments were given to Postgrex.DefaultTypes.encode_params/3:
    
        # 1
        "SET lock_timeout TO '10s'"
    
        # 2
        []
    
        # 3
        []
    
    Attempted function clauses (showing 3 out of 3):
    
        defp encode_params([param | params], [type | types], encoded)
        defp encode_params([], [], encoded)
        defp encode_params(params, _, _) when is_list(params)
```