### PR TITLE
Allow MyXQL to specify `:prepare` per operation.

### DIFF
--- a/integration_test/myxql/prepare_test.exs
+++ b/integration_test/myxql/prepare_test.exs
@@ -1,0 +1,19 @@
+defmodule Ecto.Integration.PrepareTest do
+  use Ecto.Integration.Case, async: true
+
+  alias Ecto.Integration.TestRepo
+  alias Ecto.Integration.Post
+
+  test "prepare option" do
+    one = TestRepo.insert!(%Post{title: "one"})
+    two = TestRepo.insert!(%Post{title: "two"})
+
+    # Uncached
+    assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
+    assert TestRepo.all(Post, prepare: :named) == [one, two]
+
+    # Cached
+    assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
+    assert TestRepo.all(Post, prepare: :named) == [one, two]
+  end
+end

--- a/integration_test/myxql/prepare_test.exs
+++ b/integration_test/myxql/prepare_test.exs
@@ -12,19 +12,23 @@ defmodule Ecto.Integration.PrepareTest do
     assert %{rows: [[_, orig_count]]} = TestRepo.query!(stmt_count_query, [])
     orig_count = String.to_integer(orig_count)
 
+    query = from p in Post, select: fragment("'mxql test prepare option'")
+
     # Uncached
-    assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
+    assert TestRepo.all(query, prepare: :unnamed) == [one, two]
     %{rows: [[_, new_count]]} = TestRepo.query!(stmt_count_query, [])
     assert String.to_integer(new_count) == orig_count
-    assert TestRepo.all(Post, prepare: :named) == [one, two]
+
+    assert TestRepo.all(query, prepare: :named) == [one, two]
     assert %{rows: [[_, new_count]]} = TestRepo.query!(stmt_count_query, [])
     assert String.to_integer(new_count) == orig_count + 1
 
     # Cached
-    assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
+    assert TestRepo.all(query, prepare: :unnamed) == [one, two]
     assert %{rows: [[_, new_count]]} = TestRepo.query!(stmt_count_query, [])
     assert String.to_integer(new_count) == orig_count + 1
-    assert TestRepo.all(Post, prepare: :named) == [one, two]
+
+    assert TestRepo.all(query, prepare: :named) == [one, two]
     assert %{rows: [[_, new_count]]} = TestRepo.query!(stmt_count_query, [])
     assert String.to_integer(new_count) == orig_count + 1
   end

--- a/integration_test/myxql/prepare_test.exs
+++ b/integration_test/myxql/prepare_test.exs
@@ -9,22 +9,22 @@ defmodule Ecto.Integration.PrepareTest do
     two = TestRepo.insert!(%Post{title: "two"})
 
     stmt_count_query = "SHOW GLOBAL STATUS LIKE '%prepared_stmt_count%'"
-    assert %{rows: [[orig_count]]} = TestRepo.query(stmt_count_query, [])
+    assert %{rows: [[orig_count]]} = TestRepo.query!(stmt_count_query, [])
 
     # Uncached
     assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
-    %{rows: [[new_count]]} = TestRepo.query(stmt_count_query, [])
+    %{rows: [[new_count]]} = TestRepo.query!(stmt_count_query, [])
     assert new_count == orig_count
     assert TestRepo.all(Post, prepare: :named) == [one, two]
-    assert %{rows: [[new_count]]} = TestRepo.query(stmt_count_query, [])
+    assert %{rows: [[new_count]]} = TestRepo.query!(stmt_count_query, [])
     assert new_count == orig_count + 1
 
     # Cached
     assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
-    assert %{rows: [[new_count]]} = TestRepo.query(stmt_count_query, [])
+    assert %{rows: [[new_count]]} = TestRepo.query!(stmt_count_query, [])
     assert new_count == orig_count + 1
     assert TestRepo.all(Post, prepare: :named) == [one, two]
-    assert %{rows: [[new_count]]} = TestRepo.query(stmt_count_query, [])
+    assert %{rows: [[new_count]]} = TestRepo.query!(stmt_count_query, [])
     assert new_count == orig_count + 1
   end
 end

