### PR TITLE
Remove deprecated conflict_target definition

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -209,8 +209,6 @@ if Code.ensure_loaded?(Postgrex) do
     defp conflict_target!(target),
       do: conflict_target(target)
 
-    defp conflict_target({:constraint, constraint}),
-      do: ["ON CONSTRAINT ", quote_name(constraint), ?\s]
     defp conflict_target({:unsafe_fragment, fragment}),
       do: [fragment, ?\s]
     defp conflict_target([]),

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1222,9 +1222,6 @@ defmodule Ecto.Adapters.PostgresTest do
     query = insert(nil, "schema", [:x, :y], [[:x, :y]], {[:x, :y], [], [:id]}, [])
     assert query == ~s{INSERT INTO "schema" ("x","y") VALUES ($1,$2) ON CONFLICT ("id") DO UPDATE SET "x" = EXCLUDED."x","y" = EXCLUDED."y"}
 
-    query = insert(nil, "schema", [:x, :y], [[:x, :y]], {[:x, :y], [], {:constraint, :foo}}, [])
-    assert query == ~s{INSERT INTO "schema" ("x","y") VALUES ($1,$2) ON CONFLICT ON CONSTRAINT \"foo\" DO UPDATE SET "x" = EXCLUDED."x","y" = EXCLUDED."y"}
-
     query = insert(nil, "schema", [:x, :y], [[:x, :y]], {[:x, :y], [], {:unsafe_fragment, "(\"id\")"}}, [])
     assert query == ~s{INSERT INTO "schema" ("x","y") VALUES ($1,$2) ON CONFLICT (\"id\") DO UPDATE SET "x" = EXCLUDED."x","y" = EXCLUDED."y"}
 


### PR DESCRIPTION
## Summary

Ecto 3.4.1 [removed support for passing `conflict_target: {:constraint, :index}` when doing upserts with Repo.insert](https://github.com/elixir-ecto/ecto/blob/master/CHANGELOG.md#deprecations)

Given that ecto_sql 3.8.2 requires ecto ~> 3.8.1, I think this definition can also be removed. PG test suite passes after the removal.

## Other notes
Is there interest in giving a saner error message if you try to use the deprecated option? Currently, it gets wrapped into a list so it matches `conflict_target(targets)`, resulting in:
```
 ** (FunctionClauseError) no function clause matching in String.contains?/2

     The following arguments were given to String.contains?/2:
     
         # 1
         {:constraint, :constraint}
     
         # 2
         "\""
     
     Attempted function clauses (showing 3 out of 3):
     
         def contains?(string, -[]-) when -is_binary(string)-
         def contains?(string, contents) when -is_binary(string)- and -is_list(contents)-
         def contains?(string, contents) when -is_binary(string)-
```

I could open a PR to change [this](https://github.com/elixir-ecto/ecto/blob/46ab2638708e92f0f21d806f8929d0f674841a82/lib/ecto/repo/schema.ex#L663) to `%{} when is_atom(target) or is_tuple(target) ->`, resulting in:
```
** (ArgumentError) unknown field `{:constraint, :constraint}` in conflict_target
```

#### Disclaimer
I looked into this during my unstructured development time at https://github.com/Latermedia