### PR TITLE
Fix: Use right dynamic repo during migrations

### DIFF
--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -552,7 +552,7 @@ defmodule Ecto.Migrator do
   end
 
   defp lock_for_migrations(lock_or_migration_number, repo, opts, fun) do
-    dynamic_repo = Keyword.get(opts, :dynamic_repo, repo)
+    dynamic_repo = Keyword.get(opts, :dynamic_repo, repo.get_dynamic_repo())
     skip_table_creation = Keyword.get(opts, :skip_table_creation, false)
     previous_dynamic_repo = repo.put_dynamic_repo(dynamic_repo)
 


### PR DESCRIPTION
## Problem

Setting a dynamic repo (as explained [here](https://hexdocs.pm/ecto/replicas-and-dynamic-repositories.html#dynamic-repositories)) has no effect when you run migrations because it overwrites your dynamic repo with the default one.

## Proposal

Use `repo.get_dynamic_repo()` as the default value instead of `repo`