### PR TITLE
Fix mysqldump generating `use database`

### DIFF
--- a/integration_test/myxql/storage_test.exs
+++ b/integration_test/myxql/storage_test.exs
@@ -146,57 +146,44 @@ defmodule Ecto.Integration.StorageTest do
   end
 
   test "structure dump and load with migrations table" do
+    default_db = "ecto_test"
     num = @base_migration + System.unique_integer([:positive])
     :ok = Ecto.Migrator.up(PoolRepo, num, Migration, log: false)
     {:ok, path} = Ecto.Adapters.MyXQL.structure_dump(tmp_path(), TestRepo.config())
     contents = File.read!(path)
-    assert contents =~ "INSERT INTO `ecto_test`.`schema_migrations` (version) VALUES (#{num})"
+    assert contents =~ "Database: #{default_db}"
+    assert contents =~ "INSERT INTO `schema_migrations` (version) VALUES (#{num})"
   end
 
-  test "dumps structure and schema_migration records from multiple prefixes" do
-    # Create the test_schema schema
+  test "raises when attempting to dump multiple prefixes" do
     create_database()
     prefix = params()[:database]
-
-    # Run migrations
-    version = @base_migration + System.unique_integer([:positive])
-    :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false)
-    :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false, prefix: prefix)
-
     config = Keyword.put(TestRepo.config(), :dump_prefixes, ["ecto_test", prefix])
-    {:ok, path} = Ecto.Adapters.MyXQL.structure_dump(tmp_path(), config)
-    contents = File.read!(path)
+    msg = "cannot dump multiple prefixes with MySQL. Please run the command separately for each prefix."
 
-    assert contents =~ "Current Database: `#{prefix}`"
-    assert contents =~ "Current Database: `ecto_test`"
-    assert contents =~ "CREATE TABLE `schema_migrations`"
-    assert contents =~ ~s[INSERT INTO `#{prefix}`.`schema_migrations` (version) VALUES (#{version})]
-    assert contents =~ ~s[INSERT INTO `ecto_test`.`schema_migrations` (version) VALUES (#{version})]
+    assert_raise ArgumentError, msg, fn ->
+      Ecto.Adapters.MyXQL.structure_dump(tmp_path(), config)
+    end
   after
     drop_database()
   end
 
   test "dumps structure and schema_migration records only from queried prefix" do
-    # Create the test_schema schema
+    # Create the storage_mgt database
     create_database()
     prefix = params()[:database]
 
     # Run migrations
     version = @base_migration + System.unique_integer([:positive])
-    :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false)
     :ok = Ecto.Migrator.up(PoolRepo, version, Migration, log: false, prefix: prefix)
 
-    config = Keyword.put(TestRepo.config(), :dump_prefixes, ["ecto_test"])
+    config = Keyword.put(TestRepo.config(), :dump_prefixes, [prefix])
     {:ok, path} = Ecto.Adapters.MyXQL.structure_dump(tmp_path(), config)
     contents = File.read!(path)
 
-    refute contents =~ "Current Database: `#{prefix}`"
-    assert contents =~ "Current Database: `ecto_test`"
-    assert contents =~ "CREATE TABLE `schema_migrations`"
-    refute contents =~ ~s[INSERT INTO `#{prefix}`.`schema_migrations` (version) VALUES (#{version})]
-    assert contents =~ ~s[INSERT INTO `ecto_test`.`schema_migrations` (version) VALUES (#{version})]
-  after
-    drop_database()
+    refute contents =~ "USE `#{prefix}`"
+    assert contents =~ "Database: #{prefix}"
+    assert contents =~ "INSERT INTO `schema_migrations` (version) VALUES (#{version})"
   end
 
   defp strip_timestamp(dump) do

--- a/lib/mix/tasks/ecto.dump.ex
+++ b/lib/mix/tasks/ecto.dump.ex
@@ -48,11 +48,11 @@ defmodule Mix.Tasks.Ecto.Dump do
     * `--no-compile` - does not compile applications before dumping
     * `--no-deps-check` - does not check dependencies before dumping
     * `--prefix` - prefix that will be included in the structure dump.
-      Can include multiple prefixes (ex. `--prefix foo --prefix bar`).
-      When specified, the prefixes will have their definitions dumped along
-      with the data in their migration table. The default behavior is
-      dependent on the adapter for backwards compatibility reasons.
-      For PostgreSQL, the configured database has the definitions dumped
+      Can include multiple prefixes (ex. `--prefix foo --prefix bar`) with
+      PostgreSQL but not MySQL. When specified, the prefixes will have
+      their definitions dumped along with the data in their migration table.
+      The default behavior is dependent on the adapter for backwards compatibility
+      reasons. For PostgreSQL, the configured database has the definitions dumped
       from all of its schemas but only the data from the migration table
       from the `public` schema is included. For MySQL, only the configured
       database and its migration table are dumped.
@@ -97,7 +97,7 @@ defmodule Mix.Tasks.Ecto.Dump do
       end
     end
   end
-  
+
   defp format_time(microsec) when microsec < 1_000, do: "#{microsec} μs"
   defp format_time(microsec) when microsec < 1_000_000, do: "#{div(microsec, 1_000)} ms"
   defp format_time(microsec), do: "#{Float.round(microsec / 1_000_000.0)} s"


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto_sql/issues/539.

There are 2 things:

1. Allowing multiple prefixes for mysql requires the `--databases` flag, which automatically adds the `use` statement. So don't allow this for MySQL.
2. When `dump_cmd` was created the `run_with_cmd` was refactored to add the `--databases` flag. Most likely in attempt to reduce duplication/clean up the code. Putting the database specification back into the callers because they are too different to generalize here (i.e. dump_with_cmd wants to use the config database, but structure_dump wants to allow custom prefixes).