### PR TITLE
Add support for renaming an index

### DIFF
--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -271,6 +271,20 @@ defmodule Ecto.Integration.MigrationTest do
     end
   end
 
+  defmodule RenameIndexMigration do
+    use Ecto.Migration
+
+    def change do
+      create table(:composite_parent) do
+        add :key_id, :integer
+      end
+
+      create unique_index(:composite_parent, [:id, :key_id], name: "old_index_name")
+
+      rename index(:composite_parent, [:id, :key_id], name: "old_index_name"), to: "new_index_name"
+    end
+  end
+
   defmodule ReferencesRollbackMigration do
     use Ecto.Migration
 
@@ -501,6 +515,11 @@ defmodule Ecto.Integration.MigrationTest do
     assert {1, nil} = PoolRepo.insert_all("composite_child", [[parent_id: id, parent_key_id: 2]])
 
     assert :ok == down(PoolRepo, num, CompositeForeignKeyMigration, log: false)
+  end
+
+  test "rename index", %{migration_number: num} do
+    assert :ok == up(PoolRepo, num, RenameIndexMigration, log: false)
+    assert :ok == down(PoolRepo, num, RenameIndexMigration, log: false)
   end
 
   test "rolls back references in change/1", %{migration_number: num} do

--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -838,6 +838,11 @@ if Code.ensure_loaded?(MyXQL) do
     def execute_ddl({:drop_if_exists, %Index{}, _}),
       do: error!(nil, "MySQL adapter does not support drop if exists for index")
 
+    def execute_ddl({:rename, %Index{} = index, new_name}) do
+      [["ALTER TABLE ", quote_table(index.table), " RENAME INDEX ",
+      quote_name(index.name), " TO ", quote_name(new_name)]]
+    end
+
     def execute_ddl({:rename, %Table{} = current_table, %Table{} = new_table}) do
       [["RENAME TABLE ", quote_table(current_table.prefix, current_table.name),
         " TO ", quote_table(new_table.prefix, new_table.name)]]

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -999,6 +999,11 @@ if Code.ensure_loaded?(Postgrex) do
         drop_mode(mode)]]
     end
 
+    def execute_ddl({:rename, %Index{} = current_index, new_name}) do
+      [["ALTER INDEX ", quote_name(current_index.name),
+        " RENAME TO ", quote_name(new_name)]]
+    end
+
     def execute_ddl({:rename, %Table{} = current_table, %Table{} = new_table}) do
       [["ALTER TABLE ", quote_table(current_table.prefix, current_table.name),
         " RENAME TO ", quote_table(nil, new_table.name)]]

--- a/lib/ecto/adapters/tds/connection.ex
+++ b/lib/ecto/adapters/tds/connection.ex
@@ -1155,6 +1155,15 @@ if Code.ensure_loaded?(Tds) do
       ]
     end
 
+    def execute_ddl({:rename, %Index{} = current_index, new_name}) do
+      [[
+        "sp_rename ",
+        "N'#{current_index.table}.#{current_index.name}', ",
+        "N'#{new_name}', ",
+        "N'INDEX'"
+      ]]
+    end
+
     def execute_ddl({command, %Index{}, :cascade}) when command in @drops,
       do: error!(nil, "MSSQL does not support `CASCADE` in DROP INDEX commands")
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1081,7 +1081,7 @@ defmodule Ecto.Migration do
     table_new
   end
 
-  def rename(%Index{name: old_name} = current_index, to: new_name) do
+  def rename(%Index{} = current_index, to: new_name) do
     Runner.execute({:rename, current_index, new_name})
     %{current_index | name: new_name}
   end

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1066,15 +1066,24 @@ defmodule Ecto.Migration do
   end
 
   @doc """
-  Renames a table.
+  Renames a table or index.
 
   ## Examples
 
+      # rename a table
       rename table("posts"), to: table("new_posts")
+
+      # rename an index
+      rename(index(:people, [:name], name: "persons_name_index"), to: "people_name_index")
   """
   def rename(%Table{} = table_current, to: %Table{} = table_new) do
     Runner.execute {:rename, __prefix__(table_current), __prefix__(table_new)}
     table_new
