### PR TITLE
Link to Schema primitive types docs from Migration docs

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -139,7 +139,7 @@ defmodule Ecto.Migration do
 
   ## Field Types
 
-  The Ecto primitive types are mapped to the appropriate database
+  The [Ecto primitive types](https://hexdocs.pm/ecto/Ecto.Schema.html#module-primitive-types) are mapped to the appropriate database
   type by the various database adapters. For example, `:string` is
   converted to `:varchar`, `:binary` to `:bytea` or `:blob`, and so on.
 


### PR DESCRIPTION
The `Ecto.Migration` docs often mention types, and it's convenient to be able to cross-reference with the list of supported types. However, the `Field Types` section of the docs does not list the types, and in fact they're not listed anywhere in the package - instead being listed in the `Ecto.Schema` module of the `ecto` package.

This PR adds a link to the primitive types section of the `Ecto.Schema` docs from the `Field Types` section of the `Ecto.Migration` docs. It appears that `ExDoc` does not support dynamic linking to a section of a module doc, so I went with a full hyperlink to hexdocs.

Source:
<img width="834" alt="image" src="https://user-images.githubusercontent.com/498229/203493972-411b381c-6a2b-497f-98a1-afa4bb13a607.png">

Destination:
<img width="647" alt="image" src="https://user-images.githubusercontent.com/498229/203494065-3a7ea3d2-4b20-4a54-aa46-813ca5efcc05.png">
