### PR TITLE
Quote name

### DIFF
--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -355,6 +355,11 @@ defmodule Ecto.Adapters.MyXQL do
     end
   end
 
+  @impl true
+  def quote_name(name) do
+    Ecto.Adapters.MyXQL.Connection.quote_name(name)
+  end
+
   ## Helpers
 
   defp run_query(sql, opts) do

--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -239,7 +239,7 @@ if Code.ensure_loaded?(MyXQL) do
       |> IO.iodata_to_binary()
     end
 
-    @impl true
+    @doc false
     def quote_name(name) when is_atom(name),
       do: quote_name(Atom.to_string(name))
 

--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -239,6 +239,18 @@ if Code.ensure_loaded?(MyXQL) do
       |> IO.iodata_to_binary()
     end
 
+    @impl true
+    def quote_name(name) when is_atom(name),
+      do: quote_name(Atom.to_string(name))
+
+    def quote_name(name) do
+      if String.contains?(name, "`") do
+        error!(nil, "bad field name #{inspect name}")
+      end
+
+      [?`, name, ?`]
+    end
+
     ## Query generation
 
     binary_ops =
@@ -1037,17 +1049,6 @@ if Code.ensure_loaded?(MyXQL) do
         {%{aliases: %{^as => ix}}, sources} -> {ix, sources}
         {%{} = parent, _sources} -> get_parent_sources_ix(parent, as)
       end
-    end
-
-    defp quote_name(name) when is_atom(name),
-      do: quote_name(Atom.to_string(name))
-
-    defp quote_name(name) do
-      if String.contains?(name, "`") do
-        error!(nil, "bad field name #{inspect name}")
-      end
-
-      [?`, name, ?`]
     end
 
     defp quote_names(names), do: intersperse_map(names, ?,, &quote_name/1)

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -301,6 +301,11 @@ defmodule Ecto.Adapters.Postgres do
     end
   end
 
+  @impl true
+  def quote_name(name) do
+    Ecto.Adapters.Postgres.Connection.quote_name(name)
+  end
+
   ## Helpers
 
   defp run_query(sql, opts) do

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -187,6 +187,17 @@ if Code.ensure_loaded?(Postgrex) do
        values, on_conflict(on_conflict, header) | returning(returning)]
     end
 
+    @impl true
+    def quote_name(name) when is_atom(name) do
+      quote_name(Atom.to_string(name))
+    end
+    def quote_name(name) do
+      if String.contains?(name, "\"") do
+        error!(nil, "bad field name #{inspect name}")
+      end
+      [?", name, ?"]
+    end
+
     defp insert_as({%{sources: sources}, _, _}) do
       {_expr, name, _schema} = create_name(sources, 0, [])
       [" AS " | name]
@@ -1277,16 +1288,6 @@ if Code.ensure_loaded?(Postgrex) do
 
     defp quote_names(names) do
       intersperse_map(names, ?,, &quote_name/1)
-    end
-
-    defp quote_name(name) when is_atom(name) do
-      quote_name(Atom.to_string(name))
-    end
-    defp quote_name(name) do
-      if String.contains?(name, "\"") do
-        error!(nil, "bad field name #{inspect name}")
-      end
-      [?", name, ?"]
     end
 
     defp quote_table(nil, name),    do: quote_table(name)

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -187,7 +187,7 @@ if Code.ensure_loaded?(Postgrex) do
        values, on_conflict(on_conflict, header) | returning(returning)]
     end
 
-    @impl true
+    @doc false
     def quote_name(name) when is_atom(name) do
       quote_name(Atom.to_string(name))
     end

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -169,7 +169,7 @@ defmodule Ecto.Adapters.SQL do
         Ecto.Adapters.SQL.stream(adapter_meta, query_meta, query, params, opts)
       end
 
-      @imple true
+      @impl true
       def quote_name(name) do
         Ecto.Adapters.SQL.quote_name(name)
       end
@@ -1006,7 +1006,7 @@ defmodule Ecto.Adapters.SQL do
     if String.contains?(name, "\"") do
       raise "bad field name to quote #{inspect name}"
     end
