### PR TITLE
Log level fixes

### DIFF
--- a/integration_test/myxql/test_helper.exs
+++ b/integration_test/myxql/test_helper.exs
@@ -18,7 +18,8 @@ alias Ecto.Integration.TestRepo
 Application.put_env(:ecto_sql, TestRepo,
   url: Application.get_env(:ecto_sql, :mysql_test_url) <> "/ecto_test",
   pool: Ecto.Adapters.SQL.Sandbox,
-  show_sensitive_data_on_connection_error: true
+  show_sensitive_data_on_connection_error: true,
+  log: false
 )
 
 defmodule Ecto.Integration.TestRepo do

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -18,7 +18,8 @@ alias Ecto.Integration.TestRepo
 Application.put_env(:ecto_sql, TestRepo,
   url: Application.get_env(:ecto_sql, :pg_test_url) <> "/ecto_test",
   pool: Ecto.Adapters.SQL.Sandbox,
-  show_sensitive_data_on_connection_error: true
+  show_sensitive_data_on_connection_error: true,
+  log: false
 )
 
 defmodule Ecto.Integration.TestRepo do

--- a/integration_test/sql/logging.exs
+++ b/integration_test/sql/logging.exs
@@ -133,14 +133,14 @@ defmodule Ecto.Integration.LoggingTest do
     end
 
     test "with a log: true override when logging is disabled" do
-      repo_conf = Application.get_env(:ecto_sql, TestRepo)
-
-      on_exit(fn -> Application.put_env(:ecto_sql, TestRepo, repo_conf) end)
-
-      Application.put_env(:ecto_sql, TestRepo, log: false)
-
       refute capture_log(fn ->
                TestRepo.insert!(%Post{title: "1"}, log: true)
+             end) =~ "an exception was raised logging"
+    end
+
+    test "with unspecified :log option when logging is disabled" do
+      refute capture_log(fn ->
+               TestRepo.insert!(%Post{title: "1"})
              end) =~ "an exception was raised logging"
     end
   end

--- a/integration_test/tds/test_helper.exs
+++ b/integration_test/tds/test_helper.exs
@@ -81,7 +81,8 @@ Application.put_env(
   url: Application.get_env(:ecto_sql, :tds_test_url) <> "/ecto_test",
   pool: Ecto.Adapters.SQL.Sandbox,
   set_allow_snapshot_isolation: :on,
-  show_sensitive_data_on_connection_error: true
+  show_sensitive_data_on_connection_error: true,
+  log: false
 )
 
 defmodule Ecto.Integration.TestRepo do

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1073,7 +1073,7 @@ defmodule Ecto.Adapters.SQL do
       {false, _level} ->
         :ok
 
-      {opt_level, false} when opt_level in [nil, true] ->
+      {opts_level, false} when opts_level in [nil, true] ->
         :ok
 
       {true, level} ->

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1073,7 +1073,7 @@ defmodule Ecto.Adapters.SQL do
       {false, _level} ->
         :ok
 
-      {true, false} ->
+      {opt_level, false} when opt_level in [nil, true] ->
         :ok
 
       {true, level} ->


### PR DESCRIPTION
I missed a couple things here: https://github.com/elixir-ecto/ecto_sql/pull/447

1. The test wasn't checking the right thing because the log level is set when the pool is started. Changing the config in the test doesn't work.

2. When someone defines `log: false` on the config level and doesn't specify the `:log` option in the `Repo` function it would break.