### PR TITLE
Update SSL configuration docs

### DIFF
--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -62,8 +62,9 @@ defmodule Ecto.Adapters.Postgres do
     * `:maintenance_database` - Specifies the name of the database to connect to when
       creating or dropping the database. Defaults to `"postgres"`
     * `:pool` - The connection pool module, may be set to `Ecto.Adapters.SQL.Sandbox`
-    * `:ssl` - Set to true if ssl should be used (default: false)
-    * `:ssl_opts` - A list of ssl options, see Erlang's `ssl` docs
+    * `:ssl` - Accepts a list of options to enable TLS for the client connection,
+      or `false` to disable it. See the documentation for [Erlang's `ssl` module](`e:ssl:ssl`)
+      for a list of options (default: false)
     * `:parameters` - Keyword list of connection parameters
     * `:connect_timeout` - The timeout for establishing new connections (default: 5000)
     * `:prepare` - How to prepare queries, either `:named` to use named queries


### PR DESCRIPTION
Following from [this comment](https://github.com/elixir-ecto/postgrex/issues/681#issuecomment-2180062891), this PR updates the documentation for the `ssl` and `ssl_opts` configuration options for the Postgres adapter.

Please double-check my understanding of the changes and let me know if anything is incorrect. 🙂 