### PR TITLE
MySQL split constraint message on backtick quotes

### DIFF
--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -44,7 +44,7 @@ if Code.ensure_loaded?(MyXQL) do
       MyXQL.stream(conn, sql, params, opts)
     end
 
-    @quotes ~w(" ')
+    @quotes ~w(" ' `)
 
     @impl true
     def to_constraints(%MyXQL.Error{mysql: %{name: :ER_DUP_ENTRY}, message: message}, opts) do


### PR DESCRIPTION
The Ecto integration tests are failing (only on Ecto repo) because they are not running with the `ansi_quotes` flag: https://github.com/elixir-ecto/ecto/actions/runs/4641709320/jobs/8214957517?pr=4148

What it looks like to me:

- planetscale quotes with '
- MySQL without any flags quotes with `
- MySQL with ansi_quotes flag quotes with "

Since this repo is using the ansi_quotes flag for integration tests it is not failing the same as the Ecto repo.

I tested this locally without the ansi_quote flag. 