--- a/integration_test/myxql/prepare_test.exs
+++ b/integration_test/myxql/prepare_test.exs
@@ -8,12 +8,18 @@ defmodule Ecto.Integration.PrepareTest do
     one = TestRepo.insert!(%Post{title: "one"})
     two = TestRepo.insert!(%Post{title: "two"})
 
+    stmt_count_query = "SHOW GLOBAL STATUS LIKE '%prepared_stmt_count%'"
+
     # Uncached
     assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
+    assert %{rows: [[0]]} = TestRepo.query(stmt_count_query, [])
     assert TestRepo.all(Post, prepare: :named) == [one, two]
+    assert %{rows: [[1]]} = TestRepo.query(stmt_count_query, [])
 
     # Cached
     assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
+    assert %{rows: [[1]]} = TestRepo.query(stmt_count_query, [])
     assert TestRepo.all(Post, prepare: :named) == [one, two]
+    assert %{rows: [[1]]} = TestRepo.query(stmt_count_query, [])
   end
 end

--- a/integration_test/myxql/prepare_test.exs
+++ b/integration_test/myxql/prepare_test.exs
@@ -7,8 +7,7 @@ defmodule Ecto.Integration.PrepareTest do
   alias Ecto.Integration.Post
 
   test "prepare option" do
-    one = TestRepo.insert!(%Post{title: "one"})
-    two = TestRepo.insert!(%Post{title: "two"})
+    TestRepo.insert!(%Post{title: "one"})
 
     stmt_count_query = "SHOW GLOBAL STATUS LIKE '%prepared_stmt_count%'"
     assert %{rows: [[_, orig_count]]} = TestRepo.query!(stmt_count_query, [])
@@ -17,20 +16,20 @@ defmodule Ecto.Integration.PrepareTest do
     query = from p in Post, select: fragment("'mxql test prepare option'")
 
     # Uncached
-    assert TestRepo.all(query, prepare: :unnamed) == [one, two]
+    assert TestRepo.all(query, prepare: :unnamed) == ["mxql test prepare option"]
     %{rows: [[_, new_count]]} = TestRepo.query!(stmt_count_query, [])
     assert String.to_integer(new_count) == orig_count
 
-    assert TestRepo.all(query, prepare: :named) == [one, two]
+    assert TestRepo.all(query, prepare: :named) == ["mxql test prepare option"]
     assert %{rows: [[_, new_count]]} = TestRepo.query!(stmt_count_query, [])
     assert String.to_integer(new_count) == orig_count + 1
 
     # Cached
-    assert TestRepo.all(query, prepare: :unnamed) == [one, two]
+    assert TestRepo.all(query, prepare: :unnamed) == ["mxql test prepare option"]
     assert %{rows: [[_, new_count]]} = TestRepo.query!(stmt_count_query, [])
     assert String.to_integer(new_count) == orig_count + 1
 
-    assert TestRepo.all(query, prepare: :named) == [one, two]
+    assert TestRepo.all(query, prepare: :named) == ["mxql test prepare option"]
     assert %{rows: [[_, new_count]]} = TestRepo.query!(stmt_count_query, [])
     assert String.to_integer(new_count) == orig_count + 1
   end

--- a/integration_test/myxql/prepare_test.exs
+++ b/integration_test/myxql/prepare_test.exs
@@ -1,6 +1,8 @@
 defmodule Ecto.Integration.PrepareTest do
   use Ecto.Integration.Case, async: false
 
+  import Ecto.Query, only: [from: 2]
+
   alias Ecto.Integration.TestRepo
   alias Ecto.Integration.Post
 

--- a/integration_test/myxql/prepare_test.exs
+++ b/integration_test/myxql/prepare_test.exs
@@ -10,21 +10,22 @@ defmodule Ecto.Integration.PrepareTest do
 
     stmt_count_query = "SHOW GLOBAL STATUS LIKE '%prepared_stmt_count%'"
     assert %{rows: [[_, orig_count]]} = TestRepo.query!(stmt_count_query, [])
+    orig_count = String.to_integer(orig_count)
 
     # Uncached
     assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
     %{rows: [[_, new_count]]} = TestRepo.query!(stmt_count_query, [])
