### PR TITLE
Add `pg_advisory_lock` as alternative locking strategy for Postgres

### DIFF
--- a/integration_test/pg/migrations_test.exs
+++ b/integration_test/pg/migrations_test.exs
@@ -52,8 +52,8 @@ defmodule Ecto.Integration.MigrationsTest do
 
   describe "Migrator" do
     @get_lock_command ~s(LOCK TABLE "schema_migrations" IN SHARE UPDATE EXCLUSIVE MODE)
-    @get_advisory_lock_command ~s[SELECT pg_try_advisory_lock(52584692)]
-    @release_advisory_lock_command ~s[SELECT pg_advisory_unlock(52584692)]
+    @get_advisory_lock_command ~s[SELECT pg_try_advisory_lock(7535270)]
+    @release_advisory_lock_command ~s[SELECT pg_advisory_unlock(7535270)]
     @create_table_sql ~s(CREATE TABLE IF NOT EXISTS "log_mode_table")
     @create_table_log "create table if not exists log_mode_table"
     @drop_table_sql ~s(DROP TABLE IF EXISTS "log_mode_table")

--- a/integration_test/pg/migrations_test.exs
+++ b/integration_test/pg/migrations_test.exs
@@ -52,7 +52,7 @@ defmodule Ecto.Integration.MigrationsTest do
 
   describe "Migrator" do
     @get_lock_command ~s(LOCK TABLE "schema_migrations" IN SHARE UPDATE EXCLUSIVE MODE)
-    @get_advisory_lock_command ~s[SELECT pg_advisory_lock(52584692)]
+    @get_advisory_lock_command ~s[SELECT pg_try_advisory_lock(52584692)]
     @release_advisory_lock_command ~s[SELECT pg_advisory_unlock(52584692)]
     @create_table_sql ~s(CREATE TABLE IF NOT EXISTS "log_mode_table")
     @create_table_log "create table if not exists log_mode_table"

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -40,6 +40,12 @@ defmodule Ecto.Adapters.Postgres do
   `:migration_advisory_lock_retry_interval_ms` and `:migration_advisory_lock_max_tries`.
   If the retries are exhausted, the migration will fail.
 
+  Some downsides to using advisory locks is that some Postgres-compatible systems or plugins
+  may not support session level locks well and therefore result in inconsistent behavior.
+  For example, PgBouncer when using pool_modes other than session won't work well with
+  advisory locks. CockroachDB is another system that is designed in a way that advisory
+  locks don't make sense for their distributed database.
+
   ### Connection options
 
     * `:hostname` - Server hostname

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -257,7 +257,7 @@ defmodule Ecto.Adapters.Postgres do
   end
 
   defp do_lock_for_migrations(:pg_advisory_lock, meta, opts, fun) do
-    lock = :erlang.phash2("ecto_#{inspect(meta.repo)}")
+    lock = :erlang.phash2({:ecto, meta.repo})
     config = meta.repo.config()
 
     opts =

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1172,11 +1172,12 @@ defmodule Ecto.Adapters.SQL do
     with [_ | _] <- stacktrace,
          {module, function, arity, info} <- last_non_ecto(Enum.reverse(stacktrace), repo, nil) do
       [
-        IO.ANSI.light_black(),
         ?\n,
+        IO.ANSI.light_black(),
         "↳ ",
         Exception.format_mfa(module, function, arity),
-        log_stacktrace_info(info)
+        log_stacktrace_info(info),
+        IO.ANSI.reset(),
       ]
     else
       _ -> []

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -708,6 +708,7 @@ defmodule Ecto.Migration do
   You can address this with two changes:
 
     1. Change your repository to use PG advisory locks as the migration lock.
+       Note this may not be supported by Postgres-like databases and proxies.
 
     2. Disable DDL transactions. Doing this removes the guarantee that all of
       the changes in the migration will happen at once, so you will want to

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -234,7 +234,9 @@ defmodule Ecto.Migration do
       supported by the adapter. See the adapter docs for more information.
 
           config :app, App.Repo, migration_lock: false
-          # Or to use the alternate Postgres lock strategy using advisory locks:
+          # Or use a different locking strategy. For example, Postgres can use advisory
+          # locks but be aware that your database configuration might not make this a good
+          # fit. See the Ecto.Adapters.Postgres for more information:
           config :app, App.Repo, migration_lock: :pg_advisory_lock
 
     * `:migration_default_prefix` - Ecto defaults to `nil` for the database prefix for

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -306,34 +306,8 @@ defmodule Ecto.Migration.Runner do
   end
 
   defp log_and_execute_ddl(repo, migration, log, {instruction, %Index{} = index}) do
