### PR TITLE
Support for postgres DROP CONSTRAINT ... CASCADE 

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -1022,12 +1022,13 @@ if Code.ensure_loaded?(Postgrex) do
       queries ++ comments_on("CONSTRAINT", constraint.name, constraint.comment, table_name)
     end
 
-    def execute_ddl({command, %Constraint{}, :cascade}) when command in @drops,
-      do: error!(nil, "PostgreSQL does not support `CASCADE` in DROP CONSTRAINT commands")
-
-    def execute_ddl({command, %Constraint{} = constraint, :restrict}) when command in @drops do
-      [["ALTER TABLE ", quote_table(constraint.prefix, constraint.table),
-        " DROP CONSTRAINT ", if_do(command == :drop_if_exists, "IF EXISTS "), quote_name(constraint.name)]]
+    def execute_ddl({command, %Constraint{} = constraint, mode}) when command in @drops do
+      [["ALTER TABLE ",
+        quote_table(constraint.prefix, constraint.table),
+        " DROP CONSTRAINT ",
+        if_do(command == :drop_if_exists, "IF EXISTS "),
+        quote_name(constraint.name),
+        drop_mode(mode)]]
     end
 
     def execute_ddl(string) when is_binary(string), do: [string]

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -2003,6 +2003,10 @@ defmodule Ecto.Adapters.PostgresTest do
     assert execute_ddl(drop) ==
       [~s|ALTER TABLE "products" DROP CONSTRAINT "price_must_be_positive"|]
 
+    drop = {:drop, constraint(:products, "price_must_be_positive"), :cascade}
+    assert execute_ddl(drop) ==
+      [~s|ALTER TABLE "products" DROP CONSTRAINT "price_must_be_positive" CASCADE|]
+
     drop = {:drop, constraint(:products, "price_must_be_positive", prefix: "foo"), :restrict}
     assert execute_ddl(drop) ==
       [~s|ALTER TABLE "foo"."products" DROP CONSTRAINT "price_must_be_positive"|]
@@ -2012,6 +2016,10 @@ defmodule Ecto.Adapters.PostgresTest do
     drop = {:drop_if_exists, constraint(:products, "price_must_be_positive"), :restrict}
     assert execute_ddl(drop) ==
       [~s|ALTER TABLE "products" DROP CONSTRAINT IF EXISTS "price_must_be_positive"|]
+
+    drop = {:drop_if_exists, constraint(:products, "price_must_be_positive"), :cascade}
+    assert execute_ddl(drop) ==
+      [~s|ALTER TABLE "products" DROP CONSTRAINT IF EXISTS "price_must_be_positive" CASCADE|]
 
     drop = {:drop_if_exists, constraint(:products, "price_must_be_positive", prefix: "foo"), :restrict}
     assert execute_ddl(drop) ==


### PR DESCRIPTION
Allow `mode: :cascade` when dropping a constraint.

Support for the CASCADE option was [added to DROP command previously](https://github.com/elixir-ecto/ecto_sql/pull/298) (https://github.com/elixir-ecto/ecto_sql/pull/298). However, attempting to use it to drop a constraint is prevented with an error: 

> \*\* (ArgumentError) PostgreSQL does not support `CASCADE` in DROP CONSTRAINT commands

According to the [PostgresQL docs](https://www.postgresql.org/docs/current/sql-altertable.html) `CASCADE`  is supported (by all current versions from what I can see).

> DROP CONSTRAINT [ IF EXISTS ] constraint\_name [ RESTRICT | CASCADE ]

