### PR TITLE
Change `schema_migration: true` option to `ecto_query: :schema_migrations`

### DIFF
--- a/lib/ecto/migration/schema_migration.ex
+++ b/lib/ecto/migration/schema_migration.ex
@@ -17,6 +17,8 @@ defmodule Ecto.Migration.SchemaMigration do
   @default_opts [
     timeout: :infinity,
     log: false,
+    # Keep schema_migration for backwards compatibility
+    schema_migration: true,
     ecto_query: :schema_migration,
     telemetry_options: [schema_migration: true]
   ]

--- a/lib/ecto/migration/schema_migration.ex
+++ b/lib/ecto/migration/schema_migration.ex
@@ -17,7 +17,7 @@ defmodule Ecto.Migration.SchemaMigration do
   @default_opts [
     timeout: :infinity,
     log: false,
-    schema_migration: true,
+    ecto_query: :schema_migration,
     telemetry_options: [schema_migration: true]
   ]
 

--- a/test/support/test_repo.exs
+++ b/test/support/test_repo.exs
@@ -55,7 +55,7 @@ defmodule EctoSQL.TestAdapter do
 
   def execute(_, _, {:nocache, {:all, query}}, _, opts) do
     %{from: %{source: {"schema_migrations", _}}} = query
-    true = opts[:schema_migration]
+    :schema_migrations = opts[:ecto_query]
     versions = MigrationsAgent.get()
     {length(versions), Enum.map(versions, &[elem(&1, 0)])}
   end
@@ -63,13 +63,13 @@ defmodule EctoSQL.TestAdapter do
   def execute(_, _, {:nocache, {:delete_all, query}}, params, opts) do
     %{from: %{source: {"schema_migrations", _}}} = query
     [version] = params
-    true = opts[:schema_migration]
+    :schema_migrations = opts[:ecto_query]
     MigrationsAgent.down(version, opts)
     {1, nil}
   end
 
   def insert(_, %{source: "schema_migrations"}, val, _, _, opts) do
-    true = opts[:schema_migration]
+    :schema_migrations = opts[:ecto_query]
     version = Keyword.fetch!(val, :version)
     MigrationsAgent.up(version, opts)
     {:ok, []}


### PR DESCRIPTION
This pull request, based on [this discussion](https://groups.google.com/g/elixir-ecto/c/Y_S6u0WWecc), adds an option to a preload query so that they can be filtered out when using [Multi tenancy with foreign keys](https://hexdocs.pm/ecto/multi-tenancy-with-foreign-keys.html#adding-org_id-to-read-operations)

This pull request changes the `schema_migration: true` option to `ecto_query: :schema_migration`

This change is linked to https://github.com/elixir-ecto/ecto/pull/4503