### PR TITLE
Update migrator error messaging with note regarding MIX_ENV

### DIFF
--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -687,11 +687,12 @@ defmodule Ecto.Migrator do
           * There is a deadlock while migrating (such as using concurrent
             indexes with a migration_lock)
 
-        To fix the first issue, run "mix ecto.create".
+        To fix the first issue, run "mix ecto.create" for the desired MIX_ENV.
 
         To address the second, you can run "mix ecto.drop" followed by
-        "mix ecto.create". Alternatively you may configure Ecto to use
-        another table and/or repository for managing migrations:
+        "mix ecto.create", both for the desired MIX_ENV. Alternatively you may
+        configure Ecto to use another table and/or repository for managing
+        migrations:
 
             config #{inspect repo.config[:otp_app]}, #{inspect repo},
               migration_source: "some_other_table_for_schema_migrations",


### PR DESCRIPTION
This pull request updates the migrator's error logging to reference the `MIX_ENV` when prompting them to run particular `ecto.*` mix tasks.

## Motivation

I'm currently working at a large company where we're onboarding a large number of developers to Elixir/Phoenix/Ecto. A developer's test db had been dropped, and, not knowing about the `MIX_ENV` env var, they got the current migrator error message (the migrations are triggered during application boot), and they followed the guidance in the error message (to run `mix ecto.create`), but without the appropriate prefix, and they were told that their database already _did_ exist, which was, understandably, confusing.

My hope is that the small tweak in error logging cues future developers to the existence of `MIX_ENV` for running ecto commands in different environments.
