### PR TITLE
make Ecto.Adapters.SQL.with_log/3 public

### DIFF
--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1196,7 +1196,8 @@ defmodule Ecto.Adapters.SQL do
 
   ## Log
 
-  defp with_log(telemetry, params, opts) do
+  @doc false
+  def with_log(telemetry, params, opts) do
     [log: &log(telemetry, params, &1, opts)] ++ opts
   end
 


### PR DESCRIPTION
In place of https://github.com/elixir-ecto/ecto_sql/pull/614

This PR makes it easier to implement [custom functions](https://github.com/plausible/ecto_ch/pull/173) in adapters by making `Ecto.Adapters.SQL.with_log/3` public.