### PR TITLE
Update CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,9 @@ jobs:
           - "1.13.4-erlang-24.3.4.2-alpine-3.16.0"
           - "1.13.4-erlang-22.3.4.20-alpine-3.14.0"
     steps:
-      - uses: earthly/actions/setup-earthly@v1
-        with:
-          version: v0.7.4
-      - uses: actions/checkout@v2
-      - name: test ectl_sql
+      - uses: earthly/actions-setup@v1
+      - uses: actions/checkout@v3
+      - name: test ecto_sql
         run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixirbase}} +test
   test-postgres:
     name: postgres integration test
@@ -31,10 +29,8 @@ jobs:
           - "9.6"
           - "9.5"
     steps:
-      - uses: earthly/actions/setup-earthly@v1
-        with:
-          version: v0.7.4
-      - uses: actions/checkout@v2
+      - uses: earthly/actions-setup@v1
+      - uses: actions/checkout@v3
       - name: test ecto_sql
         run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixirbase}} --build-arg POSTGRES=${{matrix.postgres}} +integration-test-postgres
   test-mysql:
@@ -48,10 +44,8 @@ jobs:
         mysql:
           - "5.7"
     steps:
-      - uses: earthly/actions/setup-earthly@v1
-        with:
-          version: v0.7.4
-      - uses: actions/checkout@v2
+      - uses: earthly/actions-setup@v1
+      - uses: actions/checkout@v3
       - name: test ecto_sql
         run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixirbase}} --build-arg POSTGRES=${{matrix.postgres}} +integration-test-mysql
   test-mssql:
@@ -66,9 +60,7 @@ jobs:
           - "2017"
           - "2019"
     steps:
-      - uses: earthly/actions/setup-earthly@v1
-        with:
-          version: v0.7.4
-      - uses: actions/checkout@v2
+      - uses: earthly/actions-setup@v1
+      - uses: actions/checkout@v3
       - name: test ecto_sql
         run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixirbase}} --build-arg MSSQL=${{matrix.mssql}} +integration-test-mssql


### PR DESCRIPTION
Fixes warnings about Node 12 deprecation. Stop using deprecated version of earthly action.