### PR TITLE
Do not modify column type while modifying fk constraint

### DIFF
--- a/integration_test/pg/migrations_test.exs
+++ b/integration_test/pg/migrations_test.exs
@@ -153,7 +153,6 @@ defmodule Ecto.Integration.MigrationsTest do
       assert up_log =~ ~s(DROP CONSTRAINT "my_comments_user_id_fkey",)
       refute up_log =~ ~s(ALTER COLUMN "user_id" TYPE)
       assert up_log =~ ~s/ADD CONSTRAINT "my_comments_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "my_users"("id") ON DELETE SET NULL/
-      assert up_log =~ ~s{ALTER TABLE "my_comments" DROP CONSTRAINT "my_comments_user_id_fkey", ADD CONSTRAINT "my_comments_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "my_users"("id") ON DELETE SET NULL}
 
       assert up_log =~ ~s(ALTER TABLE "my_posts")
       refute up_log =~ ~s(ALTER COLUMN "user_id" TYPE)

--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -134,12 +134,21 @@ defmodule Ecto.Integration.MigrationTest do
         add :alter_fk_user_id, :id
       end
 
+      create table(:alter_fk_comments) do
+        add :alter_fk_user_id, references(:alter_fk_users)
+      end
+
       alter table(:alter_fk_posts) do
-        modify :alter_fk_user_id, references(:alter_fk_users, on_delete: :nilify_all)
+        modify :alter_fk_user_id, references(:alter_fk_users, on_delete: :nilify_all), from: {:id, null: true}
+      end
+
+      alter table(:alter_fk_comments) do
+        modify :alter_fk_user_id, references(:alter_fk_users, on_delete: :delete_all), from: references(:alter_fk_users, on_delete: :nothing)
       end
     end
 
     def down do
+      drop table(:alter_fk_comments)
       drop table(:alter_fk_posts)
       drop table(:alter_fk_users)
     end

--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -581,6 +581,8 @@ defmodule Ecto.Integration.MigrationTest do
     assert [nil] ==
            PoolRepo.all from p in "alter_col_migration", select: p.another_from_default_to_no_default
     assert [0] ==
+           PoolRepo.all from p in "alter_col_migration", select: p.from_no_default_to_default
+    assert [0] ==
            PoolRepo.all from p in "alter_col_migration", select: p.another_from_no_default_to_default
 
     query = "INSERT INTO `alter_col_migration` (\"from_not_null_to_null\") VALUES ('foo')"

--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -48,6 +48,7 @@ defmodule Ecto.Integration.MigrationTest do
     def up do
       create table(:alter_col_migration) do
         add :from_null_to_not_null, :integer
+        add :another_from_null_to_not_null, :string
         add :from_not_null_to_null, :integer, null: false
 
         add :from_default_to_no_default, :integer, default: 0
@@ -56,13 +57,14 @@ defmodule Ecto.Integration.MigrationTest do
 
       alter table(:alter_col_migration) do
         modify :from_null_to_not_null, :string, null: false
+        modify :another_from_null_to_not_null, :string, null: false, from: {:string, null: true}
         modify :from_not_null_to_null, :string, null: true
 
         modify :from_default_to_no_default, :integer, default: nil
         modify :from_no_default_to_default, :integer, default: 0
       end
 
-      execute "INSERT INTO alter_col_migration (from_null_to_not_null) VALUES ('foo')"
+      execute "INSERT INTO alter_col_migration (from_null_to_not_null, another_from_null_to_not_null) VALUES ('foo', 'baz')"
     end
 
     def down do

--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -48,29 +48,21 @@ defmodule Ecto.Integration.MigrationTest do
     def up do
       create table(:alter_col_migration) do
         add :from_null_to_not_null, :integer
-        add :another_from_null_to_not_null, :string
         add :from_not_null_to_null, :integer, null: false
 
         add :from_default_to_no_default, :integer, default: 0
         add :from_no_default_to_default, :integer
-
-        add :another_from_default_to_no_default, :integer, default: 0
-        add :another_from_no_default_to_default, :integer
       end
 
       alter table(:alter_col_migration) do
         modify :from_null_to_not_null, :string, null: false
-        modify :another_from_null_to_not_null, :string, null: false, from: {:string, null: true}
         modify :from_not_null_to_null, :string, null: true
 
         modify :from_default_to_no_default, :integer, default: nil
         modify :from_no_default_to_default, :integer, default: 0
-
-        modify :another_from_default_to_no_default, :integer, default: nil, from: {:integer, default: 0}
-        modify :another_from_no_default_to_default, :integer, default: 0, from: {:integer, default: nil}
       end
 
-      execute "INSERT INTO alter_col_migration (from_null_to_not_null, another_from_null_to_not_null) VALUES ('foo', 'baz')"
+      execute "INSERT INTO alter_col_migration (from_null_to_not_null) VALUES ('foo')"
     end
 
     def down do
@@ -140,21 +132,12 @@ defmodule Ecto.Integration.MigrationTest do
         add :alter_fk_user_id, :id
       end
 
-      create table(:alter_fk_comments) do
-        add :alter_fk_user_id, references(:alter_fk_users)
-      end
-
       alter table(:alter_fk_posts) do
-        modify :alter_fk_user_id, references(:alter_fk_users, on_delete: :nilify_all), from: {:id, null: true}
-      end
-
-      alter table(:alter_fk_comments) do
-        modify :alter_fk_user_id, references(:alter_fk_users, on_delete: :nilify_all), from: references(:alter_fk_users, on_delete: :nothing)
+        modify :alter_fk_user_id, references(:alter_fk_users, on_delete: :nilify_all)
       end
     end
 
     def down do
-      drop table(:alter_fk_comments)
       drop table(:alter_fk_posts)
       drop table(:alter_fk_users)
     end
@@ -572,18 +555,12 @@ defmodule Ecto.Integration.MigrationTest do
 
     assert ["foo"] ==
            PoolRepo.all from p in "alter_col_migration", select: p.from_null_to_not_null
-    assert ["baz"] ==
-           PoolRepo.all from p in "alter_col_migration", select: p.another_from_null_to_not_null
     assert [nil] ==
            PoolRepo.all from p in "alter_col_migration", select: p.from_not_null_to_null
     assert [nil] ==
            PoolRepo.all from p in "alter_col_migration", select: p.from_default_to_no_default
-    assert [nil] ==
-           PoolRepo.all from p in "alter_col_migration", select: p.another_from_default_to_no_default
     assert [0] ==
            PoolRepo.all from p in "alter_col_migration", select: p.from_no_default_to_default
-    assert [0] ==
-           PoolRepo.all from p in "alter_col_migration", select: p.another_from_no_default_to_default
 
     query = "INSERT INTO `alter_col_migration` (\"from_not_null_to_null\") VALUES ('foo')"
     assert catch_error(PoolRepo.query!(query))
@@ -619,10 +596,8 @@ defmodule Ecto.Integration.MigrationTest do
     assert [id] = PoolRepo.all from p in "alter_fk_users", select: p.id
 
     PoolRepo.insert_all("alter_fk_posts", [[alter_fk_user_id: id]])
-    PoolRepo.insert_all("alter_fk_comments", [[alter_fk_user_id: id]])
     PoolRepo.delete_all("alter_fk_users")
     assert [nil] == PoolRepo.all from p in "alter_fk_posts", select: p.alter_fk_user_id
-    assert [nil] == PoolRepo.all from p in "alter_fk_comments", select: p.alter_fk_user_id
 
     :ok = down(PoolRepo, num, AlterForeignKeyOnDeleteMigration, log: false)
   end

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -1558,7 +1558,7 @@ if Code.ensure_loaded?(Postgrex) do
         modify_default(name, ref.type, opts)
       ]
 
