### PR TITLE
feat: enforce explicit declaration of timestamp migration options

### DIFF
--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -282,6 +282,46 @@ defmodule Ecto.MigrationTest do
               {:add, :updated_at, :utc_datetime, [null: true]}]}
   end
 
+  @tag repo_config: [migration_timestamps: :explicitly_defined]
+  test "forward: enforces the timestamps :inserted_at option to be explicitly defined" do
+    assert_raise ArgumentError, "timestamps is missing explicit :inserted_at option", fn ->
+      create(table(:posts)) do
+        timestamps()
+      end
+      flush()
+    end
+  end
+
+  @tag repo_config: [migration_timestamps: :explicitly_defined]
+  test "forward: enforces the timestamps :updated_at option to be explicitly defined" do
+    assert_raise ArgumentError, "timestamps is missing explicit :updated_at option", fn ->
+      create(table(:posts)) do
+        timestamps(inserted_at: :inserted_at)
+      end
+      flush()
+    end
+  end
+
+  @tag repo_config: [migration_timestamps: :explicitly_defined]
+  test "forward: enforces the timestamps :type option to be explicitly defined" do
+    assert_raise ArgumentError, "timestamps is missing explicit :type option", fn ->
+      create(table(:posts)) do
+        timestamps(inserted_at: :inserted_at, updated_at: :updated_at)
+      end
+      flush()
+    end
+  end
+
+  @tag repo_config: [migration_timestamps: :explicitly_defined]
+  test "forward: enforces the timestamps :default option to be explicitly defined" do
+    assert_raise ArgumentError, "timestamps is missing explicit :default option", fn ->
+      create(table(:posts)) do
+        timestamps(inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime)
+      end
+      flush()
+    end
+  end
+
   test "forward: creates a table without precision option for numeric type" do
     assert_raise ArgumentError, "column cost is missing precision option", fn ->
       create(table(:posts)) do


### PR DESCRIPTION
In our application, we decided to configure `migration_timestamps`:

```elixir
config :my_app, MyApp.Repo,
  migration_timestamps: [
    type: :timestamptz,
    inserted_at: :row_inserted_at,
    updated_at: :row_updated_at
  ]
```

Due to such change, we started running into issues with 3rd party libraries like `Oban.Pro` and `Commanded.Projections.Ecto` that ship with some Ecto Schema and sometimes migrations that use `timestamps` that didn't configure the options for the `timestamps/1` migration function were failing because the fields weren't named correctly.

## Solution

- Allow enforcing explicit configuration for `timestamps` migration function.

## Reasoning

Having `migration_timestamps` introduces a lot of hassle we would discover after we deployed the application forcing us to deal with database rollbacks since, in cases like `Oban.Pro`, you may not be doing an integration test.

Also, if somebody changes the configuration, you may get a false positive because you would generally reset your local database or start from the beginning with a migration that will be technically out of sync. To make things worst (kind of), we would typically provide a new database on CI so that it wouldn't catch potential issues.

## Alternative

In an ideal scenario, we would just avoid the usage of `timestamps/1` migration function if Ecto didn't want to introduce the feature, but the 3rd party packages will still be affected by it. Such a configuration will allow us to determine which migrations need to be fixed. Also, I feel there is some value in helping people avoid such mistakes while maintaining the consistency of the timestamps configuration across the code base.

---- 

Any other suggestion on how to tackle the problem?