-    assert new_count == orig_count
+    assert String.to_integer(new_count) == orig_count
     assert TestRepo.all(Post, prepare: :named) == [one, two]
     assert %{rows: [[_, new_count]]} = TestRepo.query!(stmt_count_query, [])
-    assert new_count == orig_count + 1
+    assert String.to_integer(new_count) == orig_count + 1
 
     # Cached
     assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
     assert %{rows: [[_, new_count]]} = TestRepo.query!(stmt_count_query, [])
-    assert new_count == orig_count + 1
+    assert String.to_integer(new_count) == orig_count + 1
     assert TestRepo.all(Post, prepare: :named) == [one, two]
     assert %{rows: [[_, new_count]]} = TestRepo.query!(stmt_count_query, [])
-    assert new_count == orig_count + 1
+    assert String.to_integer(new_count) == orig_count + 1
   end
 end

--- a/integration_test/myxql/prepare_test.exs
+++ b/integration_test/myxql/prepare_test.exs
@@ -9,22 +9,22 @@ defmodule Ecto.Integration.PrepareTest do
     two = TestRepo.insert!(%Post{title: "two"})
 
     stmt_count_query = "SHOW GLOBAL STATUS LIKE '%prepared_stmt_count%'"
-    assert %{rows: [[orig_count]]} = TestRepo.query!(stmt_count_query, [])
+    assert %{rows: [[_, orig_count]]} = TestRepo.query!(stmt_count_query, [])
 
     # Uncached
     assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
-    %{rows: [[new_count]]} = TestRepo.query!(stmt_count_query, [])
+    %{rows: [[_, new_count]]} = TestRepo.query!(stmt_count_query, [])
     assert new_count == orig_count
     assert TestRepo.all(Post, prepare: :named) == [one, two]
-    assert %{rows: [[new_count]]} = TestRepo.query!(stmt_count_query, [])
+    assert %{rows: [[_, new_count]]} = TestRepo.query!(stmt_count_query, [])
     assert new_count == orig_count + 1
 
     # Cached
     assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
-    assert %{rows: [[new_count]]} = TestRepo.query!(stmt_count_query, [])
+    assert %{rows: [[_, new_count]]} = TestRepo.query!(stmt_count_query, [])
     assert new_count == orig_count + 1
     assert TestRepo.all(Post, prepare: :named) == [one, two]
-    assert %{rows: [[new_count]]} = TestRepo.query!(stmt_count_query, [])
+    assert %{rows: [[_, new_count]]} = TestRepo.query!(stmt_count_query, [])
     assert new_count == orig_count + 1
   end
 end

--- a/integration_test/myxql/prepare_test.exs
+++ b/integration_test/myxql/prepare_test.exs
@@ -1,5 +1,5 @@
 defmodule Ecto.Integration.PrepareTest do
-  use Ecto.Integration.Case, async: true
+  use Ecto.Integration.Case, async: false
 
   alias Ecto.Integration.TestRepo
   alias Ecto.Integration.Post
@@ -9,17 +9,22 @@ defmodule Ecto.Integration.PrepareTest do
     two = TestRepo.insert!(%Post{title: "two"})
 
     stmt_count_query = "SHOW GLOBAL STATUS LIKE '%prepared_stmt_count%'"
+    assert %{rows: [[orig_count]]} = TestRepo.query(stmt_count_query, [])
 
     # Uncached
     assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
-    assert %{rows: [[0]]} = TestRepo.query(stmt_count_query, [])
+    %{rows: [[new_count]]} = TestRepo.query(stmt_count_query, [])
+    assert new_count == orig_count
     assert TestRepo.all(Post, prepare: :named) == [one, two]
-    assert %{rows: [[1]]} = TestRepo.query(stmt_count_query, [])
+    assert %{rows: [[new_count]]} = TestRepo.query(stmt_count_query, [])
+    assert new_count == orig_count + 1
 
     # Cached
     assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
-    assert %{rows: [[1]]} = TestRepo.query(stmt_count_query, [])
+    assert %{rows: [[new_count]]} = TestRepo.query(stmt_count_query, [])
+    assert new_count == orig_count + 1
     assert TestRepo.all(Post, prepare: :named) == [one, two]
