### PR TITLE
Fix compatibility with Earthly 0.7+

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,3 +1,5 @@
+VERSION 0.5
+
 all:
     BUILD +test-all
     BUILD +integration-test-all


### PR DESCRIPTION
The `VERSION` directive is required since Earthly 0.7.
