### PR TITLE
Suppress query logs in mix ecto.load when quiet flag is given.

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -566,11 +566,11 @@ defmodule Ecto.Adapters.SQL do
   Returns `true` if the `table` exists in the `repo`, otherwise `false`.
   The table is checked against the current database/schema in the connection.
   """
-  @spec table_exists?(Ecto.Repo.t, table :: String.t) :: boolean
-  def table_exists?(repo, table) when is_atom(repo) do
+  @spec table_exists?(Ecto.Repo.t, table :: String.t, opts :: Keyword.t) :: boolean
+  def table_exists?(repo, table, opts \\ []) when is_atom(repo) do
     %{sql: sql} = adapter_meta = Ecto.Adapter.lookup_meta(repo)
     {query, params} = sql.table_exists_query(table)
-    query!(adapter_meta, query, params, []).num_rows != 0
+    query!(adapter_meta, query, params, opts).num_rows != 0
   end
 
   # Returns a formatted table for a given query `result`.

--- a/lib/mix/tasks/ecto.load.ex
+++ b/lib/mix/tasks/ecto.load.ex
@@ -71,7 +71,7 @@ defmodule Mix.Tasks.Ecto.Load do
       )
 
       {migration_repo, source} = Ecto.Migration.SchemaMigration.get_repo_and_source(repo, repo.config())
-      {:ok, loaded?, _} = Ecto.Migrator.with_repo(migration_repo, table_exists_closure(table_exists?, source, opts), opts)
+      {:ok, loaded?, _} = Ecto.Migrator.with_repo(migration_repo, table_exists_closure(table_exists?, source, opts))
 
       for repo <- Enum.uniq([repo, migration_repo]) do
         cond do

--- a/lib/mix/tasks/ecto.load.ex
+++ b/lib/mix/tasks/ecto.load.ex
@@ -59,6 +59,7 @@ defmodule Mix.Tasks.Ecto.Load do
   def run(args, table_exists? \\ &Ecto.Adapters.SQL.table_exists?/2) do
     {opts, _} = OptionParser.parse!(args, strict: @switches, aliases: @aliases)
     opts = Keyword.merge(@default_opts, opts)
+    opts = if opts[:quiet], do: Keyword.merge(opts, [log: false]), else: opts
 
     Enum.each(parse_repo(args), fn repo ->
       ensure_repo(repo, args)
@@ -70,7 +71,7 @@ defmodule Mix.Tasks.Ecto.Load do
       )
 
       {migration_repo, source} = Ecto.Migration.SchemaMigration.get_repo_and_source(repo, repo.config())
-      {:ok, loaded?, _} = Ecto.Migrator.with_repo(migration_repo, &table_exists?.(&1, source))
+      {:ok, loaded?, _} = Ecto.Migrator.with_repo(migration_repo, &table_exists?.(&1, source), opts)
 
       for repo <- Enum.uniq([repo, migration_repo]) do
         cond do


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto_sql/issues/501

Since it's not performing any migrations this should quiet all the logs.