### PR TITLE
validate keys for references/2

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -760,7 +760,7 @@ defmodule Ecto.Migration do
   end
 
   def table(name, opts) when is_binary(name) and is_list(opts) do
-    struct(%Table{name: name}, opts)
+    struct!(%Table{name: name}, opts)
   end
 
   @doc ~S"""
@@ -926,7 +926,7 @@ defmodule Ecto.Migration do
 
   def index(table, columns, opts) when is_binary(table) and is_list(columns) and is_list(opts) do
     validate_index_opts!(opts)
-    index = struct(%Index{table: table, columns: columns}, opts)
+    index = struct!(%Index{table: table, columns: columns}, opts)
     %{index | name: index.name || default_index_name(index)}
   end
 
@@ -1416,21 +1416,8 @@ defmodule Ecto.Migration do
   end
 
   def references(table, opts) when is_binary(table) and is_list(opts) do
-    opts =
-      Keyword.validate!(opts, [
-        :column,
-        :name,
-        :prefix,
-        :type,
-        :on_delete,
-        :on_update,
-        :validate,
-        :with,
-        :match
-      ])
-
     opts = Keyword.merge(foreign_key_repo_opts(), opts)
-    reference = struct(%Reference{table: table}, opts)
+    reference = struct!(%Reference{table: table}, opts)
     check_on_delete!(reference.on_delete)
     check_on_update!(reference.on_update)
 
@@ -1499,7 +1486,7 @@ defmodule Ecto.Migration do
   end
 
   def constraint(table, name, opts) when is_binary(table) and is_list(opts) do
-    struct(%Constraint{table: table, name: name}, opts)
+    struct!(%Constraint{table: table, name: name}, opts)
   end
 
   @doc "Executes queue migration commands."

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1416,6 +1416,19 @@ defmodule Ecto.Migration do
   end
 
   def references(table, opts) when is_binary(table) and is_list(opts) do
+    opts =
+      Keyword.validate!(opts, [
+        :column,
+        :name,
+        :prefix,
+        :type,
+        :on_delete,
+        :on_update,
+        :validate,
+        :with,
+        :match
+      ])
+
     opts = Keyword.merge(foreign_key_repo_opts(), opts)
     reference = struct(%Reference{table: table}, opts)
     check_on_delete!(reference.on_delete)

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -276,7 +276,7 @@ defmodule Ecto.MigrationTest do
 
       assert result == table(:posts)
 
-      create table = table(:posts, primary_key: false, timestamps: false) do
+      create table = table(:posts, primary_key: false) do
         add :title, :string
       end
 

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -151,12 +151,6 @@ defmodule Ecto.MigrationTest do
              %Reference{table: "posts", column: :id, type: :identity}
   end
 
-  test "raises when unknown options are passed" do
-    assert_raise ArgumentError, ~r/unknown keys \[:foo\]/, fn ->
-      references(:posts, foo: :bar)
-    end
-  end
-
   test ":migration_cast_version_column option" do
     {_repo, query, _options} =
       SchemaMigration.versions(TestRepo, [migration_cast_version_column: true], "")

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -151,6 +151,12 @@ defmodule Ecto.MigrationTest do
              %Reference{table: "posts", column: :id, type: :identity}
   end
 
+  test "raises when unknown options are passed" do
+    assert_raise ArgumentError, ~r/unknown keys \[:foo\]/, fn ->
+      references(:posts, foo: :bar)
+    end
+  end
+
   test ":migration_cast_version_column option" do
     {_repo, query, _options} =
       SchemaMigration.versions(TestRepo, [migration_cast_version_column: true], "")


### PR DESCRIPTION
Hi there, I recently had a bug where I accidentally used

```elixir
create table(:foo, primary_key: false) do
   add(:account_id, references(:account, type: :binary_id, primary_key: true))
end
```

instead of

```elixir
create table(:foo, primary_key: false) do
   add(:account_id, references(:account, type: :binary_id), primary_key: true)
end
```

This PR enforces that only supported keys are used.