### PR TITLE
Fix for casting boolean values in MySQL

### DIFF
--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -689,8 +689,7 @@ if Code.ensure_loaded?(MyXQL) do
       [expr(other, sources, query), " + 0"]
     end
 
-    defp expr(%Ecto.Query.Tagged{value: other, type: type}, sources, query)
-         when type in [:boolean] do
+    defp expr(%Ecto.Query.Tagged{value: other, type: :boolean}, sources, query) do
       ["IF(", expr(other, sources, query), ", TRUE, FALSE)"]
     end
 

--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -689,6 +689,11 @@ if Code.ensure_loaded?(MyXQL) do
       [expr(other, sources, query), " + 0"]
     end
 
+    defp expr(%Ecto.Query.Tagged{value: other, type: type}, sources, query)
+         when type in [:boolean] do
+      ["IF(", expr(other, sources, query), ", TRUE, FALSE)"]
+    end
+
     defp expr(%Ecto.Query.Tagged{value: other, type: type}, sources, query) do
       ["CAST(", expr(other, sources, query), " AS ", ecto_cast_to_db(type, query), ?)]
     end

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -612,6 +612,16 @@ defmodule Ecto.Adapters.MyXQLTest do
     assert all(query) == ~s{SELECT CAST(? AS char) FROM `schema` AS s0}
   end
 
+  test "boolean type true is cast with an if" do
+    query = Schema |> select([], type(^true, :boolean)) |> plan()
+    assert all(query) == ~s{SELECT IF(?, TRUE, FALSE) FROM `schema` AS s0}
+  end
+
+  test "boolean type false is cast with an if" do
+    query = Schema |> select([], type(^false, :boolean)) |> plan()
+    assert all(query) == ~s{SELECT IF(?, TRUE, FALSE) FROM `schema` AS s0}
+  end
+
   test "json_extract_path" do
     query = Schema |> select([s], json_extract_path(s.meta, [0, 1])) |> plan()
     assert all(query) == ~s{SELECT json_extract(s0.`meta`, '$[0][1]') FROM `schema` AS s0}


### PR DESCRIPTION
I'm not sure if this fix is sufficient enough. I've tried it locally and it solves my problem. 


One thing I'm not sure is covered is, what if you pass a value that's not true or false to the cast expression? I assume that's just invalid SQL?