-    [?", name, ?"]
+    [?<, name, ?>]
   end
 
   ## Transactions

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -169,6 +169,11 @@ defmodule Ecto.Adapters.SQL do
         Ecto.Adapters.SQL.stream(adapter_meta, query_meta, query, params, opts)
       end
 
+      @imple true
+      def quote_name(name) do
+        Ecto.Adapters.SQL.quote_name(name)
+      end
+
       ## Schema
 
       @impl true
@@ -229,7 +234,7 @@ defmodule Ecto.Adapters.SQL do
       end
 
       defoverridable [prepare: 2, execute: 5, insert: 6, update: 6, delete: 4, insert_all: 8,
-                      execute_ddl: 3, loaders: 2, dumpers: 2, autogenerate: 1,
+                      quote_name: 1, execute_ddl: 3, loaders: 2, dumpers: 2, autogenerate: 1,
                       ensure_all_started: 2, __before_compile__: 1]
     end
   end
@@ -991,6 +996,17 @@ defmodule Ecto.Adapters.SQL do
           constraints -> {:invalid, constraints}
         end
     end
+  end
+
+  @doc false
+  def quote_name(name) when is_atom(name) do
+    quote_name(Atom.to_string(name))
+  end
+  def quote_name(name) do
+    if String.contains?(name, "\"") do
+      raise "bad field name to quote #{inspect name}"
+    end
+    [?", name, ?"]
   end
 
   ## Transactions

--- a/lib/ecto/adapters/sql/connection.ex
+++ b/lib/ecto/adapters/sql/connection.ex
@@ -133,10 +133,4 @@ defmodule Ecto.Adapters.SQL.Connection do
   """
   @callback table_exists_query(table :: String.t) :: {iodata, [term]}
 
-  @doc """
-  Returns a safe quoted name that can be used as an
-  identifier (table name, column name, collation name, ..)
-  """
-  @callback quote_name(name :: String.t) :: String.t
-
 end

--- a/lib/ecto/adapters/sql/connection.ex
+++ b/lib/ecto/adapters/sql/connection.ex
@@ -132,4 +132,11 @@ defmodule Ecto.Adapters.SQL.Connection do
   Returns a queryable to check if the given `table` exists.
   """
   @callback table_exists_query(table :: String.t) :: {iodata, [term]}
+
+  @doc """
+  Returns a safe quoted name that can be used as an
+  identifier (table name, column name, collation name, ..)
+  """
+  @callback quote_name(name :: String.t) :: String.t
+
 end

--- a/lib/ecto/adapters/tds.ex
+++ b/lib/ecto/adapters/tds.ex
@@ -295,4 +295,8 @@ defmodule Ecto.Adapters.Tds do
 
     result
   end
+
+  def quote_name(name) do
+    Ecto.Adapters.Tds.Connection.quote_name(name)
+  end
 end

--- a/lib/ecto/adapters/tds/connection.ex
+++ b/lib/ecto/adapters/tds/connection.ex
@@ -78,6 +78,19 @@ if Code.ensure_loaded?(Tds) do
 
     def to_constraints(_, _opts), do: []
 
