### PR TITLE
Ignore `nil` config database in `dump_cmd` for MySQL

### DIFF
--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -379,7 +379,13 @@ defmodule Ecto.Adapters.MyXQL do
 
   @impl true
   def dump_cmd(args, opts \\ [], config) when is_list(config) and is_list(args) do
-    args = args ++ [config[:database]]
+    args =
+      if database = config[:database] do
+        args ++ [database]
+      else
+        args
+      end
+
     run_with_cmd("mysqldump", config, args, opts)
   end
 


### PR DESCRIPTION
A small addition to the change from this morning. I think this is more in line with the original implementation. It seems the config db was ignored if not specified. Maybe as a way to specify it through `args` instead: https://github.com/greg-rychlewski/ecto_sql/commit/14d7ee25dd21a6ac30e74347a2632a955345fa44#diff-1b4b8837190c26bcdc65285b4285794ae157cb09fb94c026e1b61cd991ba41a2L449