### PR TITLE
Add note about `modify/3` potentially locking the table

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1062,7 +1062,9 @@ defmodule Ecto.Migration do
   such as adding or dropping a null constraints, consider using
   the `execute/2` command with the relevant SQL command instead
   of `modify/3`, if supported by your database. This may avoid
-  redundant type updates and be more efficient.
+  redundant type updates and be more efficient, as an unnecessary
+  type update can lock the table, even if the type actually
+  doesn't change.
 
   ## Examples
 


### PR DESCRIPTION
The note about avoiding `modify/3` is extremely useful and helpful, however without knowing the background, I had to `git blame` to find out **why** it's inefficient in the mentioned cases - it locks the table. I think it would be good to have the reason noted here as well, as locking a table is often something that you definitely want to avoid.

Relevant links:
- https://groups.google.com/g/elixir-ecto/c/rBwdS0bXl4U/m/r2Ohs5eEBgAJ
- #353