### PR TITLE
Proposal: Allow async migrations to be disabled

### DIFF
--- a/integration_test/pg/migrations_test.exs
+++ b/integration_test/pg/migrations_test.exs
@@ -3,6 +3,7 @@ defmodule Ecto.Integration.MigrationsTest do
 
   alias Ecto.Integration.PoolRepo
   alias Ecto.Integration.AdvisoryLockPoolRepo
+  alias Ecto.Integration.AsyncFalsePoolRepo
   import ExUnit.CaptureLog
 
   @moduletag :capture_log
@@ -19,6 +20,15 @@ defmodule Ecto.Integration.MigrationsTest do
 
   defmodule NormalMigration do
     use Ecto.Migration
+
+    def change do
+      create_if_not_exists table(:log_mode_table)
+    end
+  end
+
+  defmodule AsyncFalseMigration do
+    use Ecto.Migration
+    @disable_async_migration true
 
     def change do
       create_if_not_exists table(:log_mode_table)
@@ -144,6 +154,60 @@ defmodule Ecto.Integration.MigrationsTest do
       assert down_log =~ @drop_table_log
       refute down_log =~ @version_delete
       refute down_log =~ "commit []"
+    end
+
+    test "async migration disabled through repo config" do
+      num = @base_migration + System.unique_integer([:positive])
+      up_log =
+        capture_log(fn ->
+          Ecto.Migrator.up(AsyncFalsePoolRepo, num, NormalMigration, log_migrator_sql: :info, log_migrations_sql: :info, log: :info)
+        end)
+
+      assert Regex.scan(~r/(begin \[\])/, up_log) |> length() == 1
+      assert up_log =~ @get_lock_command
+      assert up_log =~ @create_table_sql
+      assert up_log =~ @create_table_log
+      assert up_log =~ @version_insert
+      assert Regex.scan(~r/(commit \[\])/, up_log) |> length() == 1
+
+      down_log =
+        capture_log(fn ->
+          Ecto.Migrator.down(AsyncFalsePoolRepo, num, NormalMigration, log_migrator_sql: :info, log_migrations_sql: :info, log: :info)
+        end)
+
+      assert Regex.scan(~r/(begin \[\])/, down_log) |> length() == 1
+      assert down_log =~ @get_lock_command
+      assert down_log =~ @drop_table_sql
+      assert down_log =~ @drop_table_log
+      assert down_log =~ @version_delete
+      assert Regex.scan(~r/(begin \[\])/, down_log) |> length() == 1
+    end
+
+    test "async migration disabled through migration module" do
+      num = @base_migration + System.unique_integer([:positive])
+      up_log =
+        capture_log(fn ->
+          Ecto.Migrator.up(PoolRepo, num, AsyncFalseMigration, log_migrator_sql: :info, log_migrations_sql: :info, log: :info)
+        end)
+
+      assert Regex.scan(~r/(begin \[\])/, up_log) |> length() == 1
+      assert up_log =~ @get_lock_command
+      assert up_log =~ @create_table_sql
+      assert up_log =~ @create_table_log
+      assert up_log =~ @version_insert
+      assert Regex.scan(~r/(commit \[\])/, up_log) |> length() == 1
+
+      down_log =
+        capture_log(fn ->
+          Ecto.Migrator.down(PoolRepo, num, AsyncFalseMigration, log_migrator_sql: :info, log_migrations_sql: :info, log: :info)
+        end)
+
+      assert Regex.scan(~r/(begin \[\])/, down_log) |> length() == 1
+      assert down_log =~ @get_lock_command
+      assert down_log =~ @drop_table_sql
+      assert down_log =~ @drop_table_log
+      assert down_log =~ @version_delete
+      assert Regex.scan(~r/(begin \[\])/, down_log) |> length() == 1
     end
   end
 end

--- a/integration_test/tds/migrations_test.exs
+++ b/integration_test/tds/migrations_test.exs
@@ -27,6 +27,7 @@ defmodule Ecto.Integration.MigrationsTest do
 
   describe "Migrator" do
     @get_lock_command ~s(sp_getapplock @Resource = 'ecto_Ecto.Integration.PoolRepo', @LockMode = 'Exclusive', @LockOwner = 'Transaction', @LockTimeout = -1)
