### PR TITLE
Update postgrex to ~> 0.17

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -85,7 +85,7 @@ defmodule EctoSQL.MixProject do
     if path = System.get_env("POSTGREX_PATH") do
       {:postgrex, path: path}
     else
-      {:postgrex, "~> 0.16.0 or ~> 1.0", optional: true}
+      {:postgrex, "~> 0.17.0 or ~> 1.0", optional: true}
     end
   end
 


### PR DESCRIPTION
## Background

I got the error

```console
> mix deps.get
Resolving Hex dependencies...

Failed to use "postgrex" because
  mix.exs requires ~> 0.17
  ecto_sql (version 3.10.0) requires ~> 0.16.0 or ~> 1.0

** (Mix) Hex dependency resolution failed, change the version requirements of your dependencies or unlock them (by using mix deps.update or mix deps.unlock). If you are unable to resolve the conflicts you can try overriding with {:dependency, "~> 1.0", override: true}
```

## What I did

I just updated the postgrex version to ~> 0.17 to resolve the error.