### PR TITLE
Support explain format option for myxql

### DIFF
--- a/integration_test/myxql/explain_test.exs
+++ b/integration_test/myxql/explain_test.exs
@@ -34,5 +34,13 @@ defmodule Ecto.Integration.ExplainTest do
         TestRepo.explain(:all, from(p in "posts", select: p.invalid, where: p.invalid == "title"))
       end)
     end
+
+    test "map format" do
+      [explain] = TestRepo.explain(:all, Post, format: :map)
+      keys = explain["query_block"] |> Map.keys
+      assert Enum.member?(keys, "cost_info")
+      assert Enum.member?(keys, "select_id")
+      assert Enum.member?(keys, "table")
+    end
   end
 end

--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -1092,7 +1092,7 @@ if Code.ensure_loaded?(MyXQL) do
     end
 
     defp format_to_sql(:json), do: "FORMAT=JSON"
-    defp format_to_sql(:traditional), do: "FORMAT=TRADITIONAL"
+    defp format_to_sql(:text), do: "FORMAT=TRADITIONAL"
 
     defp intersperse_map(list, separator, mapper, acc \\ [])
     defp intersperse_map([], _separator, _mapper, acc),

--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -222,10 +222,16 @@ if Code.ensure_loaded?(MyXQL) do
     end
 
     @impl true
-    # DB explain opts are deprecated, so they aren't used to build the explain query.
+    # DB explain opts, except format, are deprecated.
     # See Notes at https://dev.mysql.com/doc/refman/5.7/en/explain.html
     def explain_query(conn, query, params, opts) do
-      case query(conn, build_explain_query(query), params, opts) do
+      {explain_opts, opts} = Keyword.split(opts, ~w[format]a)
+      json_format? = {:format, :json} in explain_opts
+
+      case query(conn, build_explain_query(query, explain_opts), params, opts) do
+        {:ok, %MyXQL.Result{rows: rows}} when json_format? ->
+          {:ok, List.flatten(rows)}
+
         {:ok, %MyXQL.Result{} = result} ->
           {:ok, SQL.format_table(result)}
 
@@ -234,8 +240,13 @@ if Code.ensure_loaded?(MyXQL) do
       end
     end
 
-    def build_explain_query(query) do
+    def build_explain_query(query, []) do
       ["EXPLAIN ", query]
+      |> IO.iodata_to_binary()
+    end
+
+    def build_explain_query(query, [format: value]) do
+      ["EXPLAIN #{String.upcase("#{format_to_sql(value)}")} ", query]
       |> IO.iodata_to_binary()
     end
 
@@ -1079,6 +1090,9 @@ if Code.ensure_loaded?(MyXQL) do
       end
       [?`, name, ?`]
     end
+
+    defp format_to_sql(:json), do: "FORMAT=JSON"
+    defp format_to_sql(:traditional), do: "FORMAT=TRADITIONAL"
 
     defp intersperse_map(list, separator, mapper, acc \\ [])
     defp intersperse_map([], _separator, _mapper, acc),

--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -230,8 +230,9 @@ if Code.ensure_loaded?(MyXQL) do
 
       case query(conn, build_explain_query(query, explain_opts), params, opts) do
         {:ok, %MyXQL.Result{rows: rows}} when map_format? ->
-          decoded_result = MyXQL.json_library().decode!(rows)
-          {:ok, List.wrap(decoded_result)}
+          json_library = MyXQL.json_library()
+          decoded_result = Enum.map(rows, &json_library.decode!(&1))
+          {:ok, decoded_result}
 
         {:ok, %MyXQL.Result{} = result} ->
           {:ok, SQL.format_table(result)}

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -321,7 +321,8 @@ defmodule Ecto.Adapters.SQL do
 
     * Currently `:map`, `:yaml`, and `:text` format options are supported
       for PostgreSQL. `:map` is the deserialized JSON encoding. The last two
-      options return the result as a string;
+      options return the result as a string. MyXQL support `:json` or `:traditional`
+      format options. Both of those return the result as a string;
 
     * Any other value passed to `opts` will be forwarded to the underlying
       adapter query function, including Repo shared options such as `:timeout`;

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -321,7 +321,7 @@ defmodule Ecto.Adapters.SQL do
 
     * Currently `:map`, `:yaml`, and `:text` format options are supported
       for PostgreSQL. `:map` is the deserialized JSON encoding. The last two
-      options return the result as a string. MyXQL support `:json` or `:traditional`
+      options return the result as a string. MyXQL support `:json` or `:text`
       format options. Both of those return the result as a string;
 
     * Any other value passed to `opts` will be forwarded to the underlying

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -320,9 +320,9 @@ defmodule Ecto.Adapters.SQL do
   Also note that:
 
     * Currently `:map`, `:yaml`, and `:text` format options are supported
-      for PostgreSQL. `:map` is the deserialized JSON encoding. The last two
-      options return the result as a string. MyXQL support `:json` or `:text`
-      format options. Both of those return the result as a string;
+      for PostgreSQL. Only `map` and `text` are supported for MyXQL.
+      * `:map` is the deserialized JSON encoding.
+      * `:yaml` and `text` return the result as a string;
 
     * Any other value passed to `opts` will be forwarded to the underlying
       adapter query function, including Repo shared options such as `:timeout`;

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -719,7 +719,8 @@ defmodule Ecto.Adapters.MyXQLTest do
   end
 
   test "build_explain_query" do
-    assert SQL.build_explain_query("SELECT 1") == "EXPLAIN SELECT 1"
+    assert SQL.build_explain_query("SELECT 1", []) == "EXPLAIN SELECT 1"
+    assert SQL.build_explain_query("SELECT 1", format: :json) == "EXPLAIN FORMAT=JSON SELECT 1"
   end
 
   ## *_all

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -720,7 +720,7 @@ defmodule Ecto.Adapters.MyXQLTest do
 
   test "build_explain_query" do
     assert SQL.build_explain_query("SELECT 1", []) == "EXPLAIN SELECT 1"
-    assert SQL.build_explain_query("SELECT 1", format: :json) == "EXPLAIN FORMAT=JSON SELECT 1"
+    assert SQL.build_explain_query("SELECT 1", format: :map) == "EXPLAIN FORMAT=JSON SELECT 1"
   end
 
   ## *_all


### PR DESCRIPTION
Hello, thanks y'all for ecto_sql <3

I've been trying to get a structured format out of myxql `explain`, but it seems tricky (see: https://github.com/elixir-ecto/myxql/pull/159). The next best thing I can think of is to at least expose the string of the explain json, so that the caller can then encode and further process it.

I've tried to follow the "patterns" in the postgres implementation.

Thanks again!