### PR TITLE
Fix `nil` prefix with `references`

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.5
+VERSION 0.6
 
 all:
     ARG ELIXIR_BASE=1.15.6-erlang-25.3.2.6-alpine-3.17.4

--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -1314,7 +1314,7 @@ if Code.ensure_loaded?(MyXQL) do
         quote_names(current_columns),
         ?),
         " REFERENCES ",
-        quote_table(ref.prefix || table.prefix, ref.table),
+        quote_table(Keyword.get(ref.options, :prefix, table.prefix), ref.table),
         ?(,
         quote_names(reference_columns),
         ?),

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -1706,7 +1706,7 @@ if Code.ensure_loaded?(Postgrex) do
         "FOREIGN KEY (",
         quote_names(current_columns),
         ") REFERENCES ",
-        quote_name(ref.prefix || table.prefix, ref.table),
+        quote_name(Keyword.get(ref.options, :prefix, table.prefix), ref.table),
         ?(,
         quote_names(reference_columns),
         ?),

--- a/lib/ecto/adapters/tds/connection.ex
+++ b/lib/ecto/adapters/tds/connection.ex
@@ -1571,7 +1571,7 @@ if Code.ensure_loaded?(Tds) do
         reference_name(ref, table, name),
         " FOREIGN KEY (#{quote_names(current_columns)})",
         " REFERENCES ",
-        quote_table(ref.prefix || table.prefix, ref.table),
+        quote_table(Keyword.get(ref.options, :prefix, table.prefix), ref.table),
         "(#{quote_names(reference_columns)})",
         reference_on_delete(ref.on_delete),
         reference_on_update(ref.on_update)

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1418,11 +1418,7 @@ defmodule Ecto.Migration do
   end
 
   def references(table, opts) when is_binary(table) and is_list(opts) do
-    reference_options =
-      case Keyword.fetch(opts, :prefix) do
-        {:ok, prefix} -> [prefix: prefix]
-        :error -> []
-      end
+    reference_options = Keyword.take(opts, [:prefix])
 
     opts =
       foreign_key_repo_opts()

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1418,7 +1418,11 @@ defmodule Ecto.Migration do
   end
 
   def references(table, opts) when is_binary(table) and is_list(opts) do
-    {reference_options, opts} = Keyword.split(opts, [:prefix])
+    reference_options =
+      case Keyword.fetch(opts, :prefix) do
+        {:ok, prefix} -> [prefix: prefix]
+        :error -> []
+      end
 
     opts =
       foreign_key_repo_opts()

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -446,6 +446,11 @@ defmodule Ecto.Migration do
               match: nil,
               options: []
 
+    @typedoc """
+    The reference struct.
+
+    The `:prefix` field is deprecated and should instead be stored in the `:options` field.
+    """
     @type t :: %__MODULE__{
             table: String.t(),
             prefix: atom | nil,
@@ -456,7 +461,7 @@ defmodule Ecto.Migration do
             validate: boolean,
             with: list,
             match: atom | nil,
-            options: Keyword.t()
+            options: [{:prefix, atom | nil}]
           }
   end
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -443,7 +443,8 @@ defmodule Ecto.Migration do
               on_update: :nothing,
               validate: true,
               with: [],
-              match: nil
+              match: nil,
+              options: []
 
     @type t :: %__MODULE__{
             table: String.t(),
@@ -454,7 +455,8 @@ defmodule Ecto.Migration do
             on_update: atom,
             validate: boolean,
             with: list,
-            match: atom | nil
+            match: atom | nil,
+            options: Keyword.t()
           }
   end
 
@@ -1416,7 +1418,13 @@ defmodule Ecto.Migration do
   end
 
   def references(table, opts) when is_binary(table) and is_list(opts) do
-    opts = Keyword.merge(foreign_key_repo_opts(), opts)
+    {reference_options, opts} = Keyword.split(opts, [:prefix])
+
+    opts =
+      foreign_key_repo_opts()
+      |> Keyword.merge(opts)
+      |> Keyword.put(:options, reference_options)
+
     reference = struct!(%Reference{table: table}, opts)
     check_on_delete!(reference.on_delete)
     check_on_update!(reference.on_update)

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -1661,8 +1661,8 @@ defmodule Ecto.Adapters.MyXQLTest do
          {:add, :category_3, %Reference{table: :categories, on_delete: :delete_all},
           [null: false]},
          {:add, :category_4, %Reference{table: :categories, on_delete: :nilify_all}, []},
-         {:add, :category_5, %Reference{table: :categories, prefix: :foo, on_delete: :nilify_all},
-          []},
+         {:add, :category_5,
+          %Reference{table: :categories, options: [prefix: :foo], on_delete: :nilify_all}, []},
          {:add, :category_6,
           %Reference{table: :categories, with: [here: :there], on_delete: :nilify_all}, []}
        ]}

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -2102,8 +2102,8 @@ defmodule Ecto.Adapters.PostgresTest do
           [null: false]},
          {:add, :category_9, %Reference{table: :categories, on_delete: :restrict}, []},
          {:add, :category_10, %Reference{table: :categories, on_update: :restrict}, []},
-         {:add, :category_11, %Reference{table: :categories, prefix: "foo", on_update: :restrict},
-          []},
+         {:add, :category_11,
+          %Reference{table: :categories, options: [prefix: "foo"], on_update: :restrict}, []},
          {:add, :category_12, %Reference{table: :categories, with: [here: :there]}, []},
          {:add, :category_13,
           %Reference{

--- a/test/ecto/adapters/tds_test.exs
+++ b/test/ecto/adapters/tds_test.exs
@@ -1457,8 +1457,8 @@ defmodule Ecto.Adapters.TdsTest do
          {:add, :category_3, %Reference{table: :categories, on_delete: :delete_all},
           [null: false]},
          {:add, :category_4, %Reference{table: :categories, on_delete: :nilify_all}, []},
-         {:add, :category_5, %Reference{table: :categories, prefix: :foo, on_delete: :nilify_all},
-          []},
+         {:add, :category_5,
+          %Reference{table: :categories, options: [prefix: :foo], on_delete: :nilify_all}, []},
          {:add, :category_6,
           %Reference{table: :categories, with: [here: :there], on_delete: :nilify_all}, []}
        ]}

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -134,7 +134,7 @@ defmodule Ecto.MigrationTest do
                table: "posts",
                column: :other,
                type: :uuid,
-               prefix: nil,
+               prefix: :blog,
                options: [prefix: :blog]
              }
   end

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -130,7 +130,13 @@ defmodule Ecto.MigrationTest do
              %Reference{table: "posts", column: :other, type: :uuid, prefix: nil}
 
     assert references(:posts, type: :uuid, column: :other, prefix: :blog) ==
-             %Reference{table: "posts", column: :other, type: :uuid, prefix: :blog}
+             %Reference{
+               table: "posts",
+               column: :other,
+               type: :uuid,
+               prefix: nil,
+               options: [prefix: :blog]
+             }
   end
 
   @tag repo_config: [migration_foreign_key: [type: :uuid, column: :other, prefix: :blog]]


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto_sql/issues/590

There are 2 things I wasn't sure about:

1. Is there a way to mark a struct field as deprecated? Or should I just leave a comment?
2. I am still populating `:prefix` because I assumed removals only happen during new major versions