### PR TITLE
Allow :primary_key in Table to hold options

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -647,9 +647,10 @@ defmodule Ecto.Migration do
   ## Options
 
     * `:primary_key` - when `false`, a primary key field is not generated on table
-      creation. Alternatively, a keyword list can be supplied to control the
-      generation of the primary key field. The keyword list must include `:name`
-      and `:type`. See `add/3` for further options.
+      creation. Alternatively, a keyword list in the same style of the
+      `:migration_primary_key` repository configuration can be supplied
+      to control the generation of the primary key field. The keyword list
+      must include `:name` and `:type`. See `add/3` for further options.
     * `:engine` - customizes the table storage for supported databases. For MySQL,
       the default is InnoDB.
     * `:prefix` - the prefix for the table. This prefix will automatically be used

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1374,7 +1374,7 @@ defmodule Ecto.Migration do
       opts when is_list(opts) -> pk_opts_to_tuple(opts)
 
       _ ->
-        raise ArgumentError, "primary_key must be either a boolean or a keyword list of options"
+        raise ArgumentError, ":primary_key option must be either a boolean or a keyword list of options"
     end
   end
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1362,25 +1362,23 @@ defmodule Ecto.Migration do
 
   @doc false
   def __primary_key__(table) do
-    opts = case table.primary_key do
+    case table.primary_key do
       false -> false
 
       true ->
         case Runner.repo_config(:migration_primary_key, []) do
           false -> false
-          opts when is_list(opts) -> opts
+          opts when is_list(opts) -> pk_opts_to_tuple(opts)
         end
 
-      opts when is_list(opts) -> opts
+      opts when is_list(opts) -> pk_opts_to_tuple(opts)
     end
-    
-    case opts do
-      false -> false
-      opts when is_list(opts) ->
-        opts = Keyword.put(opts, :primary_key, true)
-        {name, opts} = Keyword.pop(opts, :name, :id)
-        {type, opts} = Keyword.pop(opts, :type, :bigserial)
-        {name, type, opts}
-    end
+  end
+  
+  defp pk_opts_to_tuple(opts) do
+    opts = Keyword.put(opts, :primary_key, true)
+    {name, opts} = Keyword.pop(opts, :name, :id)
+    {type, opts} = Keyword.pop(opts, :type, :bigserial)
+    {name, type, opts}
   end
 end

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1372,9 +1372,12 @@ defmodule Ecto.Migration do
         end
 
       opts when is_list(opts) -> pk_opts_to_tuple(opts)
+
+      _ ->
+        raise ArgumentError, "primary_key must be either a boolean or a keyword list of options"
     end
   end
-  
+
   defp pk_opts_to_tuple(opts) do
     opts = Keyword.put(opts, :primary_key, true)
     {name, opts} = Keyword.pop(opts, :name, :id)

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -478,7 +478,6 @@ defmodule Ecto.Migration do
     quote do
       table = %Table{} = unquote(object)
       Runner.start_command({unquote(command), Ecto.Migration.__prefix__(table)})
-      
       if primary_key = Ecto.Migration.__primary_key__(table) do
         {name, type, opts} = primary_key
         add(name, type, opts)

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -478,6 +478,7 @@ defmodule Ecto.Migration do
     quote do
       table = %Table{} = unquote(object)
       Runner.start_command({unquote(command), Ecto.Migration.__prefix__(table)})
+
       if primary_key = Ecto.Migration.__primary_key__(table) do
         {name, type, opts} = primary_key
         add(name, type, opts)

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -243,6 +243,14 @@ defmodule Ecto.MigrationTest do
            {:create, table, [{:add, :id, :uuid, [primary_key: true, default: {:fragment, "gen_random_uuid()"}]}]}
   end
 
+  test "forward: passing a value other than a bool to :primary_key on table/2 raises" do
+    assert_raise ArgumentError, "primary_key must be either a boolean or a keyword list of options", fn ->
+      create(table(:posts, primary_key: "not a valid value")) do
+      end
+      flush()
+    end
+  end
+
   @tag repo_config: [migration_primary_key: false]
   test "forward: create a table without a primary key by default via repo config" do
     create(table = table(:posts))

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -216,9 +216,26 @@ defmodule Ecto.MigrationTest do
            {:create, table, [{:add, :uuid, :uuid, [primary_key: true]}]}
   end
 
+  test "forward: create a table with only custom primary key via table options" do
+    create(table = table(:posts, primary_key: [name: :uuid, type: :uuid]))
+    flush()
+
+    assert last_command() ==
+           {:create, table, [{:add, :uuid, :uuid, [primary_key: true]}]}
+  end
+
   @tag repo_config: [migration_primary_key: [type: :uuid, default: {:fragment, "gen_random_uuid()"}]]
   test "forward: create a table with custom primary key options" do
     create(table = table(:posts)) do
+    end
+    flush()
+
+    assert last_command() ==
+           {:create, table, [{:add, :id, :uuid, [primary_key: true, default: {:fragment, "gen_random_uuid()"}]}]}
+  end
+
+  test "forward: create a table with custom primary key options via table options" do
+    create(table = table(:posts, primary_key: [type: :uuid, default: {:fragment, "gen_random_uuid()"}])) do
     end
     flush()
 

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -244,7 +244,7 @@ defmodule Ecto.MigrationTest do
   end
 
   test "forward: passing a value other than a bool to :primary_key on table/2 raises" do
-    assert_raise ArgumentError, "primary_key must be either a boolean or a keyword list of options", fn ->
+    assert_raise ArgumentError, ":primary_key option must be either a boolean or a keyword list of options", fn ->
       create(table(:posts, primary_key: "not a valid value")) do
       end
       flush()


### PR DESCRIPTION
In response to the discussion at https://groups.google.com/g/elixir-ecto/c/jWBShTQzK7M

Allows the following:

```elixir
defmodule MyMigration do
  defmacro __using__(_opts) do
    quote do
      use Ecto.Migration
      import Ecto.Migration, except: [table: 1, table: 2]
      import MyMigration
    end
  end

  def table(name, opts \\ []) do
    {id_length, opts} = Keyword.pop(opts, :id_length, 3)
    {_primary_key, opts} = Keyword.pop(opts, :primary_key)

    primary_key = [
      name: :id,
      type: :string,
      autogenerate: false,
      read_after_writes: true,
      default: {:fragment, "generate_random_id(current_schema(), '#{name}', 'id', #{id_length})"}
    ]

    opts = Keyword.put(opts, :primary_key, primary_key)

    Ecto.Migration.table(name, opts)
  end
end
```

`:primary_key` is stored into `Table` and is then used by `Ecto.Migration.__primary_key__/1` to determine the properties of the primary key to add to the migration.