### PR TITLE
Updates structure dump to support multiple prefixes on pg and myxql

### DIFF
--- a/integration_test/myxql/storage_test.exs
+++ b/integration_test/myxql/storage_test.exs
@@ -163,7 +163,7 @@ defmodule Ecto.Integration.StorageTest do
     :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false)
     :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false, prefix: prefix)
 
-    config = Keyword.merge(TestRepo.config(), [prefix: "ecto_test", prefix: prefix])
+    config = Keyword.put(TestRepo.config(), :dump_prefixes, ["ecto_test", prefix])
     {:ok, path} = Ecto.Adapters.MyXQL.structure_dump(tmp_path(), config)
     contents = File.read!(path)
 
@@ -186,7 +186,7 @@ defmodule Ecto.Integration.StorageTest do
     :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false)
     :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false, prefix: prefix)
 
-    config = Keyword.put(TestRepo.config(), :prefix, "ecto_test")
+    config = Keyword.put(TestRepo.config(), :dump_prefixes, ["ecto_test"])
     {:ok, path} = Ecto.Adapters.MyXQL.structure_dump(tmp_path(), config)
     contents = File.read!(path)
 

--- a/integration_test/myxql/storage_test.exs
+++ b/integration_test/myxql/storage_test.exs
@@ -163,7 +163,7 @@ defmodule Ecto.Integration.StorageTest do
     :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false)
     :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false, prefix: prefix)
 
-    config = Keyword.put(TestRepo.config(), :dump_prefixes, ["ecto_test", prefix])
+    config = Keyword.merge(TestRepo.config(), [prefix: "ecto_test", prefix: prefix])
     {:ok, path} = Ecto.Adapters.MyXQL.structure_dump(tmp_path(), config)
     contents = File.read!(path)
 
@@ -186,7 +186,7 @@ defmodule Ecto.Integration.StorageTest do
     :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false)
     :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false, prefix: prefix)
 
-    config = Keyword.put(TestRepo.config(), :dump_prefixes, ["ecto_test"])
+    config = Keyword.put(TestRepo.config(), :prefix, "ecto_test")
     {:ok, path} = Ecto.Adapters.MyXQL.structure_dump(tmp_path(), config)
     contents = File.read!(path)
 

--- a/integration_test/myxql/storage_test.exs
+++ b/integration_test/myxql/storage_test.exs
@@ -168,8 +168,9 @@ defmodule Ecto.Integration.StorageTest do
     contents = File.read!(path)
 
     assert contents =~ "Current Database: `#{prefix}`"
