### PR TITLE
Stacktrace test

### DIFF
--- a/integration_test/sql/logging.exs
+++ b/integration_test/sql/logging.exs
@@ -76,8 +76,7 @@ defmodule Ecto.Integration.LoggingTest do
     @stacktrace_opts [stacktrace: true, log: :error]
 
     defp stacktrace_entry(line) do
-      "↳ anonymous fn/0 in Ecto.Integration.LoggingTest.\"test logs includes stacktraces\"/1, " <>
-        "at: integration_test/sql/logging.exs:#{line - 3}"
+      ~r/↳ anonymous fn\/0 in Ecto.Integration.LoggingTest.\"test logs includes stacktraces\"\/1, at: .*integration_test\/sql\/logging.exs:#{line - 3}/
     end
 
     test "when some measurements are nil" do


### PR DESCRIPTION
the previous regex created issues for custom adapters because the integration tests are inside the `deps` directory.