### PR TITLE
Use prefix in advisory lock key

### DIFF
--- a/integration_test/pg/migrations_test.exs
+++ b/integration_test/pg/migrations_test.exs
@@ -52,8 +52,8 @@ defmodule Ecto.Integration.MigrationsTest do
 
   describe "Migrator" do
     @get_lock_command ~s(LOCK TABLE "schema_migrations" IN SHARE UPDATE EXCLUSIVE MODE)
-    @get_advisory_lock_command ~s[SELECT pg_try_advisory_lock(7535270)]
-    @release_advisory_lock_command ~s[SELECT pg_advisory_unlock(7535270)]
+    @get_advisory_lock_command ~s[SELECT pg_try_advisory_lock(129653361)]
+    @release_advisory_lock_command ~s[SELECT pg_advisory_unlock(129653361)]
     @create_table_sql ~s(CREATE TABLE IF NOT EXISTS "log_mode_table")
     @create_table_log "create table if not exists log_mode_table"
     @drop_table_sql ~s(DROP TABLE IF EXISTS "log_mode_table")

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -261,7 +261,7 @@ defmodule Ecto.Adapters.Postgres do
   end
 
   defp do_lock_for_migrations(:pg_advisory_lock, meta, opts, config, fun) do
-    lock = :erlang.phash2({:ecto, meta.repo})
+    lock = :erlang.phash2({:ecto, opts[:prefix], meta.repo})
 
     retry_state = %{
       retry_interval_ms: config[:migration_advisory_lock_retry_interval_ms] || 5000,


### PR DESCRIPTION
It's not too unusual to have different nodes per prefix that should be allowed to migrate concurrently.