+    @get_lock_command_async_false ~s(sp_getapplock @Resource = 'ecto_Ecto.Integration.AsyncFalsePoolRepo', @LockMode = 'Exclusive', @LockOwner = 'Transaction', @LockTimeout = -1)
     @create_table_sql ~s(CREATE TABLE [log_mode_table])
     @create_table_log "create table if not exists log_mode_table"
     @drop_table_sql ~s(DROP TABLE [log_mode_table])
@@ -96,7 +97,7 @@ defmodule Ecto.Integration.MigrationsTest do
         end)
 
       assert Regex.scan(~r/(begin \[\])/, up_log) |> length() == 1
-      assert up_log =~ @get_lock_command
+      assert up_log =~ @get_lock_command_async_false
       assert up_log =~ @create_table_sql
       assert up_log =~ @create_table_log
       assert up_log =~ @version_insert
@@ -108,7 +109,7 @@ defmodule Ecto.Integration.MigrationsTest do
         end)
 
       assert Regex.scan(~r/(begin \[\])/, down_log) |> length() == 1
-      assert down_log =~ @get_lock_command
+      assert down_log =~ @get_lock_command_async_false
       assert down_log =~ @drop_table_sql
       assert down_log =~ @drop_table_log
       assert down_log =~ @version_delete
@@ -123,7 +124,7 @@ defmodule Ecto.Integration.MigrationsTest do
         end)
 
       assert Regex.scan(~r/(begin \[\])/, up_log) |> length() == 1
-      assert up_log =~ @get_lock_command
+      assert up_log =~ @get_lock_command_async_false
       assert up_log =~ @create_table_sql
       assert up_log =~ @create_table_log
       assert up_log =~ @version_insert
@@ -135,7 +136,7 @@ defmodule Ecto.Integration.MigrationsTest do
         end)
 
       assert Regex.scan(~r/(begin \[\])/, down_log) |> length() == 1
-      assert down_log =~ @get_lock_command
+      assert down_log =~ @get_lock_command_async_false
       assert down_log =~ @drop_table_sql
       assert down_log =~ @drop_table_log
       assert down_log =~ @version_delete

--- a/integration_test/tds/migrations_test.exs
+++ b/integration_test/tds/migrations_test.exs
@@ -124,7 +124,7 @@ defmodule Ecto.Integration.MigrationsTest do
         end)
 
       assert Regex.scan(~r/(begin \[\])/, up_log) |> length() == 1
-      assert up_log =~ @get_lock_command_async_false
+      assert up_log =~ @get_lock_command
       assert up_log =~ @create_table_sql
       assert up_log =~ @create_table_log
       assert up_log =~ @version_insert
@@ -136,7 +136,7 @@ defmodule Ecto.Integration.MigrationsTest do
         end)
 
       assert Regex.scan(~r/(begin \[\])/, down_log) |> length() == 1
-      assert down_log =~ @get_lock_command_async_false
+      assert down_log =~ @get_lock_command
       assert down_log =~ @drop_table_sql
       assert down_log =~ @drop_table_log
       assert down_log =~ @version_delete

--- a/integration_test/tds/test_helper.exs
+++ b/integration_test/tds/test_helper.exs
@@ -139,7 +139,7 @@ end
 alias Ecto.Integration.AsyncFalsePoolRepo
 
 defmodule Ecto.Integration.AsyncFalsePoolRepo do