-    assert contents =~ ~s[INSERT INTO `#{prefix}`.`schema_migrations` (version) VALUES (#{version})]
     assert contents =~ "Current Database: `ecto_test`"
+    assert contents =~ "CREATE TABLE `schema_migrations`"
+    assert contents =~ ~s[INSERT INTO `#{prefix}`.`schema_migrations` (version) VALUES (#{version})]
     assert contents =~ ~s[INSERT INTO `ecto_test`.`schema_migrations` (version) VALUES (#{version})]
   after
     drop_database()
@@ -190,8 +191,9 @@ defmodule Ecto.Integration.StorageTest do
     contents = File.read!(path)
 
     refute contents =~ "Current Database: `#{prefix}`"
-    refute contents =~ ~s[INSERT INTO `#{prefix}`.`schema_migrations` (version) VALUES (#{version})]
     assert contents =~ "Current Database: `ecto_test`"
+    assert contents =~ "CREATE TABLE `schema_migrations`"
+    refute contents =~ ~s[INSERT INTO `#{prefix}`.`schema_migrations` (version) VALUES (#{version})]
     assert contents =~ ~s[INSERT INTO `ecto_test`.`schema_migrations` (version) VALUES (#{version})]
   after
     drop_database()

--- a/integration_test/pg/storage_test.exs
+++ b/integration_test/pg/storage_test.exs
@@ -159,7 +159,7 @@ defmodule Ecto.Integration.StorageTest do
     assert contents =~ ~s[INSERT INTO public."schema_migrations" (version) VALUES]
   end
 
-  test "when :dump_prefixes is not provided, structure is dumped for all schemas but only public schema migration records are inserted" do
+  test "when :prefix is not provided, structure is dumped for all schemas but only public schema migration records are inserted" do
     # Create the test_schema schema
     create_schema(PoolRepo.config()[:database], "test_schema")
 
@@ -189,7 +189,7 @@ defmodule Ecto.Integration.StorageTest do
     :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false)
     :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false, prefix: "test_schema")
 
-    config = Keyword.put(TestRepo.config(), :dump_prefixes, ["public", "test_schema"])
+    config = Keyword.merge(TestRepo.config(), [prefix: "public", prefix: "test_schema"])
     {:ok, path} = Postgres.structure_dump(tmp_path(), config)
     contents = File.read!(path)
 
@@ -211,7 +211,7 @@ defmodule Ecto.Integration.StorageTest do
     :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false)
     :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false, prefix: "test_schema")
 
-    config = Keyword.put(TestRepo.config(), :dump_prefixes, ["test_schema"])
+    config = Keyword.put(TestRepo.config(), :prefix, "test_schema")
     {:ok, path} = Postgres.structure_dump(tmp_path(), config)
     contents = File.read!(path)
 

--- a/integration_test/pg/storage_test.exs
+++ b/integration_test/pg/storage_test.exs
@@ -159,7 +159,7 @@ defmodule Ecto.Integration.StorageTest do
     assert contents =~ ~s[INSERT INTO public."schema_migrations" (version) VALUES]
   end
 
-  test "when :prefix is not provided, structure is dumped for all schemas but only public schema migration records are inserted" do
+  test "when :dump_prefixes is not provided, structure is dumped for all schemas but only public schema migration records are inserted" do
     # Create the test_schema schema
     create_schema(PoolRepo.config()[:database], "test_schema")
 
@@ -189,7 +189,7 @@ defmodule Ecto.Integration.StorageTest do
     :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false)
     :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false, prefix: "test_schema")
 
-    config = Keyword.merge(TestRepo.config(), [prefix: "public", prefix: "test_schema"])
+    config = Keyword.put(TestRepo.config(), :dump_prefixes, ["public", "test_schema"])
     {:ok, path} = Postgres.structure_dump(tmp_path(), config)
     contents = File.read!(path)
 
@@ -211,7 +211,7 @@ defmodule Ecto.Integration.StorageTest do
     :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false)
     :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false, prefix: "test_schema")
 
-    config = Keyword.put(TestRepo.config(), :prefix, "test_schema")
+    config = Keyword.put(TestRepo.config(), :dump_prefixes, ["test_schema"])
     {:ok, path} = Postgres.structure_dump(tmp_path(), config)
     contents = File.read!(path)
 

--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -312,11 +312,7 @@ defmodule Ecto.Adapters.MyXQL do
   def structure_dump(default, config) do
     table = config[:migration_source] || "schema_migrations"
     path  = config[:dump_path] || Path.join(default, "structure.sql")
-    prefixes =
-      case Keyword.get_values(config, :prefix) do
-        [_ | _] = prefixes -> prefixes
-        [] -> [config[:database]]
-      end
+    prefixes = config[:dump_prefixes] || [config[:database]]
 
     with {:ok, versions} <- select_versions(prefixes, table, config),
          {:ok, contents} <- mysql_dump(prefixes, config),

--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -312,9 +312,10 @@ defmodule Ecto.Adapters.MyXQL do
   def structure_dump(default, config) do
     table = config[:migration_source] || "schema_migrations"
     path  = config[:dump_path] || Path.join(default, "structure.sql")
+    dump_prefixes = config[:dump_prefixes] || [config[:database]]
 
-    with {:ok, versions} <- select_versions(table, config),
-         {:ok, contents} <- mysql_dump(config),
+    with {:ok, versions} <- select_versions(dump_prefixes, table, config),
+         {:ok, contents} <- mysql_dump(dump_prefixes, config),
          {:ok, contents} <- append_versions(table, versions, contents) do
       File.mkdir_p!(Path.dirname(path))
       File.write!(path, contents)
@@ -322,17 +323,31 @@ defmodule Ecto.Adapters.MyXQL do
     end
   end
 
-  defp select_versions(table, config) do
-    case run_query(~s[SELECT version FROM `#{table}` ORDER BY version], config) do
-      {:ok, %{rows: rows}} -> {:ok, Enum.map(rows, &hd/1)}
-      {:error, %{mysql: %{name: :ER_NO_SUCH_TABLE}}} -> {:ok, []}
+  defp select_versions(dump_prefixes, table, config) do
+    result = Enum.reduce_while(dump_prefixes, [], fn prefix, versions ->
+      case run_query(~s[SELECT version FROM `#{prefix}`.`#{table}` ORDER BY version], config) do
+        {:ok, %{rows: rows}} -> {:cont, Enum.map(rows, &{prefix, hd(&1)}) ++ versions }
+        {:error, %{mysql: %{name: :ER_NO_SUCH_TABLE}}} -> {:cont, versions}
+        {:error, _} = error -> {:halt, error}
+        {:exit, exit} -> {:error, exit_to_exception(exit)}
+      end
+    end)
+
+    case result do
       {:error, _} = error -> error
-      {:exit, exit} -> {:error, exit_to_exception(exit)}
+      versions -> {:ok, versions}
     end
   end
 
-  defp mysql_dump(config) do
-    case run_with_cmd("mysqldump", config, ["--no-data", "--routines", config[:database]]) do
+  defp mysql_dump(dump_prefixes, config) do
+    non_prefix_args = ["--databases", "--no-data", "--routines"]
+
+    args =
+      Enum.reduce(non_prefix_args, dump_prefixes, fn args, acc ->
+        [args | acc]
+      end)
+
+    case run_with_cmd("mysqldump", config, args) do
       {output, 0} -> {:ok, output}
       {output, _} -> {:error, output}
     end
@@ -341,10 +356,13 @@ defmodule Ecto.Adapters.MyXQL do
   defp append_versions(_table, [], contents) do
     {:ok, contents}
   end
+
   defp append_versions(table, versions, contents) do
-    {:ok,
-      contents <>
-      Enum.map_join(versions, &~s[INSERT INTO `#{table}` (version) VALUES (#{&1});\n])}
+    sql_statements = Enum.map_join(versions, fn {prefix, version} ->
+      ~s[INSERT INTO `#{prefix}`.`#{table}` (version) VALUES (#{version});\n]
+    end)
+
+    {:ok, contents <> sql_statements}
   end
 
   @impl true

--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -312,7 +312,11 @@ defmodule Ecto.Adapters.MyXQL do
   def structure_dump(default, config) do
     table = config[:migration_source] || "schema_migrations"
     path  = config[:dump_path] || Path.join(default, "structure.sql")
-    prefixes = config[:dump_prefixes] || [config[:database]]
+    prefixes =
+      case Keyword.get_values(config, :prefix) do
+        [_ | _] = prefixes -> prefixes
+        [] -> [config[:database]]
+      end
 
     with {:ok, versions} <- select_versions(prefixes, table, config),
          {:ok, contents} <- mysql_dump(prefixes, config),

--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -50,6 +50,10 @@ defmodule Ecto.Adapters.MyXQL do
     * `:charset` - the database encoding (default: "utf8mb4")
     * `:collation` - the collation order
     * `:dump_path` - where to place dumped structures
+    * `:dump_prefixes` - list of prefixes that will be included in the
+      structure dump. When specified, the prefixes will have their definitions
+      dumped along with the data in their migration table. When it is not
+      specified, only the configured database and its migration table are dumped.
 
   ### After connect callback
 

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -344,11 +344,7 @@ defmodule Ecto.Adapters.Postgres do
   end
 
   defp select_versions(table, config) do
-    prefixes =
-      case Keyword.get_values(config, :prefix) do
-        [_ | _] = prefixes -> prefixes
-        [] -> ["public"]
-      end
+    prefixes = config[:dump_prefixes] || ["public"]
 
     result =
       Enum.reduce_while(prefixes, [], fn prefix, versions ->
@@ -367,7 +363,7 @@ defmodule Ecto.Adapters.Postgres do
 
   defp pg_dump(default, config) do
     path = config[:dump_path] || Path.join(default, "structure.sql")
-    prefixes = Keyword.get_values(config, :prefix)
+    prefixes = config[:dump_prefixes] || []
     non_prefix_args = ["--file", path, "--schema-only", "--no-acl", "--no-owner"]
 
     args =

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -93,6 +93,11 @@ defmodule Ecto.Adapters.Postgres do
     * `:lc_collate` - the collation order
     * `:lc_ctype` - the character classification
     * `:dump_path` - where to place dumped structures
+    * `dump_prefixes` - list of prefixes that will be included in the structure dump.
+      When specified, the prefixes will have their definitions dumped along with the
+      data in their migration table. When it is not specified, the configured
+      database has the definitions dumped from all of its schemas but only
+      the data from the migration table from the `public` schema is included.
     * `:force_drop` - force the database to be dropped even
       if it has connections to it (requires PostgreSQL 13+)
 

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -363,8 +363,14 @@ defmodule Ecto.Adapters.Postgres do
 
   defp pg_dump(default, config) do
     path = config[:dump_path] || Path.join(default, "structure.sql")
-    dump_prefixes = config[:dump_prefixes] || []
-    args = ["--file", path, "--schema-only", "--no-acl", "--no-owner"] ++ Enum.flat_map(dump_prefixes, &(["-n", &1]))
+    prefixes = config[:dump_prefixes] || []
+    non_prefix_args = ["--file", path, "--schema-only", "--no-acl", "--no-owner"]
+
+    args =
+      Enum.reduce(prefixes, non_prefix_args, fn prefix, acc ->
+        ["-n", prefix | acc]
+      end)
+
     File.mkdir_p!(Path.dirname(path))
 
     case run_with_cmd("pg_dump", config, args) do

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -344,10 +344,10 @@ defmodule Ecto.Adapters.Postgres do
   end
 
   defp select_versions(table, config) do
-    dump_prefixes = config[:dump_prefixes] || ["public"]
+    prefixes = config[:dump_prefixes] || ["public"]
 
     result =
-      Enum.reduce_while(dump_prefixes, [], fn prefix, versions ->
+      Enum.reduce_while(prefixes, [], fn prefix, versions ->
         case run_query(~s[SELECT version FROM #{prefix}."#{table}" ORDER BY version], config) do
           {:ok, %{rows: rows}} -> {:cont, Enum.map(rows, &{prefix, hd(&1)}) ++ versions }
           {:error, %{postgres: %{code: :undefined_table}}} -> {:cont, versions}

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -344,7 +344,11 @@ defmodule Ecto.Adapters.Postgres do
   end
 
   defp select_versions(table, config) do
-    prefixes = config[:dump_prefixes] || ["public"]
+    prefixes =
+      case Keyword.get_values(config, :prefix) do
+        [_ | _] = prefixes -> prefixes
+        [] -> ["public"]
+      end
 
     result =
       Enum.reduce_while(prefixes, [], fn prefix, versions ->
@@ -363,7 +367,7 @@ defmodule Ecto.Adapters.Postgres do
 
   defp pg_dump(default, config) do
     path = config[:dump_path] || Path.join(default, "structure.sql")
-    prefixes = config[:dump_prefixes] || []
+    prefixes = Keyword.get_values(config, :prefix)
     non_prefix_args = ["--file", path, "--schema-only", "--no-acl", "--no-owner"]
 
     args =

--- a/lib/mix/tasks/ecto.dump.ex
+++ b/lib/mix/tasks/ecto.dump.ex
@@ -47,7 +47,7 @@ defmodule Mix.Tasks.Ecto.Dump do
     * `-q`, `--quiet` - run the command quietly
     * `--no-compile` - does not compile applications before dumping
     * `--no-deps-check` - does not check dependencies before dumping
-    * `--dump-prefixes` - comma-separated list of prefixes that will be included in the structure dump. Defaults to all schemas. (Postgres only)
+    * `--dump-prefixes` - comma-separated list of prefixes that will be included in the structure dump. When specified, the prefixes will have their definitions dumped along with the data in their migration table. The default behavior is dependent on the adapter. For Postgres, the configured database has the definitions dumped from all of its schemas as well as the data from the migration table in the `public` schema. For MySQL, the configured database has its definitions dumped as well as the data in the migration table.
   """
 
   @impl true

--- a/lib/mix/tasks/ecto.dump.ex
+++ b/lib/mix/tasks/ecto.dump.ex
@@ -18,7 +18,7 @@ defmodule Mix.Tasks.Ecto.Dump do
     repo: [:string, :keep],
     no_compile: :boolean,
     no_deps_check: :boolean,
-    dump_prefixes: :string,
+    prefix: [:string, :keep]
   ]
 
   @moduledoc """
@@ -47,13 +47,20 @@ defmodule Mix.Tasks.Ecto.Dump do
     * `-q`, `--quiet` - run the command quietly
     * `--no-compile` - does not compile applications before dumping
     * `--no-deps-check` - does not check dependencies before dumping
-    * `--dump-prefixes` - comma-separated list of prefixes that will be included in the structure dump. When specified, the prefixes will have their definitions dumped along with the data in their migration table. The default behavior is dependent on the adapter. For Postgres, the configured database has the definitions dumped from all of its schemas as well as the data from the migration table in the `public` schema. For MySQL, the configured database has its definitions dumped as well as the data in the migration table.
+    * `--prefix` - prefix that will be included in the structure dump.
+      Can include multiple prefixes (ex. --prefix foo --prefix bar).
+      When specified, the prefixes will have their definitions dumped along
+      with the data in their migration table. The default behavior is
+      dependent on the adapter for backwards compatibility reasons.
+      For PostgreSQL, the configured database has the definitions dumped
+      from all of its schemas but only the data from the migration table
+      from the `public` schema is included. For MySQL, only the configured
+      database and its migration table are dumped.
   """
 
   @impl true
   def run(args) do
     {opts, _} = OptionParser.parse! args, strict: @switches, aliases: @aliases
-    opts = Keyword.update(opts, :dump_prefixes, nil, &String.split(&1, ","))
     opts = Keyword.merge(@default_opts, opts)
 
     Enum.each parse_repo(args), fn repo ->

--- a/lib/mix/tasks/ecto.dump.ex
+++ b/lib/mix/tasks/ecto.dump.ex
@@ -18,7 +18,7 @@ defmodule Mix.Tasks.Ecto.Dump do
     repo: [:string, :keep],
     no_compile: :boolean,
     no_deps_check: :boolean,
-    migration_prefixes: :string,
+    dump_prefixes: :string,
   ]
 
   @moduledoc """
@@ -47,13 +47,13 @@ defmodule Mix.Tasks.Ecto.Dump do
     * `-q`, `--quiet` - run the command quietly
     * `--no-compile` - does not compile applications before dumping
     * `--no-deps-check` - does not check dependencies before dumping
-    * `--migration-prefixes` - comma-separated list of prefixes that will have their migration table exported. Defaults to `public`. (Postgres only)
+    * `--dump-prefixes` - comma-separated list of prefixes that will be included in the structure dump. Defaults to all schemas. (Postgres only)
   """
 
   @impl true
   def run(args) do
     {opts, _} = OptionParser.parse! args, strict: @switches, aliases: @aliases
-    opts = Keyword.update(opts, :migration_prefixes, nil, &String.split(&1, ","))
+    opts = Keyword.update(opts, :dump_prefixes, nil, &String.split(&1, ","))
     opts = Keyword.merge(@default_opts, opts)
 
     Enum.each parse_repo(args), fn repo ->

--- a/lib/mix/tasks/ecto.dump.ex
+++ b/lib/mix/tasks/ecto.dump.ex
@@ -53,14 +53,7 @@ defmodule Mix.Tasks.Ecto.Dump do
   @impl true
   def run(args) do
     {opts, _} = OptionParser.parse! args, strict: @switches, aliases: @aliases
-
-    opts =  if Keyword.has_key?(opts, :migration_prefixes) do
-      {_, opts} = Keyword.get_and_update(opts, :migration_prefixes, &{&1, String.split(&1, ",")})
-      opts
-    else
-      opts
-    end
-
+    opts = Keyword.update(opts, :migration_prefixes, nil, &String.split(&1, ","))
     opts = Keyword.merge(@default_opts, opts)
 
     Enum.each parse_repo(args), fn repo ->

--- a/lib/mix/tasks/ecto.dump.ex
+++ b/lib/mix/tasks/ecto.dump.ex
@@ -47,7 +47,7 @@ defmodule Mix.Tasks.Ecto.Dump do
     * `-q`, `--quiet` - run the command quietly
     * `--no-compile` - does not compile applications before dumping
     * `--no-deps-check` - does not check dependencies before dumping
-    * `--migration-prefixes` - list of comma-separated DB schemas that have schema_migration tables. Defaults to `public` schema only.
+    * `--migration-prefixes` - comma-separated list of prefixes that will have their migration table exported. Defaults to `public`. (Postgres only)
   """
 
   @impl true

--- a/lib/mix/tasks/ecto.dump.ex
+++ b/lib/mix/tasks/ecto.dump.ex
@@ -9,8 +9,7 @@ defmodule Mix.Tasks.Ecto.Dump do
   @aliases [
     d: :dump_path,
     q: :quiet,
-    r: :repo,
-    p: :prefixes
+    r: :repo
   ]
 
   @switches [
@@ -19,7 +18,7 @@ defmodule Mix.Tasks.Ecto.Dump do
     repo: [:string, :keep],
     no_compile: :boolean,
     no_deps_check: :boolean,
-    prefixes: :string,
+    migration_prefixes: :string,
   ]
 
   @moduledoc """
@@ -46,17 +45,17 @@ defmodule Mix.Tasks.Ecto.Dump do
     * `-r`, `--repo` - the repo to load the structure info from
     * `-d`, `--dump-path` - the path of the dump file to create
     * `-q`, `--quiet` - run the command quietly
-    * `-p`, `--prefixes` - list of comma-separated DB schemas that have schema_migration tables
     * `--no-compile` - does not compile applications before dumping
     * `--no-deps-check` - does not check dependencies before dumping
+    * `--migration-prefixes` - list of comma-separated DB schemas that have schema_migration tables. Defaults to `public` schema only.
   """
 
   @impl true
   def run(args) do
     {opts, _} = OptionParser.parse! args, strict: @switches, aliases: @aliases
 
-    opts =  if Keyword.has_key?(opts, :prefixes) do
-      {_, opts} = Keyword.get_and_update(opts, :prefixes, &{&1, String.split(&1, ",")})
+    opts =  if Keyword.has_key?(opts, :migration_prefixes) do
+      {_, opts} = Keyword.get_and_update(opts, :migration_prefixes, &{&1, String.split(&1, ",")})
       opts
     else
       opts

--- a/lib/mix/tasks/ecto.dump.ex
+++ b/lib/mix/tasks/ecto.dump.ex
@@ -72,7 +72,6 @@ defmodule Mix.Tasks.Ecto.Dump do
     |> Keyword.merge(opts)
     |> Keyword.put(:dump_prefixes, dump_prefixes)
 
-
     Enum.each parse_repo(args), fn repo ->
       ensure_repo(repo, args)
       ensure_implements(repo.__adapter__(), Ecto.Adapter.Structure,

--- a/lib/mix/tasks/ecto.dump.ex
+++ b/lib/mix/tasks/ecto.dump.ex
@@ -9,7 +9,8 @@ defmodule Mix.Tasks.Ecto.Dump do
   @aliases [
     d: :dump_path,
     q: :quiet,
-    r: :repo
+    r: :repo,
+    p: :prefixes
   ]
 
   @switches [
@@ -17,7 +18,8 @@ defmodule Mix.Tasks.Ecto.Dump do
     quiet: :boolean,
     repo: [:string, :keep],
     no_compile: :boolean,
-    no_deps_check: :boolean
+    no_deps_check: :boolean,
+    prefixes: :string,
   ]
 
   @moduledoc """
@@ -51,6 +53,14 @@ defmodule Mix.Tasks.Ecto.Dump do
   @impl true
   def run(args) do
     {opts, _} = OptionParser.parse! args, strict: @switches, aliases: @aliases
+
+    opts =  if Keyword.has_key?(opts, :prefixes) do
+      {_, opts} = Keyword.get_and_update(opts, :prefixes, &{&1, String.split(&1, ",")})
+      opts
+    else
+      opts
+    end
+
     opts = Keyword.merge(@default_opts, opts)
 
     Enum.each parse_repo(args), fn repo ->

--- a/lib/mix/tasks/ecto.dump.ex
+++ b/lib/mix/tasks/ecto.dump.ex
@@ -61,7 +61,17 @@ defmodule Mix.Tasks.Ecto.Dump do
   @impl true
   def run(args) do
     {opts, _} = OptionParser.parse! args, strict: @switches, aliases: @aliases
-    opts = Keyword.merge(@default_opts, opts)
+
+    dump_prefixes =
+      case Keyword.get_values(opts, :prefix) do
+        [_ | _] = prefixes -> prefixes
+        [] -> nil
+      end
+
+    opts = @default_opts
+    |> Keyword.merge(opts)
+    |> Keyword.put(:dump_prefixes, dump_prefixes)
+
 
     Enum.each parse_repo(args), fn repo ->
       ensure_repo(repo, args)

--- a/lib/mix/tasks/ecto.dump.ex
+++ b/lib/mix/tasks/ecto.dump.ex
@@ -46,6 +46,7 @@ defmodule Mix.Tasks.Ecto.Dump do
     * `-r`, `--repo` - the repo to load the structure info from
     * `-d`, `--dump-path` - the path of the dump file to create
     * `-q`, `--quiet` - run the command quietly
+    * `-p`, `--prefixes` - list of comma-separated DB schemas that have schema_migration tables
     * `--no-compile` - does not compile applications before dumping
     * `--no-deps-check` - does not check dependencies before dumping
   """

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -55,18 +55,18 @@ defmodule Ecto.Adapters.PostgresTest do
   defp delete_all(query), do: query |> SQL.delete_all |> IO.iodata_to_binary()
   defp execute_ddl(query), do: query |> SQL.execute_ddl |> Enum.map(&IO.iodata_to_binary/1)
 
-  defp insert(prefx, table, header, rows, on_conflict, returning, placeholders \\ []) do
+  defp insert(prefix, table, header, rows, on_conflict, returning, placeholders \\ []) do
     IO.iodata_to_binary(
-      SQL.insert(prefx, table, header, rows, on_conflict, returning, placeholders)
+      SQL.insert(prefix, table, header, rows, on_conflict, returning, placeholders)
     )
   end
 
-  defp update(prefx, table, fields, filter, returning) do
-    IO.iodata_to_binary(SQL.update(prefx, table, fields, filter, returning))
+  defp update(prefix, table, fields, filter, returning) do
+    IO.iodata_to_binary(SQL.update(prefix, table, fields, filter, returning))
   end
 
-  defp delete(prefx, table, filter, returning) do
-    IO.iodata_to_binary(SQL.delete(prefx, table, filter, returning))
+  defp delete(prefix, table, filter, returning) do
+    IO.iodata_to_binary(SQL.delete(prefix, table, filter, returning))
   end
 
   test "from" do


### PR DESCRIPTION
In order to support multi-tenancy, where a single database has multiple tenants that belong to different schemas on postgres, I wanted to add the ability to insert the schema migration versions for all schemas to the structure dump instead of just the migrations ran on `public` schema. 

Kudos to @antedeguemon for noticing an issue with the `mix ecto.dump` output having no schema migration versions for all schemas except `public`.

Likewise, for mysql, we decided to add the option to dump the structure for multiple databases for consistency with the postgres enhancement. 

