### PR TITLE
Add index storage parameters for Postgres

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -1235,6 +1235,7 @@ if Code.ensure_loaded?(Postgrex) do
           ?),
           if_do(include_fields != [], [" INCLUDE ", ?(, include_fields, ?)]),
           maybe_nulls_distinct,
+          if_do(index.options != nil, [" WITH ", ?(, index.options, ?)]),
           if_do(index.where, [" WHERE ", to_string(index.where)])
         ]
       ]

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -2694,6 +2694,13 @@ defmodule Ecto.Adapters.PostgresTest do
              [~s|CREATE INDEX "posts_permalink_index" ON ONLY "posts" ("permalink")|]
   end
 
+  test "create an index with storage parameters" do
+    create = {:create, index(:posts, [:permalink], options: "fillfactor=50")}
+
+    assert execute_ddl(create) ==
+             [~s|CREATE INDEX "posts_permalink_index" ON "posts" ("permalink") WITH (fillfactor=50)|]
+  end
+
   test "drop index" do
     drop = {:drop, index(:posts, [:id], name: "posts$main"), :restrict}
     assert execute_ddl(drop) == [~s|DROP INDEX "posts$main"|]

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -2695,10 +2695,10 @@ defmodule Ecto.Adapters.PostgresTest do
   end
 
   test "create an index with storage parameters" do
-    create = {:create, index(:posts, [:permalink], options: "fillfactor=50")}
+    create = {:create, index(:posts, [:title], options: "fillfactor=50")}
 
     assert execute_ddl(create) ==
-             [~s|CREATE INDEX "posts_permalink_index" ON "posts" ("permalink") WITH (fillfactor=50)|]
+             [~s|CREATE INDEX "posts_title_index" ON "posts" ("title") WITH (fillfactor=50)|]
   end
 
   test "drop index" do


### PR DESCRIPTION
Hi, thanks for Ecto!

This PR adds support for [index storage parameters](https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-STORAGE-PARAMETERS) for Postgres.

```elixir
index(:posts, [:permalink], options: "fillfactor=50")
```

It uses `:options` for the `WITH` clause [like TDS](https://github.com/elixir-ecto/ecto_sql/blob/d5153e3317cde7a57bfb2c0f89646f06316e9316/lib/ecto/adapters/tds/connection.ex#L1146-L1150).