-    if index.concurrently do
-      migration_config = migration.__migration__()
-
-      if not migration_config[:disable_ddl_transaction] do
-        IO.warn """
-        Migration #{inspect(migration)} has set index `#{index.name}` on table \
-        `#{index.table}` to concurrently but did not disable ddl transaction. \
-        Please set:
-
-            use Ecto.Migration
-            @disable_ddl_transaction true
-
-        """, []
-      end
-
-      if not migration_config[:disable_migration_lock] do
-        IO.warn """
-        Migration #{inspect(migration)} has set index `#{index.name}` on table \
-        `#{index.table}` to concurrently but did not disable migration lock. \
-        Please set:
-
-            use Ecto.Migration
-            @disable_migration_lock true
-
-        """, []
-      end
-    end
-
+    maybe_warn_index_ddl_transaction(index, migration)
+    maybe_warn_index_migration_lock(index, repo, migration)
     log_and_execute_ddl(repo, log, {instruction, index})
   end
 
@@ -362,6 +336,62 @@ defmodule Ecto.Migration.Runner do
   defp log(false, _msg, _metadata), do: :ok
   defp log(true, msg, metadata), do: Logger.log(:info, msg, metadata)
   defp log(level, msg, metadata),  do: Logger.log(level, msg, metadata)
+
+  defp maybe_warn_index_ddl_transaction(%{concurrently: true} = index, migration) do
+    migration_config = migration.__migration__()
+
+    if not migration_config[:disable_ddl_transaction] do
+      IO.warn """
+      Migration #{inspect(migration)} has set index `#{index.name}` on table \
+      `#{index.table}` to concurrently but did not disable ddl transaction. \
+      Please set:
+
+          use Ecto.Migration
+          @disable_ddl_transaction true
+      """, []
+    end
+  end
+  defp maybe_warn_index_ddl_transaction(_index, _migration), do: :ok
+
+  defp maybe_warn_index_migration_lock(%{concurrently: true} = index, repo, migration) do
+    migration_lock_disabled = migration.__migration__()[:disable_migration_lock]
+    lock_strategy = repo.config()[:migration_lock]
+    adapter = repo.__adapter__()
+
+    case {migration_lock_disabled, adapter, lock_strategy} do
+      {false, Ecto.Adapters.Postgres, :pg_advisory_lock} ->
+        :ok
+
+      {false, Ecto.Adapters.Postgres, _} ->
+        IO.warn """
+        Migration #{inspect(migration)} has set index `#{index.name}` on table \
+        `#{index.table}` to concurrently but did not disable migration lock. \
+        Please set:
+
+            use Ecto.Migration
+            @disable_migration_lock true
+
+        Alternatively, consider using advisory locks during migrations in the \
+        repo configuration:
+
+            config #{repo |> Module.split() |> Enum.join(".")}, migration_lock: :pg_advisory_lock
+        """, []
+
+      {false, _adapter, _migration_lock} ->
+        IO.warn """
+        Migration #{inspect(migration)} has set index `#{index.name}` on table \
+        `#{index.table}` to concurrently but did not disable migration lock. \
+        Please set:
+
+            use Ecto.Migration
+            @disable_migration_lock true
+        """, []
+
+      _ ->
+        :ok
+    end
+  end
+  defp maybe_warn_index_migration_lock(_index, _repo, _migration), do: :ok
 
   defp command(ddl) when is_binary(ddl) or is_list(ddl),
     do: "execute #{inspect ddl}"

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -374,7 +374,7 @@ defmodule Ecto.Migration.Runner do
         Alternatively, consider using advisory locks during migrations in the \
         repo configuration:
 
