### PR TITLE
Add prefix support to renaming indices

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -1195,7 +1195,7 @@ defmodule Ecto.Migration do
   end
 
   def rename(%Index{} = current_index, to: new_name) do
-    Runner.execute({:rename, current_index, new_name})
+    Runner.execute({:rename, __prefix__(current_index), new_name})
     %{current_index | name: new_name}
   end
 

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -821,6 +821,23 @@ defmodule Ecto.MigrationTest do
       assert index.prefix == "baz"
     end
 
+    test "renames an index" do
+      rename index(:people, [:name]), to: "person_names_idx"
+      flush()
+      {_, index, new_name} = last_command()
+      assert new_name == "person_names_idx"
+      assert is_nil(index.prefix)
+    end
+
+    @tag prefix: "foo"
+    test "renames an index with a prefix" do
+      rename index(:people, [:name]), to: "person_names_idx"
+      flush()
+      {_, index, new_name} = last_command()
+      assert new_name == "person_names_idx"
+      assert index.prefix == "foo"
+    end
+
     test "executes a command" do
       execute "SELECT 1", "SELECT 2"
       flush()

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -1021,6 +1021,23 @@ defmodule Ecto.MigrationTest do
       assert {:create, %Index{}} = last_command()
     end
 
+    test "renames an index" do
+      rename index(:people, [:name]), to: "person_names_idx"
+      flush()
+      {_, index, old_name} = last_command()
+      assert old_name == :people_name_index
+      assert is_nil(index.prefix)
+    end
+
+    @tag prefix: "foo"
+    test "renames an index with a prefix" do
+      rename index(:people, [:name]), to: "person_names_idx"
+      flush()
+      {_, index, old_name} = last_command()
+      assert old_name == :people_name_index
+      assert index.prefix == "foo"
+    end
+
     test "drops a constraint" do
       assert_raise Ecto.MigrationError, ~r/cannot reverse migration command/, fn ->
         drop_if_exists constraint(:posts, :price)


### PR DESCRIPTION
Why:
* When using [triplex](https://github.com/ateliware/triplex) or similar
  for multi-tenancy with query prefixes, renaming _tables_ within a
  tenant is supported, but renaming an index was not. For example:

  `rename table(:foo), to: table(:bar)` works
  `rename index(:tablename, [:columns], name: "old_index_name"), to: "new_index_name"` fails

This change addresses the need by:
* Making indices similarly prefix-aware as tables.

Not addressed:
* The type of the value to the `:to` option for `rename/2` varies. When
renaming a table, `:to` expects a `%Table{}`, when renaming an index, a string
is expected.
