### PR TITLE
Use timestamptz for :utc_datetime in Postgrex

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -1854,8 +1854,8 @@ if Code.ensure_loaded?(Postgrex) do
     defp ecto_to_db(:map), do: Application.fetch_env!(:ecto_sql, :postgres_map_type)
     defp ecto_to_db({:map, _}), do: Application.fetch_env!(:ecto_sql, :postgres_map_type)
     defp ecto_to_db(:time_usec), do: "time"
-    defp ecto_to_db(:utc_datetime), do: "timestamp"
-    defp ecto_to_db(:utc_datetime_usec), do: "timestamp"
+    defp ecto_to_db(:utc_datetime), do: "timestamptz"
+    defp ecto_to_db(:utc_datetime_usec), do: "timestamptz"
     defp ecto_to_db(:naive_datetime), do: "timestamp"
     defp ecto_to_db(:naive_datetime_usec), do: "timestamp"
     defp ecto_to_db(atom) when is_atom(atom), do: Atom.to_string(atom)

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1811,7 +1811,7 @@ defmodule Ecto.Adapters.PostgresTest do
               [{:add, :published_at, :utc_datetime, [precision: 3]},
                {:add, :submitted_at, :utc_datetime, []}]}
 
-    assert execute_ddl(create) == [~s|CREATE TABLE "posts" ("published_at" timestamp(0), "submitted_at" timestamp(0))|]
+    assert execute_ddl(create) == [~s|CREATE TABLE "posts" ("published_at" timestamptz(0), "submitted_at" timestamptz(0))|]
   end
 
   test "create table with utc_datetime_usec columns" do
@@ -1819,7 +1819,7 @@ defmodule Ecto.Adapters.PostgresTest do
               [{:add, :published_at, :utc_datetime_usec, [precision: 3]},
                {:add, :submitted_at, :utc_datetime_usec, []}]}
 
-    assert execute_ddl(create) == [~s|CREATE TABLE "posts" ("published_at" timestamp(3), "submitted_at" timestamp)|]
+    assert execute_ddl(create) == [~s|CREATE TABLE "posts" ("published_at" timestamptz(3), "submitted_at" timestamptz)|]
   end
 
   test "create table with naive_datetime columns" do


### PR DESCRIPTION
In PostgreSQL, a timestamp with a timezone can be defined with [`timestamptz`](https://www.postgresql.org/docs/current/datatype-datetime.html)

Currently, `Ecto.Adapters.Postgres.Connection` returns a `NaiveDateTime` when the timestamp is configured with:

```elixir
config :myapp, MyApp.Repo, migration_timestamps: [type: :utc_datetime_usec]
```

```elixir
@timestamps_opts type: :utc_datetime_usec
```