### PR TITLE
Relax myxql dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -92,7 +92,7 @@ defmodule EctoSQL.MixProject do
     if path = System.get_env("MYXQL_PATH") do
       {:myxql, path: path}
     else
-      {:myxql, "~> 0.6.0", optional: true}
+      {:myxql, "~> 0.6", optional: true}
     end
   end
 


### PR DESCRIPTION
This relaxes the MyXQL dependency from `~> 0.6.0` to `~> 0.6` so version `0.7.0` is allowed. I don't think `0.7.0` contains any changes that would cause it not to work with the current version of `ecto_sql`.

I'm not sure if it's intentionally pinnend to `0.6.0`, if so it's probably better to  use `"~> 0.6.0 or ~> 0.7.0" `.