-            config #{repo |> Module.split() |> Enum.join(".")}, migration_lock: :pg_advisory_lock
+            config #{inspect(repo)}, migration_lock: :pg_advisory_lock
         """, []
 
       {false, _adapter, _migration_lock} ->


### PR DESCRIPTION
Add Repo configuration options utilized by the Postgres adapter. 
- `migration_lock: :pg_advisory_lock` (default is still `true` which uses a database transaction)
- `migration_advisory_lock_max_retries: int | :infinity`
- `migration_advisory_lock_retry_interval_ms: int`
- If using the pg_advisory_lock migration lock strategy, the default max retries is `:infinity` and the interval is 5 seconds. If it's configured to have a finite max retry and it is exhausted the migration will fail-- see failure message sample below.

In this screenshot, I'm using an npm package concurrently to help me run migrations async on the same machine to simulate multiple nodes spinning up and attempting the same migrations on the same database. In this example, I have 3 nodes running at once, with their stdout prefixed with [0] [1] [2]. `CMD="mix ecto.migrate --log-migrator-sql --log-migrations-sql"` Instance 0 obtained the lock while 1 and 2 are waiting.

The test app configured the Repo with `migration_lock: :pg_advisory_lock`; otherwise it was a plain Phoenix/Ecto app.

<img width="993" alt="image" src="https://user-images.githubusercontent.com/643967/179844074-919c21c6-238c-4086-98e2-b84225bcb1a6.png">

Demo here:
https://asciinema.org/a/7R4gVIRO20UNW9sOCP9dvra0s

I'm not happy with the test story on this; I'd love to get a written test to assert this new behavior but I wasn't sure how to do that. If you have any advice, I'll take it and add as much tests as I can.

No defaults changed-- this is an opt-in option.

I also ran into a logger bug that polluted the next logged lines' format; I fixed it here.

Resolves #365 

Failure message sample and exits with status code 1:
<img width="1293" alt="image" src="https://user-images.githubusercontent.com/643967/179845939-474c7fdd-e2fb-45fc-9512-6bb73b02a769.png">

<details>
<summary>full output for one node</summary>

```
migrate_test ❯ mix ecto.migrate --log-migrations-sql --log-migrator-sql

17:09:23.969 [debug] QUERY OK db=0.1ms
SELECT pg_try_advisory_lock(78770566) []

17:09:23.977 [debug] QUERY OK db=0.1ms
SELECT pg_advisory_unlock(78770566) []

17:09:23.999 [debug] QUERY OK db=0.1ms
SELECT pg_try_advisory_lock(78770566) []

17:09:24.002 [debug] QUERY OK db=0.1ms idle=22.8ms
begin []
↳ Ecto.Migrator.run_maybe_in_transaction/5, at: lib/ecto/migrator.ex:337

17:09:24.003 [info]  == Running 20220719165517 MigrateTest.Repo.Migrations.BigTable.up/0 forward

17:09:24.003 [info]  create table big_table

17:09:24.014 [debug] QUERY OK db=10.1ms
CREATE TABLE "big_table" ("id" bigserial, "foo" varchar(255), PRIMARY KEY ("id")) []

17:09:24.015 [info]  execute "INSERT INTO big_table (foo)\n  SELECT LEFT(MD5(random()::text), 10)\n  FROM generate_series(1, 5000000) s(i)\n"

17:09:34.716 [debug] QUERY OK db=10700.8ms
INSERT INTO big_table (foo)
  SELECT LEFT(MD5(random()::text), 10)
  FROM generate_series(1, 5000000) s(i)
 []

17:09:34.718 [info]  == Migrated 20220719165517 in 10.7s

17:09:34.737 [debug] QUERY OK db=0.9ms
INSERT INTO "schema_migrations" ("version","inserted_at") VALUES ($1,$2) [20220719165517, ~N[2022-07-19 21:09:34]]
↳ anonymous fn/6 in Ecto.Migrator.async_migrate_maybe_in_transaction/7, at: lib/ecto/migrator.ex:320

17:09:34.757 [debug] QUERY OK db=20.0ms
commit []
↳ Ecto.Migrator.run_maybe_in_transaction/5, at: lib/ecto/migrator.ex:337

17:09:34.758 [debug] QUERY OK db=0.2ms
SELECT pg_advisory_unlock(78770566) []

17:09:34.758 [debug] QUERY OK db=0.1ms
SELECT pg_try_advisory_lock(78770566) []

17:09:34.758 [info]  == Running 20220719165921 MigrateTest.Repo.Migrations.LengthyIndex.change/0 forward

17:09:34.759 [info]  create index big_table_foo_index

17:09:42.589 [debug] QUERY OK db=7829.9ms queue=0.1ms idle=0.6ms
CREATE INDEX CONCURRENTLY "big_table_foo_index" ON "big_table" ("foo") []

17:09:42.589 [info]  == Migrated 20220719165921 in 7.8s

17:09:42.591 [debug] QUERY OK db=1.5ms queue=0.2ms idle=0.2ms
INSERT INTO "schema_migrations" ("version","inserted_at") VALUES ($1,$2) [20220719165921, ~N[2022-07-19 21:09:42]]
↳ anonymous fn/6 in Ecto.Migrator.async_migrate_maybe_in_transaction/7, at: lib/ecto/migrator.ex:320

17:09:42.591 [debug] QUERY OK db=0.1ms
SELECT pg_advisory_unlock(78770566) []
```
</details>