### PR TITLE
Allow user-defined function sources that begin with 'select'

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -599,7 +599,7 @@ if Code.ensure_loaded?(Postgrex) do
     defp operator_to_boolean(:or), do: " OR "
 
     defp parens_for_select([first_expr | _] = expr) do
-      if is_binary(first_expr) and String.match?(first_expr, ~r/^\s*select/i) do
+      if is_binary(first_expr) and String.match?(first_expr, ~r/^\s*select\s/i) do
         [?(, expr, ?)]
       else
         expr

--- a/lib/ecto/adapters/tds/connection.ex
+++ b/lib/ecto/adapters/tds/connection.ex
@@ -646,7 +646,7 @@ if Code.ensure_loaded?(Tds) do
     defp operator_to_boolean(:or), do: " OR "
 
     defp parens_for_select([first_expr | _] = expr) do
-      if is_binary(first_expr) and String.match?(first_expr, ~r/^\s*select/i) do
+      if is_binary(first_expr) and String.match?(first_expr, ~r/^\s*select\s/i) do
         [?(, expr, ?)]
       else
         expr

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -116,6 +116,9 @@ defmodule Ecto.Adapters.PostgresTest do
     query = from(fragment("select ? as x", ^"abc"), select: fragment("x")) |> plan()
     assert all(query) == ~s{SELECT x FROM (select $1 as x) AS f0}
 
+    query = from(f in fragment("select_rows(arg)"), select: f.x) |> plan()
+    assert all(query) == ~s{SELECT f0."x" FROM select_rows(arg) AS f0}
+
     assert_raise Ecto.QueryError, ~r"PostgreSQL adapter does not support selecting all fields from fragment", fn ->
       all from(f in fragment("select ? as x", ^"abc"), select: f) |> plan()
     end

--- a/test/ecto/adapters/tds_test.exs
+++ b/test/ecto/adapters/tds_test.exs
@@ -149,6 +149,9 @@ defmodule Ecto.Adapters.TdsTest do
     query = from(fragment("select ? as x", ^"abc"), select: fragment("x")) |> plan()
     assert all(query) == ~s{SELECT x FROM (select @1 as x) AS f0}
 
+    query = from(f in fragment("select_rows(arg)"), select: f.x) |> plan()
+    assert all(query) == ~s{SELECT f0.[x] FROM select_rows(arg) AS f0}
+
     assert_raise Ecto.QueryError, ~r"Tds adapter does not support selecting all fields from fragment", fn ->
       all from(f in fragment("select ? as x", ^"abc"), select: f) |> plan()
     end


### PR DESCRIPTION
This will allow users to use a fragment source with a function name beginning with `select`. I think this is safe because if we're dealing with a subquery then there has to be a space between select and the rest.

From what I've read, MySQL doesn't have anything like a function that can be used in `from` so i left it out.