### PR TITLE
Fix warnings in tests

### DIFF
--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -342,6 +342,7 @@ defmodule Ecto.Adapters.PostgresTest do
       from(c in "categories",
         as: :parent_category,
         left_lateral_join: b in subquery(breadcrumbs_query),
+        on: true,
         select: %{id: c.id, breadcrumbs: b.breadcrumbs}
       )
       |> plan()
@@ -1148,7 +1149,7 @@ defmodule Ecto.Adapters.PostgresTest do
   test "join with hints" do
     assert_raise Ecto.QueryError, ~r/table hints are not supported by PostgreSQL/, fn ->
       Schema
-      |> join(:inner, [p], q in Schema2, hints: ["USE INDEX FOO", "USE INDEX BAR"])
+      |> join(:inner, [p], q in Schema2, hints: ["USE INDEX FOO", "USE INDEX BAR"], on: true)
       |> select([], true)
       |> plan()
       |> all()
@@ -1181,7 +1182,11 @@ defmodule Ecto.Adapters.PostgresTest do
            ~s{INNER JOIN (SELECT sp0."x" AS "x", sp0."y" AS "z" FROM "posts" AS sp0 WHERE (sp0."title" = $1)) AS s1 ON TRUE}
 
     posts = subquery("posts" |> where(title: parent_as(:comment).subtitle) |> select([r], r.title))
-    query = "comments" |> from(as: :comment) |> join(:inner, [c], p in subquery(posts)) |> select([_, p], p) |> plan()
+    query = "comments"
+            |> from(as: :comment)
+            |> join(:inner, [c], p in subquery(posts), on: true)
+            |> select([_, p], p)
+            |> plan()
     assert all(query) ==
            ~s{SELECT s1."title" FROM "comments" AS c0 } <>
            ~s{INNER JOIN (SELECT sp0."title" AS "title" FROM "posts" AS sp0 WHERE (sp0."title" = c0."subtitle")) AS s1 ON TRUE}
@@ -1199,7 +1204,11 @@ defmodule Ecto.Adapters.PostgresTest do
 
   test "join with fragment" do
     query = Schema
-            |> join(:inner, [p], q in fragment("SELECT * FROM schema2 AS s2 WHERE s2.id = ? AND s2.field = ?", p.x, ^10))
+            |> join(:inner,
+              [p],
+              q in fragment("SELECT * FROM schema2 AS s2 WHERE s2.id = ? AND s2.field = ?", p.x, ^10),
+              on: true
+            )
             |> select([p], {p.id, ^0})
             |> where([p], p.id > 0 and p.id < ^100)
             |> plan()
@@ -1221,14 +1230,14 @@ defmodule Ecto.Adapters.PostgresTest do
 
   test "join with query interpolation" do
     inner = Ecto.Queryable.to_query(Schema2)
-    query = from(p in Schema, left_join: c in ^inner, select: {p.id, c.id}) |> plan()
+    query = from(p in Schema, left_join: c in ^inner, on: true, select: {p.id, c.id}) |> plan()
     assert all(query) ==
            "SELECT s0.\"id\", s1.\"id\" FROM \"schema\" AS s0 LEFT OUTER JOIN \"schema2\" AS s1 ON TRUE"
   end
 
   test "lateral join with fragment" do
     query = Schema
-            |> join(:inner_lateral, [p], q in fragment("SELECT * FROM schema2 AS s2 WHERE s2.id = ? AND s2.field = ?", p.x, ^10))
+            |> join(:inner_lateral, [p], q in fragment("SELECT * FROM schema2 AS s2 WHERE s2.id = ? AND s2.field = ?", p.x, ^10), on: true)
             |> select([p, q], {p.id, q.z})
             |> where([p], p.id > 0 and p.id < ^100)
             |> plan()


### PR DESCRIPTION
Some tests used joins without `:on`, which recently started giving warnings.