### PR TITLE
Release v3.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for v3.x
 
+## v3.8.2 (2022-05-18)
+
+### Bug fixes
+
+  * [postgres] Fix possible breaking change on `json_extract_path` for boolean values introduced in v3.8.0
+  * [sql] Colorize stacktrace and use `:` before printing line number 
+
 ## v3.8.1 (2022-04-29)
 
 ### Bug fixes

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule EctoSQL.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/elixir-ecto/ecto_sql"
-  @version "3.8.1"
+  @version "3.8.2"
   @adapters ~w(pg myxql tds)
 
   def project do


### PR DESCRIPTION
I hope this isn't presumptuous, but this PR makes the docs and `mix.exs` changes necessary to facilitate a minor version bump. (My team has been eager to get the enhancements from 3.8.0, but we rely on jsonb enough that we wanted to wait until #399 was tagged.)

I wasn't entirely sure how to classify the changes from #396. The `:` is arguably a bugfix, while colorization is arguably a minor enhancement... but also it seems like the project tries not to bump its version past that of `ecto` itself.

Thanks so much for the work you do maintaining this core infrastructure of the Elixir ecosystem.