### PR TITLE
Fix order of comment and after expressions

### DIFF
--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -938,7 +938,7 @@ if Code.ensure_loaded?(MyXQL) do
       after_column = Keyword.get(opts, :after)
       comment = Keyword.get(opts, :comment)
 
-      [default_expr(default), null_expr(null), after_expr(after_column), comment_expr(comment)]
+      [default_expr(default), null_expr(null), comment_expr(comment), after_expr(after_column)]
     end
 
     defp comment_expr(comment, create_table? \\ false)


### PR DESCRIPTION
Adding column with `:after` and `:comment` options was failing.
I believe `AFTER` should be placed after `COMMENT`.
cf. https://dev.mysql.com/doc/refman/8.0/en/alter-table.html