### PR TITLE
Stop runner if migration fails

### DIFF
--- a/integration_test/sql/migrator.exs
+++ b/integration_test/sql/migrator.exs
@@ -112,6 +112,7 @@ defmodule Ecto.Integration.MigratorTest do
 
   test "bad execute migration" do
     assert catch_error(up(PoolRepo, 31, BadMigration, log: false))
+    assert DynamicSupervisor.which_children(Ecto.MigratorSupervisor) == []
   end
 
   test "broken link migration" do

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -24,7 +24,7 @@ defmodule Ecto.Migration.Runner do
     log(level, "== Running #{version} #{inspect(module)}.#{operation}/0 #{direction}")
     {time, _} = :timer.tc(fn -> perform_operation(repo, module, operation) end)
     log(level, "== Migrated #{version} in #{inspect(div(time, 100_000) / 10)}s")
-
+  after
     stop()
   end
 
@@ -61,8 +61,7 @@ defmodule Ecto.Migration.Runner do
   Stops the runner.
   """
   def stop() do
-    runner = runner()
-    Process.alive?(runner) && Agent.stop(runner)
+    Agent.stop(runner())
   end
 
   @doc """

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -61,7 +61,8 @@ defmodule Ecto.Migration.Runner do
   Stops the runner.
   """
   def stop() do
-    Agent.stop(runner())
+    runner = runner()
+    Process.alive?(runner) && Agent.stop(runner)
   end
 
   @doc """

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -357,6 +357,7 @@ defmodule Ecto.Migrator do
     end
   catch
     kind, reason ->
+      Runner.stop()
       {kind, reason, __STACKTRACE__}
   end
 

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -357,7 +357,6 @@ defmodule Ecto.Migrator do
     end
   catch
     kind, reason ->
-      Runner.stop()
       {kind, reason, __STACKTRACE__}
   end
 


### PR DESCRIPTION
Currently, if a migration fails then the runner process that is associated with it will stay alive. We have the following processes:

1. Caller (calls run/up/down)
2. A task spawned from (1) that calls Runner.run
3. Runner.run creates an agent and links it to the task in (2)

When a migration fails, the task in (2) catches the exit and then passes it as an error to the caller in (1). The caller in (1) raises but by that time the task has died, which means the agent doesn't get the kill signal.

The suggestion here is to call Runner.stop from the task when it exits abnormally. I added a check to make sure the agent is still alive because it's possible for the task to exit abnormally even though the migrations succeeded and killed the agent. This can happen when there is an error updating the schema migrations table.
