### PR TITLE
fix dumping structure of mysql 8 database

### DIFF
--- a/integration_test/myxql/storage_test.exs
+++ b/integration_test/myxql/storage_test.exs
@@ -166,7 +166,7 @@ defmodule Ecto.Integration.StorageTest do
 
     assert {output, 0} =
              Ecto.Adapters.MyXQL.dump_cmd(
-               ["--no-create-info", "--tables", "schema_migrations"],
+               [],
                [],
                PoolRepo.config()
              )

--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -429,7 +429,11 @@ defmodule Ecto.Adapters.MyXQL do
 
     database_args =
       if database = opts[:database] do
-        ["--database", database]
+        if cmd == "mysqldump" do
+          ["--databases", database]
+        else
+          ["--database", database]
+        end
       else
         []
       end


### PR DESCRIPTION
mysqldump has a `--databases` option, not `--database`

fixes https://github.com/elixir-ecto/ecto_sql/issues/492