### PR TITLE
Use cast params in telemetry events

### DIFF
--- a/integration_test/sql/logging.exs
+++ b/integration_test/sql/logging.exs
@@ -70,6 +70,19 @@ defmodule Ecto.Integration.LoggingTest do
       _ = TestRepo.all(Post, telemetry_event: nil)
       refute_received :logged
     end
+
+    test "cast params" do
+      uuid = Ecto.UUID.generate()
+
+      log = fn _event_name, _measurements, metadata ->
+        assert [uuid] == metadata.params
+        send(self(), :logged)
+      end
+
+      Process.put(:telemetry, log)
+      TestRepo.all(from l in Logging, where: l.uuid == ^uuid )
+      assert_received :logged
+    end
   end
 
   describe "logs" do

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1047,6 +1047,7 @@ defmodule Ecto.Adapters.SQL do
     query = String.Chars.to_string(query)
     result = with {:ok, _query, res} <- result, do: {:ok, res}
     stacktrace = Keyword.get(opts, :stacktrace)
+    log_params = opts[:cast_params] || params
 
     acc =
       if idle_time, do: [idle_time: idle_time], else: []
@@ -1062,7 +1063,7 @@ defmodule Ecto.Adapters.SQL do
       type: :ecto_sql_query,
       repo: repo,
       result: result,
-      params: params,
+      params: log_params,
       query: query,
       source: source,
       stacktrace: stacktrace,
@@ -1083,14 +1084,14 @@ defmodule Ecto.Adapters.SQL do
       {true, level} ->
         Logger.log(
           level,
-          fn -> log_iodata(measurements, repo, source, query, opts[:cast_params] || params, result, stacktrace) end,
+          fn -> log_iodata(measurements, repo, source, query, log_params, result, stacktrace) end,
           ansi_color: sql_color(query)
         )
 
       {opts_level, args_level} ->
         Logger.log(
           opts_level || args_level,
-          fn -> log_iodata(measurements, repo, source, query, opts[:cast_params] || params, result, stacktrace) end,
+          fn -> log_iodata(measurements, repo, source, query, log_params, result, stacktrace) end,
           ansi_color: sql_color(query)
         )
     end


### PR DESCRIPTION
The cast parameters aren't being used in the telemetry events, as pointed out in this comment: https://github.com/elixir-ecto/ecto/pull/3869#issuecomment-1304802701