-      if reference_column_type == column_type(from_column_type, opts) do
+      if reference_column_type == reference_column_type(from_column_type, opts) do
         [
           drop_reference_expr,
           prefix_with_comma,

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -1548,11 +1548,7 @@ if Code.ensure_loaded?(Postgrex) do
     defp column_change(table, {:modify, name, %Reference{} = ref, opts}) do
       [
         drop_reference_expr(opts[:from], table, name),
-        "ALTER COLUMN ",
-        quote_name(name),
-        " TYPE ",
-        reference_column_type(ref.type, opts),
-        ", ADD ",
+        "ADD ",
         reference_expr(ref, table, name),
         modify_null(name, opts),
         modify_default(name, ref.type, opts)

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1285,8 +1285,8 @@ defmodule Ecto.Migration do
   >
   > We have considered changing the column type even when it is not needed
   > could lead to undesirable locks, that's why, at least in the PostgreSQL
-  > adapter, if you provide the option `:from`, and the type matches, we
-  > will avoid changing the type.
+  > adapter, if you provide the option `:from`, and the column type matches,
+  > we will skip updating it.
   >
   > Examples
   >
@@ -1297,7 +1297,7 @@ defmodule Ecto.Migration do
   >
   >     # adding a new foreign key constraint
   >     alter table("posts") do
-  >       modify :author_id, references(:authors, type: :id), from: :id
+  >       modify :author_id, references(:authors, type: :id, validate: false), from: :id
   >     end
   >
   >     # Modify the :on_delete option of an existing foreign key
@@ -1306,11 +1306,9 @@ defmodule Ecto.Migration do
   >         from: references(:posts, on_delete: :nothing)
   >     end
   >
-  >
-  > The previous syntax will offer two benefits, at least in the PostgreSQL adapter,
-  > the migration is reversible and if the column type remains the same, the column
+  > The previous syntax will offer two benefits, apart from being a reversible migration,
+  > at least in the PostgreSQL adapter, if the column type remains the same, the column
   > type update will be skipped.
-
 
   ## Examples
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1283,10 +1283,9 @@ defmodule Ecto.Migration do
   > type update can lock the table, even if the type actually
   > doesn't change.
   >
-  > We have considered changing the column type even when it is not needed
-  > could lead to undesirable locks, that's why, at least in the PostgreSQL
-  > adapter, if you provide the option `:from`, and the column type matches,
-  > we will skip updating it.
+  > These undesired locks can be avoided when using the PostgreSQL adapter by
+  > providing the `:from` option and ensuring its type matches the type provided
+  > to `modify/3`. In that scenario, the type change part of the migration is omitted.
   >
   > Examples:
   >

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1273,13 +1273,44 @@ defmodule Ecto.Migration do
 
   See `add/3` for more information on supported types.
 
-  If you want to modify a column without changing its type,
-  such as adding or dropping a null constraints, consider using
-  the `execute/2` command with the relevant SQL command instead
-  of `modify/3`, if supported by your database. This may avoid
-  redundant type updates and be more efficient, as an unnecessary
-  type update can lock the table, even if the type actually
-  doesn't change.
+  > #### Modifying a column without changing its type {: .warning}
+  >
+  > If you want to modify a column without changing its type,
+  > such as adding or dropping a null constraints, consider using
+  > the `execute/2` command with the relevant SQL command instead
+  > of `modify/3`, if supported by your database. This may avoid
+  > redundant type updates and be more efficient, as an unnecessary
+  > type update can lock the table, even if the type actually
+  > doesn't change.
+  >
+  > We have considered changing the column type even when it is not needed
+  > could lead to undesirable locks, that's why, at least in the PostgreSQL
+  > adapter, if you provide the option `:from`, and the type matches, we
+  > will avoid changing the type.
+  >
+  > Examples
+  >
+  >     # modify column with rollback options
+  >     alter table("posts") do
+  >       modify :title, :text, null: false, from: {:text, null: true}
+  >     end
+  >
+  >     # adding a new foreign key constraint
+  >     alter table("posts") do
+  >       modify :author_id, references(:authors, type: :id), from: :id
+  >     end
+  >
+  >     # Modify the :on_delete option of an existing foreign key
+  >     alter table("comments") do
+  >       modify :post_id, references(:posts, on_delete: :delete_all),
+  >         from: references(:posts, on_delete: :nothing)
+  >     end
+  >
+  >
+  > The previous syntax will offer two benefits, at least in the PostgreSQL adapter,
+  > the migration is reversible and if the column type remains the same, the column
+  > type update will be skipped.
+
 
   ## Examples
 

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1276,7 +1276,7 @@ defmodule Ecto.Migration do
   > #### Modifying a column without changing its type {: .warning}
   >
   > If you want to modify a column without changing its type,
-  > such as adding or dropping a null constraints, consider using
+  > such as adding or dropping a null constraint, consider using
   > the `execute/2` command with the relevant SQL command instead
   > of `modify/3`, if supported by your database. This may avoid
   > redundant type updates and be more efficient, as an unnecessary
@@ -1288,7 +1288,7 @@ defmodule Ecto.Migration do
   > adapter, if you provide the option `:from`, and the column type matches,
   > we will skip updating it.
   >
-  > Examples
+  > Examples:
   >
   >     # modify column with rollback options
   >     alter table("posts") do
@@ -1306,9 +1306,9 @@ defmodule Ecto.Migration do
   >         from: references(:posts, on_delete: :nothing)
   >     end
   >
-  > The previous syntax will offer two benefits, apart from being a reversible migration,
-  > at least in the PostgreSQL adapter, if the column type remains the same, the column
-  > type update will be skipped.
+  > The previous syntax offers two benefits:
+  > 1. the migrations are reversible
+  > 2. the PostgreSQL adapter will skip the type update, due to the `:from` type matching the modify type
 
   ## Examples
 

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -2535,7 +2535,6 @@ defmodule Ecto.Adapters.PostgresTest do
              ALTER COLUMN "space_id" TYPE integer,
              ALTER COLUMN "space_id" DROP NOT NULL,
              DROP CONSTRAINT "posts_group_id_fkey",
-             ALTER COLUMN "group_id" TYPE bigint,
              ADD CONSTRAINT "posts_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "groups"("gid"),
              ALTER COLUMN "status" TYPE varchar(100),
              ALTER COLUMN "status" SET NOT NULL,

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -2636,6 +2636,26 @@ defmodule Ecto.Adapters.PostgresTest do
            ]
   end
 
+  test "alter table without updating column type via modify/3" do
+    alter =
+      {:alter, table(:posts),
+       [
+         {:modify, :category_id, %Reference{table: :categories, type: :id}, from: :id},
+         {:modify, :author_id, %Reference{table: :authors, type: :id, on_delete: :delete_all},
+          from: %Reference{table: :authors, type: :id, on_delete: :nothing}}
+       ]}
+
+    assert execute_ddl(alter) ==
+             [
+               remove_newlines("""
+               ALTER TABLE "posts"
+               ADD CONSTRAINT "posts_category_id_fkey" FOREIGN KEY ("category_id") REFERENCES "categories"("id"),
+               DROP CONSTRAINT "posts_author_id_fkey",
+               ADD CONSTRAINT "posts_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "authors"("id") ON DELETE CASCADE
+               """)
+             ]
+  end
+
   test "create index" do
     create = {:create, index(:posts, [:category_id, :permalink])}
 


### PR DESCRIPTION
The following migration syntax:

```elixir
alter table(:my_table) do
  modify :parent_id, references(:my_table, type: :binary_id, on_delete: :nilify_all, validate: false),
    from: {:binary_id, null: true}
end
```

Produces a SQL equivalent like this:

```sql
ALTER TABLE "my_table"
  ALTER COLUMN "parent_id" TYPE uuid,
  ADD CONSTRAINT "my_table_parent_id_fkey" FOREIGN KEY ("parent_id") REFERENCES "my_table"("id") ON DELETE SET NULL NOT VALID
```

The problem with the first directive, `ALTER COLUMN`, is that even if the field type is the same, at least in PostgreSQL, is creating bunch of `AccessExclusiveLock` (the most restrictive one) on each of the indexes associated to that field, and the table itself, when that's not needed at all, at least in this case.

For example:

```console
test_dev=# BEGIN;
  LOCK TABLE "schema_migrations" IN SHARE UPDATE EXCLUSIVE MODE;
  ALTER TABLE "my_table" ALTER COLUMN "parent_id" TYPE uuid, ADD CONSTRAINT "my_table_parent_id_fkey" FOREIGN KEY ("parent_id") REFERENCES "my_table"("id") ON DELETE SET NULL NOT VALID;
  INSERT INTO "schema_migrations" ("version","inserted_at") VALUES ('20210718210952',NOW());
  SELECT locktype, relation::regclass, mode, transactionid AS tid, virtualtransaction AS vtid, pid, granted FROM pg_locks;
COMMIT;
BEGIN
LOCK TABLE
ALTER TABLE
INSERT 0 1
   locktype    |                     relation                        |           mode           |   tid   |  vtid   |  pid  | granted
---------------+-----------------------------------------------------+--------------------------+---------+---------+-------+---------
 relation      | schema_migrations                                   | RowExclusiveLock         |         | 4/14045 | 16813 | t
 virtualxid    |                                                     | ExclusiveLock            |         | 4/14045 | 16813 | t
 relation      | my_table_parent_id_ppppppp_id_index                 | AccessExclusiveLock      |         | 4/14045 | 16813 | t
 relation      | pg_locks                                            | AccessShareLock          |         | 4/14045 | 16813 | t
 relation      | 134438                                              | AccessShareLock          |         | 4/14045 | 16813 | t
 relation      | 134438                                              | AccessExclusiveLock      |         | 4/14045 | 16813 | t
 relation      | my_table_parent_id_rrrrr_index                      | AccessExclusiveLock      |         | 4/14045 | 16813 | t
 relation      | my_table                                            | AccessShareLock          |         | 4/14045 | 16813 | t
 relation      | my_table                                            | ShareLock                |         | 4/14045 | 16813 | t
 relation      | my_table                                            | ShareRowExclusiveLock    |         | 4/14045 | 16813 | t
 relation      | my_table                                            | AccessExclusiveLock      |         | 4/14045 | 16813 | t
 relation      | my_table_project_id_xxxx_index                      | AccessExclusiveLock      |         | 4/14045 | 16813 | t
 relation      | 135159                                              | AccessShareLock          |         | 4/14045 | 16813 | t
 relation      | 135159                                              | AccessExclusiveLock      |         | 4/14045 | 16813 | t
 relation      | 132875                                              | AccessShareLock          |         | 4/14045 | 16813 | t
 relation      | 132875                                              | AccessExclusiveLock      |         | 4/14045 | 16813 | t
 relation      | 132507                                              | AccessExclusiveLock      |         | 4/14045 | 16813 | t
 relation      | 132506                                              | AccessShareLock          |         | 4/14045 | 16813 | t
 relation      | 132506                                              | AccessExclusiveLock      |         | 4/14045 | 16813 | t
 relation      | schema_migrations                                   | ShareUpdateExclusiveLock |         | 4/14045 | 16813 | t
 relation      | 132504                                              | AccessShareLock          |         | 4/14045 | 16813 | t
 relation      | 132504                                              | AccessExclusiveLock      |         | 4/14045 | 16813 | t
 relation      | 135184                                              | AccessShareLock          |         | 4/14045 | 16813 | t
 relation      | 135184                                              | AccessExclusiveLock      |         | 4/14045 | 16813 | t
 relation      | 132505                                              | AccessShareLock          |         | 4/14045 | 16813 | t
 relation      | 132505                                              | AccessExclusiveLock      |         | 4/14045 | 16813 | t
 relation      | my_table_parent_id_ttttt_index                      | AccessExclusiveLock      |         | 4/14045 | 16813 | t
 transactionid |                                                     | ExclusiveLock            | 2175345 | 4/14045 | 16813 | t
 relation      | my_table_parent_id_aaaaaaaaaaa_id_index             | AccessExclusiveLock      |         | 4/14045 | 16813 | t
 relation      | 132503                                              | AccessShareLock          |         | 4/14045 | 16813 | t
 relation      | 132503                                              | AccessExclusiveLock      |         | 4/14045 | 16813 | t
 relation      | my_table_parent_id_gggg_index                       | AccessExclusiveLock      |         | 4/14045 | 16813 | t
(35 rows)

COMMIT
```

So, the proposal is to avoid setting the type when you pass `references` to `modify`, if there is any type incompatibility, PostgreSQL, will let you know about it right away:

```
ERROR:  foreign key constraint "my_table_parent_id_fkey" cannot be implemented
DETAIL:  Key columns "parent_id" and "id" are of incompatible types: character varying and uuid.
```

With this proposal, the resulting SQL syntax should be something like:

```sql
ALTER TABLE "my_table"
  ADD CONSTRAINT "my_table_parent_id_fkey" FOREIGN KEY ("parent_id") REFERENCES "my_table"("id") ON DELETE SET NULL NOT VALID
```
That will produce more manageable lock types:

```console
   locktype    |     relation      |           mode           |   tid   |  vtid   |  pid  | granted
---------------+-------------------+--------------------------+---------+---------+-------+---------
 relation      | pg_locks          | AccessShareLock          |         | 4/14540 | 16849 | t
 relation      | schema_migrations | RowExclusiveLock         |         | 4/14540 | 16849 | t
 virtualxid    |                   | ExclusiveLock            |         | 4/14540 | 16849 | t
 transactionid |                   | ExclusiveLock            | 2175967 | 4/14540 | 16849 | t
 relation      | schema_migrations | ShareUpdateExclusiveLock |         | 4/14540 | 16849 | t
 relation      | my_table          | AccessShareLock          |         | 4/14540 | 16849 | t
 relation      | my_table          | ShareRowExclusiveLock    |         | 4/14540 | 16849 | t
(7 rows)
```

And with that, you can avoid potential downtime in production :bowtie: 