### PR TITLE
Add `{:nilify, columns}` to `on_delete` reference option.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         elixirbase:
           - "1.11.4-erlang-21.3.8.24-alpine-3.13.3"
         postgres:
+          - "15.0"
           - "11.11"
           - "9.6"
           - "9.5"

--- a/Earthfile
+++ b/Earthfile
@@ -67,6 +67,7 @@ integration-test-postgres:
         RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.4/main' >> /etc/apk/repositories
         RUN apk add postgresql=9.5.13-r0
     ELSE IF [ "$POSTGRES" = "15.0" ]
+        apk add -X https://dl-cdn.alpinelinux.org/alpine/v3.17/main -u alpine-keys
         RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.17/main' >> /etc/apk/repositories
         RUN apk add postgresql15-client
     ELSE

--- a/Earthfile
+++ b/Earthfile
@@ -67,6 +67,10 @@ integration-test-postgres:
         RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.4/main' >> /etc/apk/repositories
         RUN apk add postgresql=9.5.13-r0
     ELSE IF [ "$POSTGRES" = "15.0" ]
+        # for 15.0 we need an upgraded version of pg_dump;
+        # alpine 3.17 does not come with the postgres 15 client by default;
+        # we must first update the public keys for the packages because they 
+        # might have been rotated since our image was built
         RUN apk add -X https://dl-cdn.alpinelinux.org/alpine/v3.17/main -u alpine-keys
         RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.17/main' >> /etc/apk/repositories
         RUN apk add postgresql15-client

--- a/Earthfile
+++ b/Earthfile
@@ -67,7 +67,7 @@ integration-test-postgres:
         RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.4/main' >> /etc/apk/repositories
         RUN apk add postgresql=9.5.13-r0
     ELSE IF [ "$POSTGRES" = "15.0" ]
-        RUN apk add postgresql15-client
+        RUN apk add postgresql15-client-15.1-r0
     ELSE
         RUN apk add postgresql-client
     END

--- a/Earthfile
+++ b/Earthfile
@@ -24,6 +24,7 @@ test:
 integration-test-all:
     ARG ELIXIR_BASE=1.13.4-erlang-24.3.4.2-alpine-3.16.0
     BUILD \
+        --build-arg POSTGRES=15.0 \
         --build-arg POSTGRES=11.11 \
         --build-arg POSTGRES=9.6 \
         --build-arg POSTGRES=9.5 \

--- a/Earthfile
+++ b/Earthfile
@@ -67,7 +67,8 @@ integration-test-postgres:
         RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.4/main' >> /etc/apk/repositories
         RUN apk add postgresql=9.5.13-r0
     ELSE IF [ "$POSTGRES" = "15.0" ]
-        RUN apk add postgresql15-client-15.1-r0
+        RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.17/main' >> /etc/apk/repositories
+        RUN apk add postgresql15-client
     ELSE
         RUN apk add postgresql-client
     END

--- a/Earthfile
+++ b/Earthfile
@@ -67,7 +67,7 @@ integration-test-postgres:
         RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.4/main' >> /etc/apk/repositories
         RUN apk add postgresql=9.5.13-r0
     ELSE IF [ "$POSTGRES" = "15.0" ]
-        apk add -X https://dl-cdn.alpinelinux.org/alpine/v3.17/main -u alpine-keys
+        RUN apk add -X https://dl-cdn.alpinelinux.org/alpine/v3.17/main -u alpine-keys
         RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.17/main' >> /etc/apk/repositories
         RUN apk add postgresql15-client
     ELSE

--- a/Earthfile
+++ b/Earthfile
@@ -142,7 +142,7 @@ integration-test-mssql:
 
 
 setup-base:
-    ARG ELIXIR_BASE=1.13.4-erlang-24.3.4.2-alpine-3.16.0
+    ARG ELIXIR_BASE=1.13.4-erlang-24.3.4.2-alpine-3.17.0
     FROM hexpm/elixir:$ELIXIR_BASE
     RUN apk add --no-progress --update git build-base
     ENV ELIXIR_ASSERT_TIMEOUT=10000

--- a/Earthfile
+++ b/Earthfile
@@ -67,7 +67,7 @@ integration-test-postgres:
         RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.4/main' >> /etc/apk/repositories
         RUN apk add postgresql=9.5.13-r0
     ELSE IF [ "$POSTGRES" = "15.0" ]
-        RUN apk add postgresql=15.0.0-r0
+        RUN apk add postgresql15-client
     ELSE
         RUN apk add postgresql-client
     END

