### PR TITLE
MySql/SQL Server raise for {:nilify, columns} on_delete action

### DIFF
--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -1050,6 +1050,9 @@ if Code.ensure_loaded?(MyXQL) do
     defp reference_column_type(type, opts), do: column_type(type, opts)
 
     defp reference_on_delete(:nilify_all), do: " ON DELETE SET NULL"
+    defp reference_on_delete({:nilify, _columns}) do
+      error!(nil, "MySQL adapter does not support the `{:nilify, columns}` action for `:on_delete`")
+    end
     defp reference_on_delete(:delete_all), do: " ON DELETE CASCADE"
     defp reference_on_delete(:restrict), do: " ON DELETE RESTRICT"
     defp reference_on_delete(_), do: []

--- a/lib/ecto/adapters/tds/connection.ex
+++ b/lib/ecto/adapters/tds/connection.ex
@@ -1502,6 +1502,9 @@ if Code.ensure_loaded?(Tds) do
     defp reference_column_type(type, opts), do: column_type(type, opts)
 
     defp reference_on_delete(:nilify_all), do: " ON DELETE SET NULL"
+    defp reference_on_delete({:nilify, _columns}) do
+      error!(nil, "Tds adapter does not support the `{:nilify, columns}` action for `:on_delete`")
+    end
     defp reference_on_delete(:delete_all), do: " ON DELETE CASCADE"
     defp reference_on_delete(:nothing), do: " ON DELETE NO ACTION"
     defp reference_on_delete(_), do: []

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -1226,6 +1226,12 @@ defmodule Ecto.Adapters.MyXQLTest do
     CONSTRAINT `posts_category_6_fkey` FOREIGN KEY (`category_6`,`here`) REFERENCES `categories`(`id`,`there`) ON DELETE SET NULL,
     PRIMARY KEY (`id`)) ENGINE = INNODB
     """ |> remove_newlines]
+
+    create = {:create, table(:posts),
+              [{:add, :category_1, %Reference{table: :categories, on_delete: {:nilify, [:category_1]}}, []}]}
+
+    msg = "MySQL adapter does not support the `{:nilify, columns}` action for `:on_delete`"
+    assert_raise ArgumentError, msg, fn -> execute_ddl(create) end
   end
 
   test "create table with options" do

--- a/test/ecto/adapters/tds_test.exs
+++ b/test/ecto/adapters/tds_test.exs
@@ -1280,6 +1280,12 @@ defmodule Ecto.Adapters.TdsTest do
              |> remove_newlines
              |> Kernel.<>(" ")
            ]
+
+    create = {:create, table(:posts),
+              [{:add, :category_1, %Reference{table: :categories, on_delete: {:nilify, [:category_1]}}, []}]}
+
+    msg = "Tds adapter does not support the `{:nilify, columns}` action for `:on_delete`"
+    assert_raise ArgumentError, msg, fn -> execute_ddl(create) end
   end
 
   test "create table with options" do


### PR DESCRIPTION
I should have done this in the previous PR. Otherwise it silently changes to whatever the db default is.