### PR TITLE
Implements hints for Postgresql

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -392,13 +392,9 @@ if Code.ensure_loaded?(Postgrex) do
        exprs}
     end
 
-    defp from(%{from: %{hints: [_ | _]}} = query, _sources) do
-      error!(query, "table hints are not supported by PostgreSQL")
-    end
-
-    defp from(%{from: %{source: source}} = query, sources) do
+    defp from(%{from: %{source: source, hints: hints}} = query, sources) do
       {from, name} = get_source(query, sources, 0, source)
-      [" FROM ", from, " AS " | name]
+      [" FROM ", from, " AS ", name | Enum.map(hints, &[?\s | &1])]
     end
 
     defp cte(%{with_ctes: %WithExpr{recursive: recursive, queries: [_ | _] = queries}} = query, sources) do

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -394,7 +394,16 @@ if Code.ensure_loaded?(Postgrex) do
 
     defp from(%{from: %{source: source, hints: hints}} = query, sources) do
       {from, name} = get_source(query, sources, 0, source)
-      [" FROM ", from, " AS ", name | Enum.map(hints, &[?\s | &1])]
+      [" FROM ", from, " AS ", name | hints(hints)]
+    end
+
+    defp hints([]), do: []
+    defp hints(hint) when is_binary(hint), do: [?\s | hint]
+    defp hints([{key, value} | tail]) do
+      [?\s, to_string(key), ?\s, to_string(value) | hints(tail)]
+    end
+    defp hints([hint | tail]) do
+      [?\s, hint | hints(tail)]
     end
 
     defp cte(%{with_ctes: %WithExpr{recursive: recursive, queries: [_ | _] = queries}} = query, sources) do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -74,10 +74,35 @@ defmodule Ecto.Adapters.PostgresTest do
     assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0}
   end
 
-  test "from with hints" do
-    assert_raise Ecto.QueryError, ~r/table hints are not supported by PostgreSQL/, fn ->
-      Schema |> from(hints: "USE INDEX FOO") |> select([r], r.x) |> plan() |> all()
-    end
+  test "from with hints list" do
+    query =
+      Schema
+      |> from(hints: ["TABLESAMPLE system_rows(1)"])
+      |> select([r], r.x)
+      |> plan()
+
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0 TABLESAMPLE system_rows(1)}
+  end
+
+  test "from with hints string" do
+    query =
+      Schema
+      |> from(hints: "TABLESAMPLE system_rows(1)")
+      |> select([r], r.x)
+      |> plan()
+
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0 TABLESAMPLE system_rows(1)}
+  end
+
+  test "from with hints list of tuples" do
+    one = 1
+    query =
+      Schema
+      |> from(hints: ["TABLESAMPLE SYSTEM": one])
+      |> select([r], r.x)
+      |> plan()
+
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0 TABLESAMPLE SYSTEM 1}
   end
 
   test "from without schema" do


### PR DESCRIPTION
### Overview

Implements FROM statement hints for postgresql

### Use-case

This is useful for `TABLESAMPLE ` hint in postgresql
https://www.postgresql.org/docs/current/sql-select.html#SQL-FROM

For example:
```elixir
from x in Item, hints: ["TABLESAMPLE system_rows(1)"]
```

Fixes well-known problem with getting random rows from the table using Ecto
https://elixirforum.com/t/ecto-add-raw-sql-at-end-of-query-or-rather-choose-row-at-random/3386

---

If this change requires any tests, I am happy to implement them, just show me how.