+  end
+
+  def rename(%Index{name: old_name} = current_index, to: new_name) do
+    Runner.execute({:rename, current_index, new_name})
+    %{current_index | name: new_name}
   end
 
   @doc """

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -224,7 +224,8 @@ defmodule Ecto.Migration.Runner do
     do: {:create, index}
   defp reverse({:drop_if_exists, %Index{} = index, _}),
     do: {:create_if_not_exists, index}
-
+  defp reverse({:rename, %Index{} = index, new_name}),
+    do: {:rename, %{index | name: new_name}, index.name}
   defp reverse({:create, %Table{} = table, _columns}),
     do: {:drop, table, :restrict}
   defp reverse({:create_if_not_exists, %Table{} = table, _columns}),
@@ -418,6 +419,8 @@ defmodule Ecto.Migration.Runner do
     do: "drop index #{quote_name(index.prefix, index.name)}#{drop_mode(mode)}"
   defp command({:drop_if_exists, %Index{} = index, mode}),
     do: "drop index if exists #{quote_name(index.prefix, index.name)}#{drop_mode(mode)}"
+  defp command({:rename, %Index{} = index_current, new_name}),
+    do: "rename index #{quote_name(index_current.name)} to #{new_name}"
   defp command({:rename, %Table{} = current_table, %Table{} = new_table}),
     do: "rename table #{quote_name(current_table.prefix, current_table.name)} to #{quote_name(new_table.prefix, new_table.name)}"
   defp command({:rename, %Table{} = table, current_column, new_column}),

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -1558,6 +1558,11 @@ defmodule Ecto.Adapters.MyXQLTest do
     assert execute_ddl(drop) == [~s|DROP INDEX `posts$main` ON `foo`.`posts`|]
   end
 
+  test "rename index" do
+    rename = {:rename, index(:people, [:name], name: "persons_name_index"), "people_name_index"}
+    assert execute_ddl(rename) == [~s|ALTER TABLE `people` RENAME INDEX `persons_name_index` TO `people_name_index`|]
+  end
+
   test "rename table" do
     rename = {:rename, table(:posts), table(:new_posts)}
     assert execute_ddl(rename) == [~s|RENAME TABLE `posts` TO `new_posts`|]

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1964,6 +1964,11 @@ defmodule Ecto.Adapters.PostgresTest do
     assert execute_ddl(drop) == [~s|DROP INDEX "foo"."posts$main" CASCADE|]
   end
 
+  test "rename index" do
+    rename = {:rename, index(:people, [:name], name: "persons_name_index"), "people_name_index"}
+    assert execute_ddl(rename) == [~s|ALTER INDEX "persons_name_index" RENAME TO "people_name_index"|]
+  end
+
   test "create check constraint" do
     create = {:create, constraint(:products, "price_must_be_positive", check: "price > 0")}
     assert execute_ddl(create) ==

--- a/test/ecto/adapters/tds_test.exs
+++ b/test/ecto/adapters/tds_test.exs
@@ -1670,6 +1670,11 @@ defmodule Ecto.Adapters.TdsTest do
     assert execute_ddl(drop) == [~s|DROP INDEX [posts$main] ON [posts] LOCK=NONE; |]
   end
 
+  test "rename index" do
+    rename = {:rename, index(:people, [:name], name: "persons_name_index"), "people_name_index"}
+    assert execute_ddl(rename) == [~s|sp_rename N'people.persons_name_index', N'people_name_index', N'INDEX'|]
+  end
+
   defp remove_newlines(string) when is_binary(string) do
     string |> String.trim() |> String.replace("\n", " ")
   end


### PR DESCRIPTION
Renaming a table without renaming its indexes creates a mismatch. Add support for renaming indexes also.

This PR does not handle renaming foreign keys with `ALTER TABLE "people" RENAME CONSTRAINT "persons_team_id_fkey" TO "people_team_id_fkey"`; that could be a good next feature.