### PR TITLE
Update Earthly in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: earthly/actions/setup-earthly@v1
         with:
-          version: v0.5.10
+          version: v0.7.4
       - uses: actions/checkout@v2
       - name: test ectl_sql
         run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixirbase}} +test
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: earthly/actions/setup-earthly@v1
         with:
-          version: v0.5.10
+          version: v0.7.4
       - uses: actions/checkout@v2
       - name: test ecto_sql
         run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixirbase}} --build-arg POSTGRES=${{matrix.postgres}} +integration-test-postgres
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: earthly/actions/setup-earthly@v1
         with:
-          version: v0.5.10
+          version: v0.7.4
       - uses: actions/checkout@v2
       - name: test ecto_sql
         run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixirbase}} --build-arg POSTGRES=${{matrix.postgres}} +integration-test-mysql
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: earthly/actions/setup-earthly@v1
         with:
-          version: v0.5.10
+          version: v0.7.4
       - uses: actions/checkout@v2
       - name: test ecto_sql
         run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixirbase}} --build-arg MSSQL=${{matrix.mssql}} +integration-test-mssql


### PR DESCRIPTION
Sorry, I think I broke Earthly in #513!

It seems that Earthly didn't support the `VERSION` directive, yet.
Updating Earthly to the latest version, while pinning the `VERSION` to 0.5 (the current version used in CI), shouldn't break things.
