### PR TITLE
fix: unexpected behavior passing bitstring or string as target version to Migrator.run

### DIFF
--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -561,7 +561,7 @@ defmodule Ecto.Migrator do
     |> Enum.take_while(&(within_target_version?.(&1, target, direction)))
   end
 
-  defp pending_step(versions, migration_source, direction, count) when is_integer(count) do
+  defp pending_step(versions, migration_source, direction, count) do
     pending_in_direction(versions, migration_source, direction)
     |> Enum.take(count)
   end

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -537,7 +537,7 @@ defmodule Ecto.Migrator do
     lock_for_migrations(lock, repo, opts, fun)
   end
 
-  defp pending_to(versions, migration_source, direction, target) do
+  defp pending_to(versions, migration_source, direction, target) when is_integer(target) do
     within_target_version? = fn
       {version, _, _}, target, :up ->
         version <= target
@@ -549,7 +549,7 @@ defmodule Ecto.Migrator do
     |> Enum.take_while(&(within_target_version?.(&1, target, direction)))
   end
 
-  defp pending_to_exclusive(versions, migration_source, direction, target) do
+  defp pending_to_exclusive(versions, migration_source, direction, target) when is_integer(target) do
     within_target_version? = fn
       {version, _, _}, target, :up ->
         version < target
@@ -561,7 +561,7 @@ defmodule Ecto.Migrator do
     |> Enum.take_while(&(within_target_version?.(&1, target, direction)))
   end
 
-  defp pending_step(versions, migration_source, direction, count) do
+  defp pending_step(versions, migration_source, direction, count) when is_integer(count) do
     pending_in_direction(versions, migration_source, direction)
     |> Enum.take(count)
   end

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -575,6 +575,20 @@ defmodule Ecto.MigratorTest do
         assert run(TestRepo, paths, :up, to: 12, log: false) == [10, 11, 12]
       end)
     end
+
+    test "raises if target is not integer" do
+      in_tmp fn path ->
+        message_base = "no function clause matching in "
+
+        assert_raise(FunctionClauseError, message_base <> "Ecto.Migrator.pending_to/4", fn ->
+          run(TestRepo, path, :up, to: "123")
+        end)
+
+        assert_raise(FunctionClauseError, message_base <> "Ecto.Migrator.pending_to_exclusive/4", fn ->
+          run(TestRepo, path, :up, to_exclusive: "123")
+        end)
+      end
+    end
   end
 
   describe "migrations" do


### PR DESCRIPTION
Calling migrator with wrong variable type, like string or bitstring, will execute all missing migrations, instead of the expected behavior.