### PR TITLE
fix: myxql type cast of :integer should be signed integer

### DIFF
--- a/integration_test/sql/sql.exs
+++ b/integration_test/sql/sql.exs
@@ -21,6 +21,11 @@ defmodule Ecto.Integration.SQLTest do
     assert [123] = TestRepo.all(from p in "posts", select: type(fragment("visits"), :integer))
   end
 
+  test "type casting negative integers" do
+    TestRepo.insert!(%Post{visits: -42})
+    assert [-42] = TestRepo.all(from(p in Post, select: type(p.visits, :integer)))
+  end
+
   @tag :array_type
   test "fragment array types" do
     text1 = "foo"

--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -1445,7 +1445,7 @@ if Code.ensure_loaded?(MyXQL) do
     end
 
     defp ecto_cast_to_db(:id, _query), do: "unsigned"
-    defp ecto_cast_to_db(:integer, _query), do: "unsigned"
+    defp ecto_cast_to_db(:integer, _query), do: "signed"
     defp ecto_cast_to_db(:string, _query), do: "char"
     defp ecto_cast_to_db(:utc_datetime_usec, _query), do: "datetime(6)"
     defp ecto_cast_to_db(:naive_datetime_usec, _query), do: "datetime(6)"

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -161,7 +161,7 @@ defmodule Ecto.Adapters.MyXQLTest do
                ~s{UNION ALL } <>
                ~s{(SELECT sc0.`id`, st1.`depth` + 1 FROM `categories` AS sc0 } <>
                ~s{INNER JOIN `tree` AS st1 ON st1.`id` = sc0.`parent_id`)) } <>
-               ~s{SELECT s0.`x`, t1.`id`, CAST(t1.`depth` AS unsigned) } <>
+               ~s{SELECT s0.`x`, t1.`id`, CAST(t1.`depth` AS signed) } <>
                ~s{FROM `schema` AS s0 } <>
                ~s{INNER JOIN `tree` AS t1 ON t1.`id` = s0.`category_id`}
   end
@@ -1475,7 +1475,7 @@ defmodule Ecto.Adapters.MyXQLTest do
       |> plan()
       |> all()
 
-    cast_types = %{bid: "binary(16)", num: "unsigned"}
+    cast_types = %{bid: "binary(16)", num: "signed"}
     from_values_text = values_text(values, cast_types)
     join_values_text = values_text(values, cast_types)
     select_fields = Enum.map_join(types, ", ", fn {field, _} -> "v1.`#{field}`" end)
@@ -1498,7 +1498,7 @@ defmodule Ecto.Adapters.MyXQLTest do
       |> plan(:delete_all)
       |> delete_all()
 
-    cast_types = %{bid: "binary(16)", num: "unsigned"}
+    cast_types = %{bid: "binary(16)", num: "signed"}
     values_text = values_text(values, cast_types)
     fields = Enum.map_join(types, ",", fn {field, _} -> "`#{field}`" end)
 
@@ -1523,7 +1523,7 @@ defmodule Ecto.Adapters.MyXQLTest do
       |> plan(:update_all)
       |> update_all()
 
-    cast_types = %{bid: "binary(16)", num: "unsigned"}
+    cast_types = %{bid: "binary(16)", num: "signed"}
     values_text = values_text(values, cast_types)
     fields = Enum.map_join(types, ",", fn {field, _} -> "`#{field}`" end)
 


### PR DESCRIPTION
Currently, the myxql adapter of ecto_sql type casts `:integer` into `unsigned`. This seems wrong since integers are signed in ecto. It should cast to `signed`. This PR fixes it.