### PR TITLE
update child_spec callback type in Ecto.Adapters.SQL.Connection

### DIFF
--- a/lib/ecto/adapters/sql/connection.ex
+++ b/lib/ecto/adapters/sql/connection.ex
@@ -19,7 +19,7 @@ defmodule Ecto.Adapters.SQL.Connection do
   Receives options and returns `DBConnection` supervisor child
   specification.
   """
-  @callback child_spec(options :: Keyword.t) :: :supervisor.child_spec()
+  @callback child_spec(options :: Keyword.t) :: :supervisor.child_spec() | {module, Keyword.t}
 
   @doc """
   Prepares and executes the given query with `DBConnection`.

--- a/lib/ecto/adapters/sql/connection.ex
+++ b/lib/ecto/adapters/sql/connection.ex
@@ -19,7 +19,7 @@ defmodule Ecto.Adapters.SQL.Connection do
   Receives options and returns `DBConnection` supervisor child
   specification.
   """
-  @callback child_spec(options :: Keyword.t) :: {module, Keyword.t}
+  @callback child_spec(options :: Keyword.t) :: :supervisor.child_spec()
 
   @doc """
   Prepares and executes the given query with `DBConnection`.


### PR DESCRIPTION
... so that it matches with [`DBConnection.child_spec` type](https://github.com/elixir-ecto/db_connection/blob/9168f4e8b333b4d60c4cc32d6980125e05de3155/lib/db_connection.ex#L502)

Otherwise dialyzer warns on adapters that delegate child_spec directly to the driver.