### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
             ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-
       - name: Install dependencies
         run: mix deps.get
+      - name: Check unused dependencies
+        run: mix deps.unlock --check-unused
+        if: ${{ matrix.lint }}
       - name: Check formatting
         run: mix format --check-formatted
         if: ${{ matrix.lint }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,6 @@ jobs:
       - name: Check formatting
         run: mix format --check-formatted
         if: ${{ matrix.lint }}
-      - name: Compile
-        run: mix compile
       - name: Run tests
         run: mix test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,18 +4,45 @@ jobs:
   test:
     name: unittest
     runs-on: ubuntu-latest
+    env:
+      MIX_ENV: test
     strategy:
       fail-fast: false
       matrix:
-        elixirbase:
-          - image: "1.13.4-erlang-24.3.4.2-alpine-3.16.0"
+        include:
+          - elixir: 1.15.6
+            otp: 24.3.4.13
+          - elixir: 1.15.6
+            otp: 25.3.2.6
             lint: lint
-          - image: "1.13.4-erlang-22.3.4.20-alpine-3.14.0"
     steps:
-      - uses: earthly/actions-setup@v1
-      - uses: actions/checkout@v3
-      - name: test ecto_sql
-        run: earthly -P --ci --build-arg LINT=${{matrix.elixirbase.lint}} --build-arg ELIXIR_BASE=${{matrix.elixirbase.image}} +test
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Elixir and Erlang
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
+      - name: Restore deps and _build cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-
+      - name: Install dependencies
+        run: mix deps.get
+      - name: Check formatting
+        run: mix format --check-formatted
+        if: ${{ matrix.lint }}
+      - name: Compile
+        run: mix compile
+        if: ${{ matrix.lint }}
+      - name: Run tests
+        run: mix test
+
   test-postgres:
     name: postgres integration test
     runs-on: ubuntu-latest
@@ -34,6 +61,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: test ecto_sql
         run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixirbase}} --build-arg POSTGRES=${{matrix.postgres}} +integration-test-postgres
+
   test-mysql:
     name: mysql integration test
     runs-on: ubuntu-latest
@@ -50,6 +78,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: test ecto_sql
         run: earthly -P --ci --build-arg ELIXIR_BASE=${{matrix.elixirbase}} --build-arg MYSQL=${{matrix.mysql}} +integration-test-mysql
+
   test-mssql:
     name: mssql integration test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
         if: ${{ matrix.lint }}
       - name: Compile
         run: mix compile
-        if: ${{ matrix.lint }}
       - name: Run tests
         run: mix test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
       - name: Check formatting
         run: mix format --check-formatted
         if: ${{ matrix.lint }}
+      - name: Compile
+        run: mix compile
       - name: Run tests
         run: mix test
 

--- a/lib/ecto/adapter/migration.ex
+++ b/lib/ecto/adapter/migration.ex
@@ -67,5 +67,5 @@ defmodule Ecto.Adapter.Migration do
   """
   @callback lock_for_migrations(adapter_meta, options :: Keyword.t(), fun) ::
               result
-            when fun: (() -> result), result: var
+            when fun: (-> result), result: var
 end

--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -225,7 +225,7 @@ if Code.ensure_loaded?(MyXQL) do
 
     defp insert_all_value(nil), do: "DEFAULT"
     defp insert_all_value({%Ecto.Query{} = query, _params_counter}), do: [?(, all(query), ?)]
-    defp insert_all_value(_), do: '?'
+    defp insert_all_value(_), do: ~c"?"
 
     @impl true
     def update(prefix, table, fields, filters, _returning) do
@@ -628,7 +628,7 @@ if Code.ensure_loaded?(MyXQL) do
     end
 
     defp expr({:^, [], [_ix]}, _sources, _query) do
-      '?'
+      ~c"?"
     end
 
     defp expr({{:., _, [{:parent_as, _, [as]}, field]}, _, []}, _sources, query)

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -815,17 +815,26 @@ defmodule Ecto.MigratorTest do
     end
 
     test "version migrations stop before all have been run" do
-      assert run(TestRepo, [{13, ChangeMigration}, {14, UpDownMigration}], :up, to: 13, log: false) ==
+      assert run(TestRepo, [{13, ChangeMigration}, {14, UpDownMigration}], :up,
+               to: 13,
+               log: false
+             ) ==
                [13]
     end
 
     test "version migrations stop at the number of available migrations" do
-      assert run(TestRepo, [{13, ChangeMigration}, {14, UpDownMigration}], :up, to: 14, log: false) ==
+      assert run(TestRepo, [{13, ChangeMigration}, {14, UpDownMigration}], :up,
+               to: 14,
+               log: false
+             ) ==
                [13, 14]
     end
 
     test "version migrations stop even if asked to exceed available" do
-      assert run(TestRepo, [{13, ChangeMigration}, {14, UpDownMigration}], :up, to: 15, log: false) ==
+      assert run(TestRepo, [{13, ChangeMigration}, {14, UpDownMigration}], :up,
+               to: 15,
+               log: false
+             ) ==
                [13, 14]
     end
   end


### PR DESCRIPTION
Changes:

- I updated the CI to use Elixir 1.15 but what happened was it broke some of the migration tests. They were using `@moduletag direction: :forward | :backward` to run them properly and it seemed like it was relying on the ordering of the lines in the test file. I changed it to describe tag instead and it worked. Also I didn't use OTP 26 because a bunch of tests broke due to map key orderings. But I can work on fixing that a bit later.
- I'm not sure you'll agree, but I moved the unit tests to github actions because it seemed a bit cleaner to me and I believe Earthly is not really needed unless it's for integration tests? But I can revert this if you prefer the old way