-    assert %{rows: [[1]]} = TestRepo.query(stmt_count_query, [])
+    assert %{rows: [[new_count]]} = TestRepo.query(stmt_count_query, [])
+    assert new_count == orig_count + 1
   end
 end

--- a/integration_test/myxql/prepare_test.exs
+++ b/integration_test/myxql/prepare_test.exs
@@ -9,11 +9,11 @@ defmodule Ecto.Integration.PrepareTest do
   test "prepare option" do
     TestRepo.insert!(%Post{title: "one"})
 
-    stmt_count_query = "SHOW GLOBAL STATUS LIKE '%prepared_stmt_count%'"
-    assert %{rows: [[_, orig_count]]} = TestRepo.query!(stmt_count_query, [])
-    orig_count = String.to_integer(orig_count)
-
     query = from p in Post, select: fragment("'mxql test prepare option'")
+    stmt_count_query = "SHOW GLOBAL STATUS LIKE '%prepared_stmt_count%'"
+
+    %{rows: [[_, orig_count]]} = TestRepo.query!(stmt_count_query, [])
+    orig_count = String.to_integer(orig_count)
 
     # Uncached
     assert TestRepo.all(query, prepare: :unnamed) == ["mxql test prepare option"]

--- a/integration_test/pg/prepare_test.exs
+++ b/integration_test/pg/prepare_test.exs
@@ -8,18 +8,12 @@ defmodule Ecto.Integration.PrepareTest do
     one = TestRepo.insert!(%Post{title: "one"})
     two = TestRepo.insert!(%Post{title: "two"})
 
-    stmt_count_query = "SHOW GLOBAL STATUS LIKE '%prepared_stmt_count%'"
-
     # Uncached
     assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
-    assert %{rows: [[0]]} = TestRepo.query(stmt_count_query, [])
     assert TestRepo.all(Post, prepare: :named) == [one, two]
-    assert %{rows: [[1]]} = TestRepo.query(stmt_count_query, [])
 
     # Cached
     assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
-    assert %{rows: [[1]]} = TestRepo.query(stmt_count_query, [])
     assert TestRepo.all(Post, prepare: :named) == [one, two]
-    assert %{rows: [[1]]} = TestRepo.query(stmt_count_query, [])
   end
 end

--- a/integration_test/pg/prepare_test.exs
+++ b/integration_test/pg/prepare_test.exs
@@ -8,12 +8,18 @@ defmodule Ecto.Integration.PrepareTest do
     one = TestRepo.insert!(%Post{title: "one"})
     two = TestRepo.insert!(%Post{title: "two"})
 
+    stmt_count_query = "SHOW GLOBAL STATUS LIKE '%prepared_stmt_count%'"
+
     # Uncached
     assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
+    assert %{rows: [[0]]} = TestRepo.query(stmt_count_query, [])
     assert TestRepo.all(Post, prepare: :named) == [one, two]
+    assert %{rows: [[1]]} = TestRepo.query(stmt_count_query, [])
 
     # Cached
     assert TestRepo.all(Post, prepare: :unnamed) == [one, two]
+    assert %{rows: [[1]]} = TestRepo.query(stmt_count_query, [])
     assert TestRepo.all(Post, prepare: :named) == [one, two]
+    assert %{rows: [[1]]} = TestRepo.query(stmt_count_query, [])
   end
 end

--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -10,6 +10,13 @@ defmodule Ecto.Adapters.MyXQL do
   below. All options can be given via the repository
   configuration:
 
+      config :your_app, YourApp.Repo,
+        ...
+
+  The `:prepare` option may be specified per operation:
+
+      YourApp.Repo.all(Queryable, prepare: :unnamed)
+
   ### Connection options
 
     * `:protocol` - Set to `:socket` for using UNIX domain socket, or `:tcp` for TCP


### PR DESCRIPTION
This is based on the issue we received in MyXQL about the number of prepared statements growing out of control because of GraphQL type queries. 

We already let Postgres specify this option ([see here](https://github.com/elixir-ecto/ecto_sql/pull/372)). 

I don't remember exactly why we limited to just Postgres. I think it was because we had a strong reason for it (to bypass the generic query plan Postgres creates for prepared statements) and we didn't want to hijack the option names for other adapters. We have a pretty good reason to add it for MyXQL now. WDYT?