### PR TITLE
Fix MySQL CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         elixirbase:
-          - "1.11.4-erlang-21.3.8.24-alpine-3.13.3"
+          - "1.11.4-erlang-23.3.4.9-alpine-3.16.9"
         postgres:
           - "16.2-alpine"
           - "11.11-alpine"
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false
       matrix:
         elixirbase:
-          - "1.11.4-erlang-21.3.8.24-alpine-3.13.3"
+          - "1.11.4-erlang-23.3.4.9-alpine-3.16.9"
         mysql:
           - "5.7"
           - "8.0"
@@ -88,7 +88,7 @@ jobs:
       fail-fast: false
       matrix:
         elixirbase:
-          - "1.11.4-erlang-21.3.8.24-alpine-3.13.3"
+          - "1.11.4-erlang-23.3.4.9-alpine-3.16.9"
         mssql:
           - "2017"
           - "2019"

--- a/Earthfile
+++ b/Earthfile
@@ -92,7 +92,6 @@ integration-test-mysql:
             # the default authentication plugin for MySQL 8 is sha 256 but it doesn't come with the docker image. falling back to the 5.7 way
             --default-authentication-plugin=mysql_native_password; \
             # wait for mysql to start
-
             while ! mysqladmin ping --host=127.0.0.1 --port=3306 --protocol=TCP --silent; do \
                 test "$(date +%s)" -le "$timeout" || (echo "timed out waiting for mysql"; exit 1); \
                 echo "waiting for mysql"; \

--- a/Earthfile
+++ b/Earthfile
@@ -87,12 +87,15 @@ integration-test-mysql:
         --pull "mysql:$MYSQL" --platform linux/amd64
         RUN set -e; \
             timeout=$(expr $(date +%s) + 30); \
-            docker run --name mysql --network=host -d -e MYSQL_ROOT_PASSWORD=root "mysql:$MYSQL" \
+            docker run --name mysql --network=host -d -e MYSQL_ROOT_PASSWORD=root "mysql:$MYSQL" --verbose  \
             --sql_mode="ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,ANSI_QUOTES" \
+            --log-error-verbosity=3 \
             # the default authentication plugin for MySQL 8 is sha 256 but it doesn't come with the docker image. falling back to the 5.7 way
             --default-authentication-plugin=mysql_native_password; \
             # wait for mysql to start
-            while ! mysqladmin ping --host=127.0.0.1 --port=3306 --protocol=TCP --silent; do \
+
+            while ! mysqladmin ping --host=127.0.0.1 --port=3306 --protocol=TCP; do \
+                docker logs mysql; \
                 test "$(date +%s)" -le "$timeout" || (echo "timed out waiting for mysql"; exit 1); \
                 echo "waiting for mysql"; \
                 sleep 1; \

--- a/Earthfile
+++ b/Earthfile
@@ -87,15 +87,13 @@ integration-test-mysql:
         --pull "mysql:$MYSQL" --platform linux/amd64
         RUN set -e; \
             timeout=$(expr $(date +%s) + 30); \
-            docker run --name mysql --network=host -d -e MYSQL_ROOT_PASSWORD=root "mysql:$MYSQL" --verbose  \
+            docker run --name mysql --network=host -d -e MYSQL_ROOT_PASSWORD=root "mysql:$MYSQL" \
             --sql_mode="ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,ANSI_QUOTES" \
-            --log-error-verbosity=3 \
             # the default authentication plugin for MySQL 8 is sha 256 but it doesn't come with the docker image. falling back to the 5.7 way
             --default-authentication-plugin=mysql_native_password; \
             # wait for mysql to start
 
-            while ! mysqladmin ping --host=127.0.0.1 --port=3306 --protocol=TCP; do \
-                docker logs mysql; \
+            while ! mysqladmin ping --host=127.0.0.1 --port=3306 --protocol=TCP --silent; do \
                 test "$(date +%s)" -le "$timeout" || (echo "timed out waiting for mysql"; exit 1); \
                 echo "waiting for mysql"; \
                 sleep 1; \


### PR DESCRIPTION
The CI has been failing for a few weeks, it seems since MySQL updated their images: https://github.com/docker-library/mysql/commit/a15b34a032f48089ee7b02d307d8f89a96b3bb76.

I don't know exactly what was happening but the MySQL server was not starting and it was complaining about not being able to allocate threads during bootstrap and the data directory being unusable. 

After trying many things to get it working with the old image, I found that it just works ™ with this image. The difference is the old image was Alpine 3.13 and this one is Alpine 3.16. Alpine 3.13 was end of life 2 years ago so I guess it makes sense there might be some weird errors when it's used as the host OS for newer images.

With this change we can still keep the Elixir version we were testing against but I couldn't find an acceptable image on `hexpm/elixir` with the Erlang version we were using before. So now we are testing against a slightly newer Erlang.