### PR TITLE
Clarify that index names can be a string or an atom

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -396,7 +396,7 @@ defmodule Ecto.Migration do
     @type t :: %__MODULE__{
             table: String.t(),
             prefix: String.t() | nil,
-            name: atom,
+            name: String.t() | atom,
             columns: [atom | String.t()],
             unique: boolean,
             concurrently: boolean,
@@ -779,7 +779,8 @@ defmodule Ecto.Migration do
 
   ## Options
 
-    * `:name` - the name of the index. Defaults to "#{table}_#{column}_index".
+    * `:name` - the name of the index. Can be provided as a string or an atom.
+    Defaults to "#{table}_#{column}_index".
     * `:prefix` - specify an optional prefix for the index.
     * `:unique` - indicates whether the index should be unique. Defaults to `false`.
     * `:comment` - adds a comment to the index.


### PR DESCRIPTION
Definitely both work, I've tried it out to make sure. Not having it specified caused some confusion in my team and I think it can help to specify this.

I did change the time spec, as I'm rather sure it also ends up in there as a string.

I'm a bit surprised/confused that the docs default to atom usage as as best I can tell the index is used for instance here:

(Postgres connection)
```elixir
    queries = [
        [
          "CREATE ",
          if_do(index.unique, "UNIQUE "),
          "INDEX ",
          if_do(index.concurrently, "CONCURRENTLY "),
          if_do(command == :create_if_not_exists, "IF NOT EXISTS "),
          quote_name(index.name),
          " ON ",
          more stuff

```

which ends up converting the atom back to a string:

```elixir
    defp quote_name(nil, name), do: quote_name(name)

    defp quote_name(prefix, name), do: [quote_name(prefix), ?., quote_name(name)]

    defp quote_name(name) when is_atom(name) do
      quote_name(Atom.to_string(name))
    end

    more stuff
```

But yeah, I don't know as well - I was thinking maybe to use name as a string in the docs at least once to show it's possible but maybe that breaks with a desire for uniformity.

As always, thank you all for your wonderful work! :green_heart: 