### PR TITLE
Update Postgres adapter docs

### DIFF
--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -120,8 +120,7 @@ defmodule Ecto.Adapters.Postgres do
   alongside Ecto, you must define a type module with your extensions.
   Create a new file anywhere in your application with the following:
 
-      Postgrex.Types.define(MyApp.PostgresTypes,
-                            [MyExtension.Foo, MyExtensionBar] ++ Ecto.Adapters.Postgres.extensions())
+      Postgrex.Types.define(MyApp.PostgresTypes, [MyExtension.Foo, MyExtensionBar])
 
   Once your type module is defined, you can configure the repository to use it:
 

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -140,9 +140,7 @@ defmodule Ecto.Adapters.Postgres do
   @default_maintenance_database "postgres"
   @default_prepare_opt :named
 
-  @doc """
-  All Ecto extensions for Postgrex.
-  """
+  @doc false
   def extensions do
     []
   end

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -142,6 +142,13 @@ defmodule Ecto.Adapters.Postgres do
 
   @doc """
   All Ecto extensions for Postgrex.
+
+  Currently Ecto does not define any of its own extensions for Postgrex.
+  If this changes in a future release, you will need to call this function
+  when defining your own custom extensions:
+
+      Postgrex.Types.define(MyApp.PostgresTypes,
+                            [MyExtension.Foo, MyExtensionBar] ++ Ecto.Adapters.Postgres.extensions())
   """
   def extensions do
     []

--- a/lib/ecto/adapters/postgres.ex
+++ b/lib/ecto/adapters/postgres.ex
@@ -140,7 +140,9 @@ defmodule Ecto.Adapters.Postgres do
   @default_maintenance_database "postgres"
   @default_prepare_opt :named
 
-  @doc false
+  @doc """
+  All Ecto extensions for Postgrex.
+  """
   def extensions do
     []
   end


### PR DESCRIPTION
`Ecto.Adapters.Postgres.extensions()` looks to me like a relic from the past that is no longer applicable. But please let me know if I'm missing something.