### PR TITLE
Change migration prefix type to string

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -395,7 +395,7 @@ defmodule Ecto.Migration do
 
     @type t :: %__MODULE__{
             table: String.t(),
-            prefix: atom,
+            prefix: String.t() | nil,
             name: atom,
             columns: [atom | String.t()],
             unique: boolean,
@@ -420,7 +420,7 @@ defmodule Ecto.Migration do
 
     @type t :: %__MODULE__{
             name: String.t(),
-            prefix: atom | nil,
+            prefix: String.t() | nil,
             comment: String.t() | nil,
             primary_key: boolean | keyword(),
             engine: atom,
@@ -453,7 +453,7 @@ defmodule Ecto.Migration do
     """
     @type t :: %__MODULE__{
             table: String.t(),
-            prefix: atom | nil,
+            prefix: String.t() | nil,
             column: atom,
             type: atom,
             on_delete: atom,
@@ -461,7 +461,7 @@ defmodule Ecto.Migration do
             validate: boolean,
             with: list,
             match: atom | nil,
-            options: [{:prefix, atom | nil}]
+            options: [{:prefix, String.t() | nil}]
           }
   end
 
@@ -482,7 +482,7 @@ defmodule Ecto.Migration do
     @type t :: %__MODULE__{
             name: atom,
             table: String.t(),
-            prefix: atom | nil,
+            prefix: String.t() | nil,
             check: String.t() | nil,
             exclude: String.t() | nil,
             comment: String.t() | nil,

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -1609,7 +1609,7 @@ defmodule Ecto.Adapters.MyXQLTest do
 
   test "create table with prefix" do
     create =
-      {:create, table(:posts, prefix: :foo),
+      {:create, table(:posts, prefix: "foo"),
        [{:add, :category_0, %Reference{table: :categories}, []}]}
 
     assert execute_ddl(create) == [
@@ -1623,7 +1623,7 @@ defmodule Ecto.Adapters.MyXQLTest do
 
   test "create table with comment on columns and table" do
     create =
-      {:create, table(:posts, comment: "comment", prefix: :foo),
+      {:create, table(:posts, comment: "comment", prefix: "foo"),
        [
          {:add, :category_0, %Reference{table: :categories}, [comment: "column comment"]},
          {:add, :created_at, :datetime, []},
@@ -1662,7 +1662,7 @@ defmodule Ecto.Adapters.MyXQLTest do
           [null: false]},
          {:add, :category_4, %Reference{table: :categories, on_delete: :nilify_all}, []},
          {:add, :category_5,
-          %Reference{table: :categories, options: [prefix: :foo], on_delete: :nilify_all}, []},
+          %Reference{table: :categories, options: [prefix: "foo"], on_delete: :nilify_all}, []},
          {:add, :category_6,
           %Reference{table: :categories, with: [here: :there], on_delete: :nilify_all}, []}
        ]}
@@ -1901,14 +1901,14 @@ defmodule Ecto.Adapters.MyXQLTest do
   end
 
   test "drop table with prefixes" do
-    drop = {:drop, table(:posts, prefix: :foo), :restrict}
+    drop = {:drop, table(:posts, prefix: "foo"), :restrict}
     assert execute_ddl(drop) == [~s|DROP TABLE `foo`.`posts`|]
   end
 
   test "drop constraint" do
     assert_raise ArgumentError, ~r/MySQL adapter does not support constraints/, fn ->
       execute_ddl(
-        {:drop, constraint(:products, "price_must_be_positive", prefix: :foo), :restrict}
+        {:drop, constraint(:products, "price_must_be_positive", prefix: "foo"), :restrict}
       )
     end
   end
@@ -1916,7 +1916,7 @@ defmodule Ecto.Adapters.MyXQLTest do
   test "drop_if_exists constraint" do
     assert_raise ArgumentError, ~r/MySQL adapter does not support constraints/, fn ->
       execute_ddl(
-        {:drop_if_exists, constraint(:products, "price_must_be_positive", prefix: :foo),
+        {:drop_if_exists, constraint(:products, "price_must_be_positive", prefix: "foo"),
          :restrict}
       )
     end
@@ -2008,7 +2008,7 @@ defmodule Ecto.Adapters.MyXQLTest do
 
   test "alter table with prefix" do
     alter =
-      {:alter, table(:posts, prefix: :foo),
+      {:alter, table(:posts, prefix: "foo"),
        [
          {:add, :author_id, %Reference{table: :author}, []},
          {:modify, :permalink_id, %Reference{table: :permalinks}, null: false}
@@ -2071,7 +2071,7 @@ defmodule Ecto.Adapters.MyXQLTest do
   end
 
   test "create index with prefix" do
-    create = {:create, index(:posts, [:category_id, :permalink], prefix: :foo)}
+    create = {:create, index(:posts, [:category_id, :permalink], prefix: "foo")}
 
     assert execute_ddl(create) ==
              [
@@ -2128,7 +2128,7 @@ defmodule Ecto.Adapters.MyXQLTest do
   end
 
   test "drop index with prefix" do
-    drop = {:drop, index(:posts, [:id], name: "posts$main", prefix: :foo), :restrict}
+    drop = {:drop, index(:posts, [:id], name: "posts$main", prefix: "foo"), :restrict}
     assert execute_ddl(drop) == [~s|DROP INDEX `posts$main` ON `foo`.`posts`|]
   end
 
@@ -2146,7 +2146,7 @@ defmodule Ecto.Adapters.MyXQLTest do
   end
 
   test "rename table with prefix" do
-    rename = {:rename, table(:posts, prefix: :foo), table(:new_posts, prefix: :foo)}
+    rename = {:rename, table(:posts, prefix: "foo"), table(:new_posts, prefix: "foo")}
     assert execute_ddl(rename) == [~s|RENAME TABLE `foo`.`posts` TO `foo`.`new_posts`|]
   end
 
@@ -2159,7 +2159,7 @@ defmodule Ecto.Adapters.MyXQLTest do
   end
 
   test "rename column in prefixed table" do
-    rename = {:rename, table(:posts, prefix: :foo), :given_name, :first_name}
+    rename = {:rename, table(:posts, prefix: "foo"), :given_name, :first_name}
 
     assert execute_ddl(rename) == [
              ~s|ALTER TABLE `foo`.`posts` RENAME COLUMN `given_name` TO `first_name`|

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -2012,7 +2012,7 @@ defmodule Ecto.Adapters.PostgresTest do
 
   test "create table with prefix" do
     create =
-      {:create, table(:posts, prefix: :foo),
+      {:create, table(:posts, prefix: "foo"),
        [{:add, :category_0, %Reference{table: :categories}, []}]}
 
     assert execute_ddl(create) == [
@@ -2406,7 +2406,7 @@ defmodule Ecto.Adapters.PostgresTest do
   end
 
   test "drop table with prefix" do
-    drop = {:drop, table(:posts, prefix: :foo), :restrict}
+    drop = {:drop, table(:posts, prefix: "foo"), :restrict}
     assert execute_ddl(drop) == [~s|DROP TABLE "foo"."posts"|]
   end
 
@@ -2414,7 +2414,7 @@ defmodule Ecto.Adapters.PostgresTest do
     drop = {:drop, table(:posts), :cascade}
     assert execute_ddl(drop) == [~s|DROP TABLE "posts" CASCADE|]
 
-    drop = {:drop, table(:posts, prefix: :foo), :cascade}
+    drop = {:drop, table(:posts, prefix: "foo"), :cascade}
     assert execute_ddl(drop) == [~s|DROP TABLE "foo"."posts" CASCADE|]
   end
 
@@ -2518,7 +2518,7 @@ defmodule Ecto.Adapters.PostgresTest do
 
   test "alter table with prefix" do
     alter =
-      {:alter, table(:posts, prefix: :foo),
+      {:alter, table(:posts, prefix: "foo"),
        [
          {:add, :author_id, %Reference{table: :author}, []},
          {:modify, :permalink_id, %Reference{table: :permalinks}, null: false}
@@ -2586,14 +2586,14 @@ defmodule Ecto.Adapters.PostgresTest do
   end
 
   test "create index with prefix" do
-    create = {:create, index(:posts, [:category_id, :permalink], prefix: :foo)}
+    create = {:create, index(:posts, [:category_id, :permalink], prefix: "foo")}
 
     assert execute_ddl(create) ==
              [
                ~s|CREATE INDEX "posts_category_id_permalink_index" ON "foo"."posts" ("category_id", "permalink")|
              ]
 
-    create = {:create, index(:posts, ["lower(permalink)"], name: "posts$main", prefix: :foo)}
+    create = {:create, index(:posts, ["lower(permalink)"], name: "posts$main", prefix: "foo")}
 
     assert execute_ddl(create) ==
              [~s|CREATE INDEX "posts$main" ON "foo"."posts" (lower(permalink))|]
@@ -2601,7 +2601,7 @@ defmodule Ecto.Adapters.PostgresTest do
 
   test "create index with comment" do
     create =
-      {:create, index(:posts, [:category_id, :permalink], prefix: :foo, comment: "comment")}
+      {:create, index(:posts, [:category_id, :permalink], prefix: "foo", comment: "comment")}
 
     assert execute_ddl(create) == [
              remove_newlines("""
@@ -2727,7 +2727,7 @@ defmodule Ecto.Adapters.PostgresTest do
   end
 
   test "drop index with prefix" do
-    drop = {:drop, index(:posts, [:id], name: "posts$main", prefix: :foo), :restrict}
+    drop = {:drop, index(:posts, [:id], name: "posts$main", prefix: "foo"), :restrict}
     assert execute_ddl(drop) == [~s|DROP INDEX "foo"."posts$main"|]
   end
 
@@ -2741,7 +2741,7 @@ defmodule Ecto.Adapters.PostgresTest do
     drop = {:drop, index(:posts, [:id], name: "posts$main"), :cascade}
     assert execute_ddl(drop) == [~s|DROP INDEX "posts$main" CASCADE|]
 
-    drop = {:drop, index(:posts, [:id], name: "posts$main", prefix: :foo), :cascade}
+    drop = {:drop, index(:posts, [:id], name: "posts$main", prefix: "foo"), :cascade}
     assert execute_ddl(drop) == [~s|DROP INDEX "foo"."posts$main" CASCADE|]
   end
 
@@ -2755,7 +2755,7 @@ defmodule Ecto.Adapters.PostgresTest do
 
   test "rename index with prefix" do
     rename =
-      {:rename, index(:people, [:name], name: "persons_name_index", prefix: :foo),
+      {:rename, index(:people, [:name], name: "persons_name_index", prefix: "foo"),
        "people_name_index"}
 
     assert execute_ddl(rename) == [
@@ -2868,7 +2868,7 @@ defmodule Ecto.Adapters.PostgresTest do
   end
 
   test "rename table with prefix" do
-    rename = {:rename, table(:posts, prefix: :foo), table(:new_posts, prefix: :foo)}
+    rename = {:rename, table(:posts, prefix: "foo"), table(:new_posts, prefix: "foo")}
     assert execute_ddl(rename) == [~s|ALTER TABLE "foo"."posts" RENAME TO "new_posts"|]
   end
 
@@ -2878,7 +2878,7 @@ defmodule Ecto.Adapters.PostgresTest do
   end
 
   test "rename column in prefixed table" do
-    rename = {:rename, table(:posts, prefix: :foo), :given_name, :first_name}
+    rename = {:rename, table(:posts, prefix: "foo"), :given_name, :first_name}
 
     assert execute_ddl(rename) == [
              ~s|ALTER TABLE "foo"."posts" RENAME "given_name" TO "first_name"|

--- a/test/ecto/adapters/tds_test.exs
+++ b/test/ecto/adapters/tds_test.exs
@@ -1433,7 +1433,7 @@ defmodule Ecto.Adapters.TdsTest do
 
   test "create table with prefix" do
     create =
-      {:create, table(:posts, prefix: :foo),
+      {:create, table(:posts, prefix: "foo"),
        [{:add, :category_0, %Reference{table: :categories}, []}]}
 
     assert execute_ddl(create) == [
@@ -1458,7 +1458,7 @@ defmodule Ecto.Adapters.TdsTest do
           [null: false]},
          {:add, :category_4, %Reference{table: :categories, on_delete: :nilify_all}, []},
          {:add, :category_5,
-          %Reference{table: :categories, options: [prefix: :foo], on_delete: :nilify_all}, []},
+          %Reference{table: :categories, options: [prefix: "foo"], on_delete: :nilify_all}, []},
          {:add, :category_6,
           %Reference{table: :categories, with: [here: :there], on_delete: :nilify_all}, []}
        ]}
@@ -1593,7 +1593,7 @@ defmodule Ecto.Adapters.TdsTest do
   end
 
   test "drop table with prefixes" do
-    drop = {:drop, table(:posts, prefix: :foo), :restrict}
+    drop = {:drop, table(:posts, prefix: "foo"), :restrict}
     assert execute_ddl(drop) == ["DROP TABLE [foo].[posts]; "]
   end
 
@@ -1766,7 +1766,7 @@ defmodule Ecto.Adapters.TdsTest do
   end
 
   test "rename table with prefix" do
-    rename = {:rename, table(:posts, prefix: :foo), table(:new_posts, prefix: :foo)}
+    rename = {:rename, table(:posts, prefix: "foo"), table(:new_posts, prefix: "foo")}
     assert execute_ddl(rename) == [~s|EXEC sp_rename 'foo.posts', 'foo.new_posts'|]
   end
 
@@ -1778,7 +1778,7 @@ defmodule Ecto.Adapters.TdsTest do
   end
 
   test "rename column in table with prefixes" do
-    rename = {:rename, table(:posts, prefix: :foo), :given_name, :first_name}
+    rename = {:rename, table(:posts, prefix: "foo"), :given_name, :first_name}
 
     assert execute_ddl(rename) ==
              ["EXEC sp_rename 'foo.posts.given_name', 'first_name', 'COLUMN'"]
@@ -1803,7 +1803,7 @@ defmodule Ecto.Adapters.TdsTest do
   end
 
   test "create index with prefix" do
-    create = {:create, index(:posts, [:category_id, :permalink], prefix: :foo)}
+    create = {:create, index(:posts, [:category_id, :permalink], prefix: "foo")}
 
     assert execute_ddl(create) ==
              [
@@ -1812,7 +1812,7 @@ defmodule Ecto.Adapters.TdsTest do
   end
 
   test "create index with prefix if not exists" do
-    create = {:create_if_not_exists, index(:posts, [:category_id, :permalink], prefix: :foo)}
+    create = {:create_if_not_exists, index(:posts, [:category_id, :permalink], prefix: "foo")}
 
     assert execute_ddl(create) ==
              [
@@ -1839,7 +1839,7 @@ defmodule Ecto.Adapters.TdsTest do
     assert execute_ddl(create) ==
              [~s|CREATE UNIQUE INDEX [posts_permalink_index] ON [posts] ([permalink]);|]
 
-    create = {:create, index(:posts, [:permalink], unique: true, prefix: :foo)}
+    create = {:create, index(:posts, [:permalink], unique: true, prefix: "foo")}
 
     assert execute_ddl(create) ==
              [~s|CREATE UNIQUE INDEX [posts_permalink_index] ON [foo].[posts] ([permalink]);|]
@@ -1866,7 +1866,7 @@ defmodule Ecto.Adapters.TdsTest do
 
   test "drop index with prefix" do
     drop =
-      {:drop, index(:posts, [:id], name: "posts_category_id_permalink_index", prefix: :foo),
+      {:drop, index(:posts, [:id], name: "posts_category_id_permalink_index", prefix: "foo"),
        :restrict}
 
     assert execute_ddl(drop) ==
@@ -1876,7 +1876,7 @@ defmodule Ecto.Adapters.TdsTest do
   test "drop index with prefix if exists" do
     drop =
       {:drop_if_exists,
-       index(:posts, [:id], name: "posts_category_id_permalink_index", prefix: :foo), :restrict}
+       index(:posts, [:id], name: "posts_category_id_permalink_index", prefix: "foo"), :restrict}
 
     assert execute_ddl(drop) ==
              [
@@ -1892,7 +1892,7 @@ defmodule Ecto.Adapters.TdsTest do
 
     drop_cascade =
       {:drop_if_exists,
-       index(:posts, [:id], name: "posts_category_id_permalink_index", prefix: :foo), :cascade}
+       index(:posts, [:id], name: "posts_category_id_permalink_index", prefix: "foo"), :cascade}
 
     assert_raise ArgumentError, ~r"MSSQL does not support `CASCADE` in DROP INDEX commands", fn ->
       execute_ddl(drop_cascade)

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -129,20 +129,20 @@ defmodule Ecto.MigrationTest do
     assert references(:posts, type: :uuid, column: :other) ==
              %Reference{table: "posts", column: :other, type: :uuid, prefix: nil}
 
-    assert references(:posts, type: :uuid, column: :other, prefix: :blog) ==
+    assert references(:posts, type: :uuid, column: :other, prefix: "blog") ==
              %Reference{
                table: "posts",
                column: :other,
                type: :uuid,
-               prefix: :blog,
-               options: [prefix: :blog]
+               prefix: "blog",
+               options: [prefix: "blog"]
              }
   end
 
-  @tag repo_config: [migration_foreign_key: [type: :uuid, column: :other, prefix: :blog]]
+  @tag repo_config: [migration_foreign_key: [type: :uuid, column: :other, prefix: "blog"]]
   test "create a reference with using the foreign key repo config" do
     assert references(:posts) ==
-             %Reference{table: "posts", column: :other, type: :uuid, prefix: :blog}
+             %Reference{table: "posts", column: :other, type: :uuid, prefix: "blog"}
   end
 
   @tag repo_config: [migration_primary_key: [type: :binary_id]]
@@ -711,7 +711,7 @@ defmodule Ecto.MigrationTest do
       assert table.prefix == :foo
     end
 
-    @tag prefix: :bar
+    @tag prefix: "bar"
     test "raise error when prefixes don't match" do
       assert_raise Ecto.MigrationError,
                    "the :prefix option `foo` does not match the migrator prefix `bar`",

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -35,11 +35,11 @@ defmodule Ecto.MigratorTest do
     use Ecto.Migration
 
     def change do
-      create table(:comments, prefix: :foo) do
+      create table(:comments, prefix: "foo") do
         add :name, :string
       end
 
-      create index(:posts, [:title], prefix: :foo)
+      create index(:posts, [:title], prefix: "foo")
     end
   end
 
@@ -259,24 +259,24 @@ defmodule Ecto.MigratorTest do
 
   test "migrator prefix" do
     capture_log(fn ->
-      :ok = up(TestRepo, 10, ChangeMigration, prefix: :custom)
+      :ok = up(TestRepo, 10, ChangeMigration, prefix: "custom")
     end)
 
-    assert [{10, :custom} | _] = MigrationsAgent.get()
+    assert [{10, "custom"} | _] = MigrationsAgent.get()
 
     Process.put(:repo_default_options, prefix: nil)
 
     capture_log(fn ->
-      :ok = up(TestRepo, 11, ChangeMigration, prefix: :custom)
+      :ok = up(TestRepo, 11, ChangeMigration, prefix: "custom")
     end)
 
-    assert [{11, :custom} | _] = MigrationsAgent.get()
+    assert [{11, "custom"} | _] = MigrationsAgent.get()
 
     capture_log(fn ->
-      :already_up = up(TestRepo, 11, ChangeMigration, prefix: :custom, log: true)
+      :already_up = up(TestRepo, 11, ChangeMigration, prefix: "custom", log: true)
     end)
 
-    assert [{11, :custom} | _] = MigrationsAgent.get()
+    assert [{11, "custom"} | _] = MigrationsAgent.get()
   end
 
   test "logs migrations" do


### PR DESCRIPTION
As discussed in https://github.com/elixir-ecto/ecto/pull/4359, we will normalize the migration prefixes to be strings so that they match the prefixes in queries.