### PR TITLE
Update Ecto.Migration.references/2 documentation

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1381,7 +1381,7 @@ defmodule Ecto.Migration do
   By default it assumes you are linking to the referenced table
   via its primary key with name `:id`. If you are using a non-default
   key setup (e.g. using `uuid` type keys) you must ensure you set the
-  options, such as `:name` and `:type`, to match your target key.
+  options, such as `:column` and `:type`, to match your target key.
 
   ## Examples
 


### PR DESCRIPTION
The `:name` option is unrelated to the referred column. On occasion, what would need to change is `:column` and `:type` according to the column name and column type of the referenced column.