### PR TITLE
Fix typos again

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -411,7 +411,7 @@ defmodule Ecto.Adapters.SQL do
   shared Repo options such as `:timeout`. Non built-in adapters may have specific behaviour and you should
   consult their documentation for more details.
 
-  For version compatiblity, please check your database's documentation:
+  For version compatibility, please check your database's documentation:
 
     * _Postgrex_: [PostgreSQL doc](https://www.postgresql.org/docs/current/sql-explain.html).
     * _MyXQL_: [MySQL doc](https://dev.mysql.com/doc/refman/8.0/en/explain.html).

--- a/lib/ecto/adapters/sql/sandbox.ex
+++ b/lib/ecto/adapters/sql/sandbox.ex
@@ -224,7 +224,7 @@ defmodule Ecto.Adapters.SQL.Sandbox do
         # assertions
       end
 
-  By using `start_supervised!/1`, ExUnit guarantess the process finishes
+  By using `start_supervised!/1`, ExUnit guarantees the process finishes
   before your test (the connection owner).
 
   In some situations, however, the dynamic processes are directly started

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -822,7 +822,7 @@ defmodule Ecto.Migration do
 
   If the database adapter supports several migration lock strategies, such as
   Postgrex, then review those strategies and consider using a strategy that
-  utilizes advisory locks to faciliate running migrations one at a time even
+  utilizes advisory locks to facilitate running migrations one at a time even
   across multiple nodes. For example:
 
   ### Config file (PostgreSQL)

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -1442,7 +1442,7 @@ defmodule Ecto.Adapters.PostgresTest do
                ~s{SELECT s0."x" FROM "schema" AS s0 WINDOW "w" AS (PARTITION BY s0."x", s0."z" ORDER BY s0."x")}
     end
 
-    test "partition by ond order by over" do
+    test "partition by one order by over" do
       query =
         Schema
         |> select([r], count(r.x) |> over(partition_by: [r.x, r.z], order_by: r.x))


### PR DESCRIPTION
Found via `codespell -L froms` and `typos --format brief`