### PR TITLE
Pass `up/4` opts to `Ecto.Migrator`

### DIFF
--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -83,21 +83,17 @@ defmodule Ecto.Migrator do
 
       {Ecto.Migrator,
        repos: Application.fetch_env!(:my_app, :ecto_repos),
-       skip: System.get_env("SKIP_MIGRATIONS") == "true",
-       all: true}
+       skip: System.get_env("SKIP_MIGRATIONS") == "true"}
 
   To skip migrations you can also pass `skip: true` or as in the example
   set the environment variable `SKIP_MIGRATIONS` to a truthy value.
 
-  And all other options described in `run/4`,
-  including all the options described in `up/4`, are allowed.
-
-  For example if you want to run a specific number of migrations,
-  log the SQL commands, and run migrations in a prefix:
+  And all other options described in `up/4` are allowed,
+  for example if you want to log the SQL commands,
+  and run migrations in a prefix:
 
       {Ecto.Migrator,
        repos: Application.fetch_env!(:my_app, :ecto_repos),
-       step: 10,
        log_migrator_sql: true,
        prefix: "my_app"}
 
@@ -506,6 +502,7 @@ defmodule Ecto.Migrator do
     {repos, opts} = Keyword.pop!(opts, :repos)
     {skip?, opts} = Keyword.pop(opts, :skip, false)
     {migrator, opts} = Keyword.pop(opts, :migrator, &Ecto.Migrator.run/3)
+    opts = Keyword.put(opts, :all, true)
 
     unless skip? do
       for repo <- repos do

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -488,8 +488,7 @@ defmodule Ecto.Migrator do
 
     * `:skip` - Option to skip migrations. Defaults to `false`.
 
-  Plus all other options described in `run/4`,
-  including all the options described in `up/4`.
+  Plus all other options described in `up/4`.
 
   See "Example: Running migrations on application startup" for more info.
   """

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -89,8 +89,10 @@ defmodule Ecto.Migrator do
   To skip migrations you can also pass `skip: true` or as in the example
   set the environment variable `SKIP_MIGRATIONS` to a truthy value.
 
-  And all other options described in `up/4` are allowed,
-  for example if you want to run a specific number of migrations,
+  And all other options described in `run/4`,
+  including all the options described in `up/4`, are allowed.
+
+  For example if you want to run a specific number of migrations,
   log the SQL commands, and run migrations in a prefix:
 
       {Ecto.Migrator,

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -878,7 +878,7 @@ defmodule Ecto.MigratorTest do
         []
       end
 
-      assert {:ok, :undefined} = start_supervised({Ecto.Migrator, [repos: [TestRepo], migrator: migrator, skip: false, all: true, prefix: "foo"]})
+      assert {:ok, :undefined} = start_supervised({Ecto.Migrator, [repos: [TestRepo], migrator: migrator, skip: false, prefix: "foo"]})
     end
 
     test "skip is set" do

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -861,7 +861,7 @@ defmodule Ecto.MigratorTest do
     end
   end
 
-  describe "gen_server" do 
+  describe "gen_server" do
     test "runs the migrator with repos config" do
       migrator = fn repo, _, _ ->
         assert TestRepo == repo
@@ -869,6 +869,16 @@ defmodule Ecto.MigratorTest do
       end
 
       assert {:ok, :undefined} = start_supervised({Ecto.Migrator, [repos: [TestRepo], migrator: migrator]})
+    end
+
+    test "runs the migrator with extra opts" do
+      migrator = fn repo, _, opts ->
+        assert TestRepo == repo
+        assert opts == [all: true, prefix: "foo"]
+        []
+      end
+
+      assert {:ok, :undefined} = start_supervised({Ecto.Migrator, [repos: [TestRepo], migrator: migrator, skip: false, prefix: "foo"]})
     end
 
     test "skip is set" do

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -878,7 +878,7 @@ defmodule Ecto.MigratorTest do
         []
       end
 
-      assert {:ok, :undefined} = start_supervised({Ecto.Migrator, [repos: [TestRepo], migrator: migrator, skip: false, prefix: "foo"]})
+      assert {:ok, :undefined} = start_supervised({Ecto.Migrator, [repos: [TestRepo], migrator: migrator, skip: false, all: true, prefix: "foo"]})
     end
 
     test "skip is set" do


### PR DESCRIPTION
Ref: https://github.com/elixir-ecto/ecto_sql/pull/482/files#r1150260123

I've removed the fixed opt `all: true` to make it more explicit and less complex, otherwise we would have to check if `opts` has any of the `run/4` opts and change `all` to `false`. Removing it follows the existing behavior, makes sense?