### PR TITLE
Processes can join a transaction-in-progress

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -221,6 +221,14 @@ defmodule Ecto.Adapters.SQL do
         Ecto.Adapters.SQL.rollback(meta, value)
       end
 
+      def connection do
+        Ecto.Adapters.SQL.connection()
+      end
+
+      def join_transaction(conn) do
+        Ecto.Adapters.SQL.join_transaction(conn)
+      end
+
       ## Migration
 
       @impl true
@@ -1011,6 +1019,17 @@ defmodule Ecto.Adapters.SQL do
       %DBConnection{conn_mode: :transaction} = conn -> DBConnection.rollback(conn, value)
       _ -> raise "cannot call rollback outside of transaction"
     end
+  end
+
+  @doc false
+  def connection do
+    Process.get()
+    |> Enum.find(&match?({{__MODULE__, pid}, %DBConnection{conn_mode: :transaction}} when is_pid(pid), &1))
+  end
+
+  @doc false
+  def join_transaction({id, conn}) do
+    Process.put(id, conn)
   end
 
   ## Migrations


### PR DESCRIPTION
This is a proof-of-concept follow-up to #409. I believe it should be possible for a process to query a repo inside of a running transaction.

I think this would also need callbacks for transaction commit / rollback.