### PR TITLE
fix missing clause in mysql `storage_down/1`

### DIFF
--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -210,6 +210,8 @@ defmodule Ecto.Adapters.MyXQL do
         {:error, :already_down}
       {:error, %{mysql: %{name: :ER_BAD_DB_ERROR}}} ->
         {:error, :already_down}
+      {:error, error} ->
+        {:error, Exception.message(error)}
       {:exit, :killed} ->
         {:error, :already_down}
       {:exit, exit} ->


### PR DESCRIPTION
When using the mysql adapter, trying to drop a database with an unreachable server, the following exception is raise:
```
** (CaseClauseError) no case clause matching: {:error, %DBConnection.ConnectionError{message: "connection not available and request was dropped from queue after 2997ms. This means requests are coming in and your connection pool cannot serve them fast enough. You can address this by:\n\n  1. Ensuring your database is available and that you can connect to it\n  2. Tracking down slow queries and making sure they are running fast enough\n  3. Increasing the pool_size (although this increases resource consumption)\n  4. Allowing requests to wait longer by increasing :queue_target and :queue_interval\n\nSee DBConnection.start_link/2 for more information\n", reason: :queue_timeout, severity: :error}}
    (ecto_sql 3.8.3) lib/ecto/adapters/myxql.ex:206: Ecto.Adapters.MyXQL.storage_down/1
    (ecto 3.8.4) lib/mix/tasks/ecto.drop.ex:81: Mix.Tasks.Ecto.Drop.drop_database/2
    (elixir 1.13.4) lib/enum.ex:937: Enum."-each/2-lists^foreach/1-0-"/2
    (mix 1.13.4) lib/mix/task.ex:397: anonymous fn/3 in Mix.Task.run_task/3
    (mix 1.13.4) lib/mix/cli.ex:84: Mix.CLI.run_task/2
```

this simple PR adds the missing clause to `storage_down/1`, just like it is done in `storage_up` or in the other adapters.