-  use Ecto.Integration.Repo, otp_app: :ecto_sql, adapter: Ecto.Adapters.Postgres
+  use Ecto.Integration.Repo, otp_app: :ecto_sql, adapter: Ecto.Adapters.Tds
 end
 
 Application.put_env(

--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -266,6 +266,12 @@ defmodule Ecto.Adapters.MyXQL do
   def lock_for_migrations(meta, opts, fun) do
     %{opts: adapter_opts, repo: repo} = meta
 
+    if not opts[:async_migration] do
+      raise Ecto.MigrationError,
+            "MyXQL does not allow async migrations to be disabled when locking for concurrent migrators. " <>
+              "DDL statements are not allowed to be run within the transaction created to hold the lock."
+    end
+
     if Keyword.fetch(adapter_opts, :pool_size) == {:ok, 1} do
       Ecto.Adapters.SQL.raise_migration_pool_size_error()
     end

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -264,7 +264,7 @@ defmodule Ecto.Adapters.Postgres do
   def lock_for_migrations(meta, opts, fun) do
     %{opts: adapter_opts, repo: repo} = meta
 
-    if Keyword.fetch(adapter_opts, :pool_size) == {:ok, 1} do
+    if opts[:async_migration] and Keyword.fetch(adapter_opts, :pool_size) == {:ok, 1} do
       Ecto.Adapters.SQL.raise_migration_pool_size_error()
     end
 

--- a/lib/ecto/adapters/tds.ex
+++ b/lib/ecto/adapters/tds.ex
@@ -279,7 +279,7 @@ defmodule Ecto.Adapters.Tds do
   def lock_for_migrations(meta, opts, fun) do
     %{opts: adapter_opts, repo: repo} = meta
 
-    if Keyword.fetch(adapter_opts, :pool_size) == {:ok, 1} do
+    if opts[:async_migration] and Keyword.fetch(adapter_opts, :pool_size) == {:ok, 1} do
       Ecto.Adapters.SQL.raise_migration_pool_size_error()
     end
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -206,6 +206,13 @@ defmodule Ecto.Migration do
           # fit. See the Ecto.Adapters.Postgres for more information:
           config :app, App.Repo, migration_lock: :pg_advisory_lock
 
+    * `:async_migration` - By default, Ecto will spawn a new process to run a migration.
+      This allows the migration lock to run in a transaction even when the migration itself
+      cannot. However, some databases are not able to separate the locking transaction from
+      the migration commands. For example, SQLite. In this case, you may disable async
+      migrations by configuring this option to `false`. You may also set it at the individual
+      migration level by adding `@disable_async_migration true` to the migration file.
+
     * `:migration_repo` - The migration repository is where the table managing the
       migrations will be stored (`migration_source` defines the table name). It defaults
       to the given repository itself but you can configure it via:
@@ -502,6 +509,7 @@ defmodule Ecto.Migration do
       import Ecto.Migration
       @disable_ddl_transaction false
       @disable_migration_lock false
+      @disable_async_migration false
       @before_compile Ecto.Migration
     end
   end
@@ -512,7 +520,8 @@ defmodule Ecto.Migration do
       def __migration__ do
         [
           disable_ddl_transaction: @disable_ddl_transaction,
-          disable_migration_lock: @disable_migration_lock
+          disable_migration_lock: @disable_migration_lock,
+          disable_async_migration: @disable_async_migration
         ]
       end
     end

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -209,9 +209,9 @@ defmodule Ecto.Migration do
     * `:async_migration` - By default, Ecto will spawn a new process to run a migration.
       This allows the migration lock to run in a transaction even when the migration itself
       cannot. However, some databases are not able to separate the locking transaction from
-      the migration commands. For example, SQLite. In this case, you may disable async
-      migrations by configuring this option to `false`. You may also set it at the individual
-      migration level by adding `@disable_async_migration true` to the migration file.
+      the migration commands. In this case, you may disable async migrations by configuring
+      this option to `false`. You may also set it at the individual migration level by adding
+      `@disable_async_migration true` to the migration file.
 
     * `:migration_repo` - The migration repository is where the table managing the
       migrations will be stored (`migration_source` defines the table name). It defaults


### PR DESCRIPTION
**Problem**

For some databases, like SQLite, it's not possible to separate the locking transaction from the migration transaction. In SQLite's case, once you get the write lock you are locking any other connection from writing to any part of the database. 

Since Ecto SQL requires migrations to be run in a different process than the lock, some database adapters won't be able to take advantage of its ability to handle concurrent migrators.

**Proposal**

Allow async migrations to be disabled through configuration/migration attribute. I also considered having a callback on the adapter, same as the ddl transaction one, but then it will cause some tricky situations for existing adapters. 

For example, today the SQLite adapter silently ignores the migration lock option instead of asking the user to disable it. If the async behaviour is controlled by a callback instead of repo configuration, the adapter would start taking write locks instead of silently ignoring the lock. 

This could cause unexpected busy errors for the user who might not even realized that locking is enabled by default since it has been ignored in the past. If the async behaviour is opt-in through configuration then the user knows they must consider concurrent writes.