### PR TITLE
Improve and standardize errors for join qualifiers

### DIFF
--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -398,6 +398,7 @@ if Code.ensure_loaded?(MyXQL) do
     defp join_qual(:full, _),  do: " FULL OUTER JOIN "
     defp join_qual(:cross, _), do: " CROSS JOIN "
     defp join_qual(:cross_lateral, _), do: " CROSS JOIN LATERAL "
+    defp join_qual(qual), do: error!(nil, "join qualifier #{inspect(qual)} is not supported in the MySQL adapter")
 
     defp where(%{wheres: wheres} = query, sources) do
       boolean(" WHERE ", wheres, sources, query)

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -94,7 +94,7 @@ if Code.ensure_loaded?(Postgrex) do
 
     @impl true
     def query_many(_conn, _sql, _params, _opts) do
-      raise RuntimeError, "query_many is not supported in the Postgrex adapter"
+      raise RuntimeError, "query_many is not supported in the PostgreSQL adapter"
     end
 
     @impl true
@@ -528,6 +528,7 @@ if Code.ensure_loaded?(Postgrex) do
     defp join_qual(:full),  do: "FULL OUTER JOIN "
     defp join_qual(:cross), do: "CROSS JOIN "
     defp join_qual(:cross_lateral), do: "CROSS JOIN LATERAL "
+    defp join_qual(qual), do: error!(nil, "join qualifier #{inspect(qual)} is not supported in the PostgreSQL adapter")
 
     defp where(%{wheres: wheres} = query, sources) do
       boolean(" WHERE ", wheres, sources, query)

--- a/lib/ecto/adapters/tds/connection.ex
+++ b/lib/ecto/adapters/tds/connection.ex
@@ -526,7 +526,7 @@ if Code.ensure_loaded?(Tds) do
     defp join_qual(:cross), do: "CROSS JOIN "
     defp join_qual(:inner_lateral), do: "CROSS APPLY "
     defp join_qual(:left_lateral), do: "OUTER APPLY "
-    defp join_qual(:cross_lateral), do: error!(nil, "cross lateral joins are not supported in the Tds Adapter")
+    defp join_qual(qual), do: error!(nil, "join qualifier #{inspect(qual)} is not supported in the Tds adapter")
 
     defp where(%Query{wheres: wheres} = query, sources) do
       boolean(" WHERE ", wheres, sources, query)


### PR DESCRIPTION
Adds a default clause for when the qualifier isn't implemented by the adapter, raising an error. Before this change, ad-hoc error messages were present and if not implemented, a function-clause error would happen.

Motivated by `:array` and `:left_array` being added in Ecto.