### PR TITLE
FIX: Empty array compare in postgresql

### DIFF
--- a/integration_test/sql/sql.exs
+++ b/integration_test/sql/sql.exs
@@ -6,6 +6,7 @@ defmodule Ecto.Integration.SQLTest do
   alias Ecto.Integration.Barebone
   alias Ecto.Integration.Post
   alias Ecto.Integration.CorruptedPk
+  alias Ecto.Integration.Tag
   import Ecto.Query, only: [from: 2]
 
   test "fragmented types" do
@@ -26,6 +27,18 @@ defmodule Ecto.Integration.SQLTest do
     text2 = "bar"
     result = TestRepo.query!("SELECT $1::text[]", [[text1, text2]])
     assert result.rows == [[[text1, text2]]]
+  end
+
+  @tag :array_type
+  test "Converts empty array correctly" do
+    result = TestRepo.query!("SELECT array[1,2,3] = $1", [[]])
+    assert result.rows == [[false]]
+
+    result = TestRepo.query!("SELECT array[]::integer[] = $1", [[]])
+    assert result.rows == [[true]]
+
+    query = from t in Tag, where: t.items == []
+    assert [] == TestRepo.all(query)
   end
 
   test "query!/4 with dynamic repo" do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -752,6 +752,9 @@ defmodule Ecto.Adapters.PostgresTest do
 
     query = Schema |> select([], fragment("?", ~w(abc def))) |> plan()
     assert all(query) == ~s{SELECT ARRAY['abc','def'] FROM "schema" AS s0}
+
+    query = Schema |> where([s], s.w == []) |> select([s], s.w) |> plan()
+    assert all(query) == ~s{SELECT s0."w" FROM "schema" AS s0 WHERE (s0."w" = '\{\}')}
   end
 
   test "interpolated values" do


### PR DESCRIPTION
We cannot compare in postgres with the empty array i. e. `where array_column = ARRAY[];`
as that will result in an error:
  ERROR:  cannot determine type of empty array
  HINT:  Explicitly cast to the desired type, for example ARRAY[]::integer[].

On the other side comparing with '{}' works
because '{}' represents the pseudo-type "unknown"
and thus the type gets inferred based on the column it is being compared to so `where array_column = '{}';` works.


----------------------------

We just encountered this issue in production, so instead of going with creating an issue first, I added the fix right ahead. Hope that is fine!

Best regards,
Dario