### PR TITLE
Fix rollback failure removing reference MySQL

### DIFF
--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -267,8 +267,8 @@ defmodule Ecto.Migration.Runner do
         table_reverse(t, [{:modify, name, reverse_type, reverse_opts} | acc])
     end
   end
-  defp table_reverse([{:add, name, _type, _opts} | t], acc) do
-    table_reverse(t, [{:remove, name} | acc])
+  defp table_reverse([{:add, name, type, _opts} | t], acc) do
+    table_reverse(t, [{:remove, name, type, []} | acc])
   end
   defp table_reverse([_ | _], _acc) do
     false

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -773,7 +773,7 @@ defmodule Ecto.MigrationTest do
               {:modify, :title, :text, [from: {:string, null: false, size: 100}, null: true, size: 255]},
               {:modify, :author, :text, [from: :string, null: false]},
               {:modify, :extension, :string, from: :text},
-              {:remove, :summary}
+              {:remove, :summary, :text, []}
             ]}
 
     assert_raise Ecto.MigrationError, ~r/cannot reverse migration command/, fn ->
@@ -880,6 +880,17 @@ defmodule Ecto.MigrationTest do
       flush()
       assert down_sql == last_command()
     end
+  end
+
+  test "backward: adding a reference column (column type is returned)" do
+    alter table(:posts) do
+      add :author_id, references(:authors)
+    end
+
+    flush()
+
+    assert {:alter, %Table{name: "posts"},
+            [{:remove, :author_id, %Reference{table: "authors"}, []}]} = last_command()
   end
 
   defp last_command(), do: Process.get(:last_command)


### PR DESCRIPTION
This change make the adapter aware that the removed column is a reference and that a foreign key constraint will need to be dropped first.

Closes: #494