### PR TITLE
Add support for `ONLY` in index creation

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -925,6 +925,7 @@ if Code.ensure_loaded?(Postgrex) do
                   if_do(command == :create_if_not_exists, "IF NOT EXISTS "),
                   quote_name(index.name),
                   " ON ",
+                  if_do(index.only, "ONLY "),
                   quote_table(index.prefix, index.table),
                   if_do(index.using, [" USING " , to_string(index.using)]),
                   ?\s, ?(, fields, ?),

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -366,6 +366,7 @@ defmodule Ecto.Migration do
               concurrently: false,
               using: nil,
               include: [],
+              only: false,
               nulls_distinct: nil,
               where: nil,
               comment: nil,
@@ -379,6 +380,7 @@ defmodule Ecto.Migration do
       unique: boolean,
       concurrently: boolean,
       using: atom | String.t,
+      only: boolean,
       include: [atom | String.t],
       nulls_distinct: boolean | nil,
       where: atom | String.t,
@@ -720,6 +722,8 @@ defmodule Ecto.Migration do
       This option is currently only supported by PostgreSQL 15+.
       For MySQL, it is always false. For MSSQL, it is always true.
       See the dedicated section on this option for more information.
+    * `:only` - Indicates not to recurse creating indexes on partitions, if the table is partitioned.
+      This option is currently only supported by PostgreSQL 11+. Defaults to `false`.
     * `:comment` - adds a comment to the index.
 
   ## Adding/dropping indexes concurrently

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1828,6 +1828,12 @@ defmodule Ecto.Adapters.PostgresTest do
       [~s|CREATE INDEX "posts_permalink_index" ON "posts" USING hash ("permalink")|]
   end
 
+  test "create an index without recursively creating indexes on partitions" do
+    create = {:create, index(:posts, [:permalink], only: true)}
+    assert execute_ddl(create) ==
+      [~s|CREATE INDEX "posts_permalink_index" ON ONLY "posts" ("permalink")|]
+  end
+
   test "drop index" do
     drop = {:drop, index(:posts, [:id], name: "posts$main"), :restrict}
     assert execute_ddl(drop) == [~s|DROP INDEX "posts$main"|]


### PR DESCRIPTION
By default when creating an index on a partitioned table,
it will also recurse and create indexes on all the underlying
partitions. This commit adds the option to only create the index
on the partioned table. Then the partitions can be indexed individually
and attached to the parent index.

I could not find support for this in MySQL or MSSQL. In Postgres it was
added in version 11.

See also https://www.postgresql.org/docs/11/sql-createindex.html
and best practices https://www.postgresql.org/docs/14/ddl-partitioning.html#DDL-PARTITIONING-DECLARATIVE-BEST-PRACTICES