--- a/Earthfile
+++ b/Earthfile
@@ -66,6 +66,8 @@ integration-test-postgres:
         # and in the 3.4 version, it is not included in postgresql-client but rather in postgresql
         RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.4/main' >> /etc/apk/repositories
         RUN apk add postgresql=9.5.13-r0
+    ELSE IF [ "$POSTGRES" = "15.0" ]
+        RUN apk add postgresql15-15.1-r0
     ELSE
         RUN apk add postgresql-client
     END

--- a/Earthfile
+++ b/Earthfile
@@ -67,7 +67,7 @@ integration-test-postgres:
         RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.4/main' >> /etc/apk/repositories
         RUN apk add postgresql=9.5.13-r0
     ELSE IF [ "$POSTGRES" = "15.0" ]
-        RUN apk add postgresql15-15.1-r0
+        RUN apk add postgresql=15.0.0-r0
     ELSE
         RUN apk add postgresql-client
     END

--- a/integration_test/myxql/test_helper.exs
+++ b/integration_test/myxql/test_helper.exs
@@ -100,7 +100,9 @@ excludes = [
   # MySQL doesn't have a boolean type, so this ends up returning 0/1
   :map_boolean_in_expression,
   # MySQL doesn't support indexed parameters
-  :placeholders
+  :placeholders,
+  # MySQL doesn't support specifying columns for ON DELETE SET NULL
+  :on_delete_nilify_column_list
 ]
 
 if Version.match?(version, ">= 8.0.0") do

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -55,7 +55,6 @@ end
 pool_repo_config = [
   url: Application.get_env(:ecto_sql, :pg_test_url) <> "/ecto_test",
   pool_size: 10,
-  post: 5431,
   max_restarts: 20,
   max_seconds: 10
 ]

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -55,6 +55,7 @@ end
 pool_repo_config = [
   url: Application.get_env(:ecto_sql, :pg_test_url) <> "/ecto_test",
   pool_size: 10,
+  post: 5431,
   max_restarts: 20,
   max_seconds: 10
 ]
@@ -100,11 +101,19 @@ version =
 excludes = [:selected_as_with_having, :selected_as_with_order_by_expression]
 excludes_above_9_5 = [:without_conflict_target]
 excludes_below_9_6 = [:add_column_if_not_exists, :no_error_on_conditional_column_migration]
+excludes_below_15_0 = [:on_delete_nilify_column_list]
 
-if Version.match?(version, "< 9.6.0") do
-  ExUnit.configure(exclude: excludes ++ excludes_above_9_5 ++ excludes_below_9_6)
-else
-  ExUnit.configure(exclude: excludes ++ excludes_above_9_5)
+exclude_list = excludes ++ excludes_above_9_5
+
+cond do
+  Version.match?(version, "< 9.6.0") ->
+    ExUnit.configure(exclude: exclude_list ++ excludes_below_9_6)
+
+  Version.match?(version, "< 15.0.0") ->
+    ExUnit.configure(exclude: exclude_list ++ excludes_below_15_0)
+
+  true ->
+    ExUnit.configure(exclude: exclude_list)
 end
 
 :ok = Ecto.Migrator.up(TestRepo, 0, Ecto.Integration.Migration, log: false)

--- a/integration_test/pg/test_helper.exs
+++ b/integration_test/pg/test_helper.exs
@@ -106,7 +106,7 @@ exclude_list = excludes ++ excludes_above_9_5
 
 cond do
   Version.match?(version, "< 9.6.0") ->
-    ExUnit.configure(exclude: exclude_list ++ excludes_below_9_6)
+    ExUnit.configure(exclude: exclude_list ++ excludes_below_9_6 ++ excludes_below_15_0)
 
   Version.match?(version, "< 15.0.0") ->
     ExUnit.configure(exclude: exclude_list ++ excludes_below_15_0)

--- a/integration_test/tds/test_helper.exs
+++ b/integration_test/tds/test_helper.exs
@@ -54,7 +54,9 @@ ExUnit.start(
     # MSSQL can't reference aliased columns in HAVING
     :selected_as_with_having,
     # MSSQL can't reference aliased columns in ORDER BY expressions
-    :selected_as_with_order_by_expression
+    :selected_as_with_order_by_expression,
+    # MSSQL doesn't support specifying columns for ON DELETE SET NULL
+    :on_delete_nilify_column_list
   ]
 )
 

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -1305,6 +1305,8 @@ if Code.ensure_loaded?(Postgrex) do
     defp reference_column_type(type, opts), do: column_type(type, opts)
 
     defp reference_on_delete(:nilify_all), do: " ON DELETE SET NULL"
