### PR TITLE
Make checkout/3 overridable in adapters

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -229,7 +229,7 @@ defmodule Ecto.Adapters.SQL do
       end
 
       defoverridable [prepare: 2, execute: 5, insert: 6, update: 6, delete: 4, insert_all: 8,
-                      execute_ddl: 3, loaders: 2, dumpers: 2, autogenerate: 1,
+                      execute_ddl: 3, loaders: 2, dumpers: 2, autogenerate: 1, checkout: 3,
                       ensure_all_started: 2, __before_compile__: 1]
     end
   end


### PR DESCRIPTION
[Exandra](https://github.com/vinniefranco/exandra) (a Cassandra/Scylla adapter for Ecto) uses [`Xandra.Cluster`](https://hexdocs.pm/xandra/0.16.0/Xandra.Cluster.html) underneath. The issue arises because a `Xandra.Cluster` process is **not** a db_connection pool. That's because it has to connect to multiple nodes in a cluster, have a lot of logic to decide which node to execute each query on, and so on. Anyway, this causes issues with Ecto because the default `checkout/3` implementation (injected through `use Ecto.Adapters.SQL`) relies on the db_connection behavior. This PR simply makes that callback overridable, which in our case means that we can use the cluster's logic to check out a connection.

Thoughts? 🙃 

cc @vinniefranco