### PR TITLE
Support :prefix on index rename

### DIFF
--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -460,7 +460,7 @@ defmodule Ecto.Migration.Runner do
     do: "drop index if exists #{quote_name(index.prefix, index.name)}#{drop_mode(mode)}"
 
   defp command({:rename, %Index{} = index_current, new_name}),
-    do: "rename index #{quote_name(index_current.name)} to #{new_name}"
+    do: "rename index #{quote_name(index_current.prefix, index_current.name)} to #{new_name}"
 
   defp command({:rename, %Table{} = current_table, %Table{} = new_table}),
     do:

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -2726,6 +2726,16 @@ defmodule Ecto.Adapters.PostgresTest do
            ]
   end
 
+  test "rename index with prefix" do
+    rename =
+      {:rename, index(:people, [:name], name: "persons_name_index", prefix: :foo),
+       "people_name_index"}
+
+    assert execute_ddl(rename) == [
+             ~s|ALTER INDEX "foo"."persons_name_index" RENAME TO "people_name_index"|
+           ]
+  end
+
   test "create check constraint" do
     create = {:create, constraint(:products, "price_must_be_positive", check: "price > 0")}
 


### PR DESCRIPTION
Hi :wave: 

we wanted to rename an index in a schema on Postgres like the following but the prefix was ignored. This patch adds support for `:prefix` for Postgres.

```elixir
rename index(:foo, [:column], prefix: "bar", name: "old"), to: "new"
```

