### PR TITLE
MyXQL: Add back subquery parens inside of function calls

### DIFF
--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -826,7 +826,7 @@ if Code.ensure_loaded?(MyXQL) do
             fun,
             ?(,
             modifier,
-            Enum.map_intersperse(args, ", ", &top_level_expr(&1, sources, query)),
+            Enum.map_intersperse(args, ", ", &expr(&1, sources, query)),
             ?)
           ]
       end

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -478,7 +478,7 @@ defmodule Ecto.Adapters.MyXQLTest do
       |> plan()
 
     assert all(query) ==
-             ~s{SELECT s0.`x` FROM `schema` AS s0 ORDER BY exists(SELECT ss0.`x` AS `result` FROM `schema` AS ss0 WHERE (ss0.`x` = s0.`x`))}
+             ~s{SELECT s0.`x` FROM `schema` AS s0 ORDER BY exists((SELECT ss0.`x` AS `result` FROM `schema` AS ss0 WHERE (ss0.`x` = s0.`x`)))}
   end
 
   test "union and union all" do
@@ -882,7 +882,7 @@ defmodule Ecto.Adapters.MyXQLTest do
       |> plan()
 
     assert all(query) ==
-             ~s{SELECT s0.`x` FROM `schema` AS s0 GROUP BY exists(SELECT ss0.`x` AS `result` FROM `schema` AS ss0 WHERE (ss0.`x` = s0.`x`))}
+             ~s{SELECT s0.`x` FROM `schema` AS s0 GROUP BY exists((SELECT ss0.`x` AS `result` FROM `schema` AS ss0 WHERE (ss0.`x` = s0.`x`)))}
   end
 
   test "interpolated values" do
@@ -1089,7 +1089,7 @@ defmodule Ecto.Adapters.MyXQLTest do
         |> plan
 
       assert all(query) ==
-               ~s{SELECT s0.`x` FROM `schema` AS s0 WINDOW `w` AS (ORDER BY exists(SELECT ss0.`x` AS `result` FROM `schema` AS ss0 WHERE (ss0.`x` = s0.`x`)))}
+               ~s{SELECT s0.`x` FROM `schema` AS s0 WINDOW `w` AS (ORDER BY exists((SELECT ss0.`x` AS `result` FROM `schema` AS ss0 WHERE (ss0.`x` = s0.`x`))))}
     end
 
     test "two windows" do

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -416,6 +416,12 @@ defmodule Ecto.Adapters.MyXQLTest do
     assert all(query) == ~s{SELECT coalesce(s0.`x`, 5) FROM `schema` AS s0}
   end
 
+  test "coalesce with subquery" do
+    squery = from s in Schema, select: s.x
+    query = Schema |> select([s], coalesce(subquery(squery), 5)) |> plan()
+    assert all(query) == ~s{SELECT coalesce((SELECT ss0.`x` AS `x` FROM `schema` AS ss0), 5) FROM `schema` AS s0}
+  end
+
   test "where" do
     query = Schema |> where([r], r.x == 42) |> where([r], r.y != 43) |> select([r], r.x) |> plan()
 

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -419,7 +419,9 @@ defmodule Ecto.Adapters.MyXQLTest do
   test "coalesce with subquery" do
     squery = from s in Schema, select: s.x
     query = Schema |> select([s], coalesce(subquery(squery), 5)) |> plan()
-    assert all(query) == ~s{SELECT coalesce((SELECT ss0.`x` AS `x` FROM `schema` AS ss0), 5) FROM `schema` AS s0}
+
+    assert all(query) ==
+             ~s{SELECT coalesce((SELECT ss0.`x` AS `x` FROM `schema` AS ss0), 5) FROM `schema` AS s0}
   end
 
   test "where" do

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -584,6 +584,12 @@ defmodule Ecto.Adapters.PostgresTest do
     assert all(query) == ~s{SELECT coalesce(s0."x", 5) FROM "schema" AS s0}
   end
 
+  test "coalesce with subquery" do
+    squery = from s in Schema, select: s.x
+    query = Schema |> select([s], coalesce(subquery(squery), 5)) |> plan()
+    assert all(query) == ~s{SELECT coalesce((SELECT ss0."x" AS "x" FROM "schema" AS ss0), 5) FROM "schema" AS s0}
+  end
+
   test "where" do
     query = Schema |> where([r], r.x == 42) |> where([r], r.y != 43) |> select([r], r.x) |> plan()
 

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -587,7 +587,9 @@ defmodule Ecto.Adapters.PostgresTest do
   test "coalesce with subquery" do
     squery = from s in Schema, select: s.x
     query = Schema |> select([s], coalesce(subquery(squery), 5)) |> plan()
-    assert all(query) == ~s{SELECT coalesce((SELECT ss0."x" AS "x" FROM "schema" AS ss0), 5) FROM "schema" AS s0}
+
+    assert all(query) ==
+             ~s{SELECT coalesce((SELECT ss0."x" AS "x" FROM "schema" AS ss0), 5) FROM "schema" AS s0}
   end
 
   test "where" do


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto_sql/issues/642

This was removed when subquery support was added to order by/group by. I believe it was because stuff like `exists((..subquery...))` looked weird and not necessarily because it breaks the query. All my local tests passed and all our integration tests pass, including the ones added when this change was made.

I opted for adding the parens back because the other option is to special case certain functions. Which I think can get hairy.