### PR TITLE
Use proper range increment for values list

### DIFF
--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -881,7 +881,7 @@ if Code.ensure_loaded?(MyXQL) do
     end
 
     defp values_list(types, num_rows, query) do
-      rows = Enum.to_list(1..num_rows)
+      rows = Enum.to_list(1..num_rows//1)
 
       [
         "VALUES ",

--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -881,7 +881,7 @@ if Code.ensure_loaded?(MyXQL) do
     end
 
     defp values_list(types, num_rows, query) do
-      rows = Enum.to_list(1..num_rows//1)
+      rows = :lists.seq(1, num_rows, 1)
 
       [
         "VALUES ",

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -1137,7 +1137,7 @@ if Code.ensure_loaded?(Postgrex) do
     end
 
     defp values_list(types, idx, num_rows) do
-      rows = Enum.to_list(1..num_rows)
+      rows = Enum.to_list(1..num_rows//1)
 
       [
         "VALUES ",

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -1137,7 +1137,7 @@ if Code.ensure_loaded?(Postgrex) do
     end
 
     defp values_list(types, idx, num_rows) do
-      rows = Enum.to_list(1..num_rows//1)
+      rows = :lists.seq(1, num_rows, 1)
 
       [
         "VALUES ",

--- a/lib/ecto/adapters/tds/connection.ex
+++ b/lib/ecto/adapters/tds/connection.ex
@@ -981,7 +981,7 @@ if Code.ensure_loaded?(Tds) do
     end
 
     defp values_list(types, idx, num_rows) do
-      rows = Enum.to_list(1..num_rows//1)
+      rows = :lists.seq(1, num_rows, 1)
 
       [
         "VALUES ",

--- a/lib/ecto/adapters/tds/connection.ex
+++ b/lib/ecto/adapters/tds/connection.ex
@@ -981,7 +981,7 @@ if Code.ensure_loaded?(Tds) do
     end
 
     defp values_list(types, idx, num_rows) do
-      rows = Enum.to_list(1..num_rows)
+      rows = Enum.to_list(1..num_rows//1)
 
       [
         "VALUES ",


### PR DESCRIPTION
Re-reading the SQL generated in the error report for empty values list I noticed it produces 2 empty values:

```sql
SELECT TRUE FROM "users" AS u0 INNER JOIN (VALUES (),()) AS v1 () ON u0."id" = v1."id" LIMIT 1
```

So just adjusting the range increment to be right. We might no have to care about it but just in case we make more changes to empty list behaviour in the future I want to avoid getting bit by this.