### PR TITLE
Fix fallback generic with no query parameters

### DIFF
--- a/integration_test/pg/explain_test.exs
+++ b/integration_test/pg/explain_test.exs
@@ -37,6 +37,9 @@ defmodule Ecto.Integration.ExplainTest do
 
     assert explain =~ "p0.visits = $1"
     assert explain =~ "(p0.title)::text = $2"
+
+    # Works when no parameters are given
+    TestRepo.explain(:all, Post, plan: :fallback_generic, verbose: true, timeout: 20000)
   end
 
   test "explain with fallback generic plan cannot use analyze" do

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -397,7 +397,7 @@ if Code.ensure_loaded?(Postgrex) do
     end
 
     def build_fallback_generic_queries(query, num_params, opts) do
-      prepare_opts =
+      prepare_args =
         if num_params > 0,
           do: ["( ", Enum.map_intersperse(1..num_params, ", ", fn _ -> "unknown" end), " )"],
           else: []
@@ -406,7 +406,7 @@ if Code.ensure_loaded?(Postgrex) do
         [
           "PREPARE ",
           @explain_prepared_statement_name,
-          prepare_opts,
+          prepare_args,
           " AS ",
           query
         ]
@@ -414,7 +414,7 @@ if Code.ensure_loaded?(Postgrex) do
 
       set = "SET LOCAL plan_cache_mode = force_generic_plan"
 
-      execute_opts =
+      execute_args =
         if num_params > 0,
           do: ["( ", Enum.map_intersperse(1..num_params, ", ", fn _ -> "NULL" end), " )"],
           else: []
@@ -425,7 +425,7 @@ if Code.ensure_loaded?(Postgrex) do
           build_explain_opts(opts),
           "EXECUTE ",
           @explain_prepared_statement_name,
-          execute_opts
+          execute_args
         ]
         |> IO.iodata_to_binary()
 

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -397,18 +397,27 @@ if Code.ensure_loaded?(Postgrex) do
     end
 
     def build_fallback_generic_queries(query, num_params, opts) do
+      prepare_opts =
+        if num_params > 0,
+          do: ["( ", Enum.map_intersperse(1..num_params, ", ", fn _ -> "unknown" end), " )"],
+          else: []
+
       prepare =
         [
           "PREPARE ",
           @explain_prepared_statement_name,
-          "(",
-          Enum.map_intersperse(1..num_params, ", ", fn _ -> "unknown" end),
-          ") AS ",
+          prepare_opts,
+          " AS ",
           query
         ]
         |> IO.iodata_to_binary()
 
       set = "SET LOCAL plan_cache_mode = force_generic_plan"
+
+      execute_opts =
+        if num_params > 0,
+          do: ["( ", Enum.map_intersperse(1..num_params, ", ", fn _ -> "NULL" end), " )"],
+          else: []
 
       execute =
         [
@@ -416,9 +425,7 @@ if Code.ensure_loaded?(Postgrex) do
           build_explain_opts(opts),
           "EXECUTE ",
           @explain_prepared_statement_name,
-          "(",
-          Enum.map_intersperse(1..num_params, ", ", fn _ -> "NULL" end),
-          ")"
+          execute_opts
         ]
         |> IO.iodata_to_binary()
 


### PR DESCRIPTION
I had a bug in the old code when no query parameters are present. `1..num_params` returns a list of 2 values instead of empty list. 

Also postgres doesn't like empty parentheses for these functions.