+    @impl true
+    def quote_name(name) when is_atom(name) do
+      quote_name(Atom.to_string(name))
+    end
+
+    def quote_name(name) do
+      if String.contains?(name, ["[", "]"]) do
+        error!(nil, "bad field name #{inspect(name)} '[' and ']' are not permitted")
+      end
+
+      "[#{name}]"
+    end
+
     defp prepare_params(params) do
       {params, _} =
         Enum.map_reduce(params, 1, fn param, acc ->
@@ -1505,18 +1518,6 @@ if Code.ensure_loaded?(Tds) do
         {%{aliases: %{^as => ix}}, sources} -> {ix, sources}
         {%{} = parent, _sources} -> get_parent_sources_ix(parent, as)
       end
-    end
-
-    defp quote_name(name) when is_atom(name) do
-      quote_name(Atom.to_string(name))
-    end
-
-    defp quote_name(name) do
-      if String.contains?(name, ["[", "]"]) do
-        error!(nil, "bad field name #{inspect(name)} '[' and ']' are not permitted")
-      end
-
-      "[#{name}]"
     end
 
     defp quote_names(names), do: intersperse_map(names, ?,, &quote_name/1)

--- a/lib/ecto/adapters/tds/connection.ex
+++ b/lib/ecto/adapters/tds/connection.ex
@@ -78,7 +78,7 @@ if Code.ensure_loaded?(Tds) do
 
     def to_constraints(_, _opts), do: []
 
-    @impl true
+    @doc false
     def quote_name(name) when is_atom(name) do
       quote_name(Atom.to_string(name))
     end

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -671,6 +671,18 @@ defmodule Ecto.Adapters.MyXQLTest do
     assert all(query) == String.trim(result)
   end
 
+  test "fragment with escaped parameter" do
+    query =
+      plan from(e in "schema",
+        select: true,
+        order_by: fragment("? COLLATE ?", e.binary, escape!("en-x-icu")))
+
+    result =
+      "SELECT TRUE FROM `schema` AS s0 ORDER BY s0.`binary` COLLATE `en-x-icu`"
+
+    assert all(query) == String.trim(result)
+  end
+
   test "build_explain_query" do
     assert SQL.build_explain_query("SELECT 1") == "EXPLAIN SELECT 1"
   end

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -785,6 +785,18 @@ defmodule Ecto.Adapters.PostgresTest do
     assert all(query) == String.trim(result)
   end
 
+  test "fragment with escaped parameter" do
+    query =
+      plan from(e in "schema",
+        select: true,
+        order_by: fragment("? COLLATE ?", e.binary, escape!("en-x-icu")))
+
+    result =
+      "SELECT TRUE FROM \"schema\" AS s0 ORDER BY s0.\"binary\" COLLATE \"en-x-icu\""
+
+    assert all(query) == String.trim(result)
+  end
+
   test "build_explain_query" do
      assert_raise(ArgumentError, "bad boolean value T", fn ->
        SQL.build_explain_query("SELECT 1", analyze: "T")

--- a/test/ecto/adapters/tds_test.exs
+++ b/test/ecto/adapters/tds_test.exs
@@ -322,7 +322,7 @@ defmodule Ecto.Adapters.TdsTest do
       |> select([:id, :parent_id])
 
     cte_query = initial_query |> union_all(^iteration_query)
-    
+
     breadcrumbs_query =
       "tree"
       |> recursive_ctes(true)
@@ -799,6 +799,18 @@ defmodule Ecto.Adapters.TdsTest do
     result =
       "SELECT CAST(1 as bit) FROM [schema] AS s0 " <>
         "WHERE (s0.[start_time] = \"query?\")"
+
+    assert all(query) == String.trim(result)
+  end
+
+  test "fragment with escaped parameter" do
+    query =
+      plan from(e in "schema",
+        select: true,
+        order_by: fragment("? COLLATE ?", e.binary, escape!("en-x-icu")))
+
+    result =
+      "SELECT CAST(1 as bit) FROM [schema] AS s0 ORDER BY s0.[binary] COLLATE [en-x-icu]"
 
     assert all(query) == String.trim(result)
   end

--- a/test/test_repo.exs
+++ b/test/test_repo.exs
@@ -72,6 +72,10 @@ defmodule EctoSQL.TestAdapter do
     {:ok, []}
   end
 
+  def quote_name(name) do
+    [?<, name, ?>]
+  end
+
   def in_transaction?(_), do: Process.get(:in_transaction?) || false
 
   def transaction(mod, _opts, fun) do


### PR DESCRIPTION
This PR adds `quote_name/1` to the Ecto.Adapter behaviour and makes this previously private function to be public in order to support the [Fragment Escape](https://github.com/elixir-ecto/ecto/pull/3908) PR for Ecto.

It also adds `quote_name/1` implementations to each of the Postgres, MyXQL and TDS adapters with tests.
