### PR TITLE
Fix calls to deprecated Logger.warn/2

### DIFF
--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -268,7 +268,7 @@ defmodule Ecto.Migrator do
           if opts[:strict_version_order] do
             raise Ecto.MigrationError, message
           else
-            Logger.warn message
+            Logger.warning message
           end
         end
 

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule EctoSQL.MixProject do
     [
       app: :ecto_sql,
       version: @version,
-      elixir: "~> 1.10",
+      elixir: "~> 1.11",
       deps: deps(),
       test_paths: test_paths(System.get_env("ECTO_ADAPTER")),
       xref: [


### PR DESCRIPTION
Related to elixir-ecto/ecto#4212.

Thought I would create a PR here too for completeness, but if it clutters the PR list feel free to close it.