+    defp reference_on_delete({:nilify, columns}),
+      do: [" ON DELETE SET NULL (", quote_names(columns), ")"]
     defp reference_on_delete(:delete_all), do: " ON DELETE CASCADE"
     defp reference_on_delete(:restrict), do: " ON DELETE RESTRICT"
     defp reference_on_delete(_), do: []

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1282,7 +1282,8 @@ defmodule Ecto.Migration do
     * `:on_delete` - What to do if the referenced entry is deleted. May be
       `:nothing` (default), `:delete_all`, `:nilify_all`, `{:nilify, columns}`,
       or `:restrict`. `{:nilify, columns}` accepts `columns` as a list of atoms.
-      This option may not be supported by your database. Please check its documentation.
+      This option is not supported by all databases. Please check your documentation
+      before using.
     * `:on_update` - What to do if the referenced entry is updated. May be
       `:nothing` (default), `:update_all`, `:nilify_all`, or `:restrict`.
     * `:validate` - Whether or not to validate the foreign key constraint on

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1283,8 +1283,6 @@ defmodule Ecto.Migration do
       `:nothing` (default), `:delete_all`, `:nilify_all`, `{:nilify, columns}`,
       or `:restrict`. `{:nilify, columns}` expects a list of atoms for `columns`
       and is not supported by all databases.
-      This option is not supported by all databases. Please check your documentation
-      before using.
     * `:on_update` - What to do if the referenced entry is updated. May be
       `:nothing` (default), `:update_all`, `:nilify_all`, or `:restrict`.
     * `:validate` - Whether or not to validate the foreign key constraint on

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1281,7 +1281,8 @@ defmodule Ecto.Migration do
     * `:type` - The foreign key type, which defaults to `:bigserial`.
     * `:on_delete` - What to do if the referenced entry is deleted. May be
       `:nothing` (default), `:delete_all`, `:nilify_all`, `{:nilify, columns}`,
-      or `:restrict`. `{:nilify, columns}` accepts `columns` as a list of atoms.
+      or `:restrict`. `{:nilify, columns}` expects a list of atoms for `columns`
+      and is not supported by all databases.
       This option is not supported by all databases. Please check your documentation
       before using.
     * `:on_update` - What to do if the referenced entry is updated. May be

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1501,7 +1501,8 @@ defmodule Ecto.Adapters.PostgresTest do
                {:add, :category_10, %Reference{table: :categories, on_update: :restrict}, []},
                {:add, :category_11, %Reference{table: :categories, prefix: "foo", on_update: :restrict}, []},
                {:add, :category_12, %Reference{table: :categories, with: [here: :there]}, []},
-               {:add, :category_13, %Reference{table: :categories, on_update: :restrict, with: [here: :there], match: :full}, []},]}
+               {:add, :category_13, %Reference{table: :categories, on_update: :restrict, with: [here: :there], match: :full}, []},
+               {:add, :category_14, %Reference{table: :categories, with: [here: :there, here2: :there2], on_delete: {:nilify, [:here, :here2]}}, []},]}
 
     assert execute_ddl(create) == ["""
     CREATE TABLE "posts" ("id" serial,
@@ -1519,6 +1520,7 @@ defmodule Ecto.Adapters.PostgresTest do
     "category_11" bigint, CONSTRAINT "posts_category_11_fkey" FOREIGN KEY ("category_11") REFERENCES "foo"."categories"("id") ON UPDATE RESTRICT,
     "category_12" bigint, CONSTRAINT "posts_category_12_fkey" FOREIGN KEY ("category_12","here") REFERENCES "categories"("id","there"),
     "category_13" bigint, CONSTRAINT "posts_category_13_fkey" FOREIGN KEY ("category_13","here") REFERENCES "categories"("id","there") MATCH FULL ON UPDATE RESTRICT,
+    "category_14" bigint, CONSTRAINT "posts_category_14_fkey" FOREIGN KEY ("category_14","here","here2") REFERENCES "categories"("id","there","there2") ON DELETE SET NULL ("here","here2"),
     PRIMARY KEY ("id"))
     """ |> remove_newlines]
   end


### PR DESCRIPTION
Postgres 15 allows the user to specify which columns should be set to null if the referenced record is deleted.

A side note: I noticed that one of the common on delete options from postgres/mysql is not present: `ON DELETE SET DEFAULT`. I was wondering if this was on purpose or I can submit a PR to add it? I wasn't sure if it was left out on purpose to avoid having to do the same thing for associations.