### PR TITLE
Don't add comment to removed columns

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -1354,6 +1354,9 @@ if Code.ensure_loaded?(Postgrex) do
 
     defp comments_for_columns(table_name, columns) do
       Enum.flat_map(columns, fn
+        {:remove, _column_name, _column_type, _opts}  ->
+          []
+
         {_operation, column_name, _column_type, opts} ->
           column_name = [table_name, ?. | quote_name(column_name)]
           comments_on("COLUMN", column_name, opts[:comment])

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1580,6 +1580,11 @@ defmodule Ecto.Adapters.PostgresTest do
     ~s|COMMENT ON COLUMN "foo"."posts"."updated_at" IS 'column comment 2'|]
   end
 
+  test "removing a column does not add a comment" do
+    alter = {:alter, table(:posts), [{:remove, :title, :string, [comment: "comment"]}]}
+    assert execute_ddl(alter) == [~s/ALTER TABLE "posts" DROP COLUMN "title"/]
+  end
+
   test "create table with references" do
     create = {:create, table(:posts),
               [{:add, :id, :serial, [primary_key: true]},


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto_sql/issues/544

edit: 

Some things I checked:

- It's not an issue for MySQL/TDS. MySQL is handling the case already. TDS doesn't seem like it supports comments.
- `remove_if_exists` doesn't support opts so don't have to worry about it.
- it makes sense to allow the `comment` option for this operation because of the reverse operation