### PR TITLE
allow passing `%Tds.Parameter` structs as params for named parameter usage in `query`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Currently, one cannot pass a list of `Tds.Parameter` structs to `query`.  They must be basic values/structs.  When one has a large handwritten SQL query, it is nice to use named parameters, e.g. `@StartTime`.  This change allows including these structs as parameters.

I didn't see any tests around parameters but happy to add some.