### PR TITLE
Add primary_key to schema_migrations

### DIFF
--- a/lib/ecto/migration/schema_migration.ex
+++ b/lib/ecto/migration/schema_migration.ex
@@ -8,7 +8,7 @@ defmodule Ecto.Migration.SchemaMigration do
 
   @primary_key false
   schema "schema_migrations" do
-    field :version, :integer
+    field :version, :integer, primary_key: true
     timestamps updated_at: false
   end
 


### PR DESCRIPTION
The `primary_key` is misisng from the schema, causing the reflection to return an empty list, when in fact there is a primary key already set.