### PR TITLE
Add support for index directions

### DIFF
--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -1312,10 +1312,33 @@ if Code.ensure_loaded?(MyXQL) do
     defp default_expr(:error),
       do: []
 
+    defp index_expr({dir, literal})
+         when is_binary(literal),
+         do: index_dir(dir, literal)
+
+    defp index_expr({dir, literal}),
+      do: index_dir(dir, quote_name(literal))
+
     defp index_expr(literal) when is_binary(literal),
       do: literal
 
     defp index_expr(literal), do: quote_name(literal)
+
+    defp index_dir(dir, str)
+         when dir in [
+                :asc,
+                :asc_nulls_first,
+                :asc_nulls_last,
+                :desc,
+                :desc_nulls_first,
+                :desc_nulls_last
+              ] do
+      case dir do
+        :asc -> [str | " ASC"]
+        :desc -> [str | " DESC"]
+        _ -> error!(nil, "#{dir} is not supported in indexes in MySQL")
+      end
+    end
 
     defp engine_expr(storage_engine),
       do: [" ENGINE = ", String.upcase(to_string(storage_engine || "INNODB"))]

--- a/lib/ecto/adapters/tds/connection.ex
+++ b/lib/ecto/adapters/tds/connection.ex
@@ -1196,7 +1196,7 @@ if Code.ensure_loaded?(Tds) do
       include =
         index.include
         |> List.wrap()
-        |> Enum.map_intersperse(", ", &index_expr/1)
+        |> Enum.map_intersperse(", ", &include_expr/1)
 
       [
         [
@@ -1570,8 +1570,34 @@ if Code.ensure_loaded?(Tds) do
     defp constraint_name(type, table, name),
       do: quote_name("#{type}_#{table.prefix}_#{table.name}_#{name}")
 
+    defp index_expr({dir, literal})
+         when is_binary(literal),
+         do: index_dir(dir, literal)
+
+    defp index_expr({dir, literal}),
+      do: index_dir(dir, quote_name(literal))
+
     defp index_expr(literal) when is_binary(literal), do: literal
     defp index_expr(literal), do: quote_name(literal)
+
+    defp index_dir(dir, str)
+         when dir in [
+                :asc,
+                :asc_nulls_first,
+                :asc_nulls_last,
+                :desc,
+                :desc_nulls_first,
+                :desc_nulls_last
+              ] do
+      case dir do
+        :asc -> [str | " ASC"]
+        :desc -> [str | " DESC"]
+        _ -> error!(nil, "#{dir} is not supported in indexes in Tds adapter")
+      end
+    end
+
+    defp include_expr(literal) when is_binary(literal), do: literal
+    defp include_expr(literal), do: quote_name(literal)
 
     defp engine_expr(_storage_engine), do: [""]
 

--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -2147,6 +2147,25 @@ defmodule Ecto.Adapters.MyXQLTest do
              ]
   end
 
+  test "create index with direction" do
+    create =
+      {:create, index(:posts, [:category_id, desc: :permalink])}
+
+    assert execute_ddl(create) ==
+             [
+               ~s|CREATE INDEX `posts_category_id_permalink_index` ON `posts` (`category_id`, `permalink` DESC)|
+             ]
+  end
+
+  test "create index with invalid direction" do
+    create =
+      {:create, index(:posts, [:category_id, asc_nulls_first: :permalink])}
+
+    assert_raise ArgumentError, "asc_nulls_first is not supported in indexes in MySQL", fn ->
+      execute_ddl(create)
+    end
+  end
+
   test "create unique index" do
     create = {:create, index(:posts, [:permalink], unique: true)}
 

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -2700,6 +2700,16 @@ defmodule Ecto.Adapters.PostgresTest do
            ]
   end
 
+  test "create index with direction" do
+    create =
+      {:create, index(:posts, [:category_id, desc_nulls_last: :permalink])}
+
+    assert execute_ddl(create) ==
+             [
+               ~s|CREATE INDEX "posts_category_id_permalink_index" ON "posts" ("category_id", "permalink" DESC NULLS LAST)|
+             ]
+  end
+
   test "create unique index" do
     create = {:create, index(:posts, [:permalink], unique: true)}
 

--- a/test/ecto/adapters/tds_test.exs
+++ b/test/ecto/adapters/tds_test.exs
@@ -1856,6 +1856,27 @@ defmodule Ecto.Adapters.TdsTest do
              [~s|CREATE INDEX [posts$main] ON [posts] ([permalink]) WITH(ONLINE=ON);|]
   end
 
+  test "create index with direction" do
+    create =
+      {:create, index(:posts, [:category_id, desc: :permalink])}
+
+    assert execute_ddl(create) ==
+             [
+               ~s|CREATE INDEX [posts_category_id_permalink_index] ON [posts] ([category_id], [permalink] DESC);|
+             ]
+  end
+
+  test "create index with invalid direction" do
+    create =
+      {:create, index(:posts, [:category_id, asc_nulls_first: :permalink])}
+
+    assert_raise ArgumentError,
+                 "asc_nulls_first is not supported in indexes in Tds adapter",
+                 fn ->
+                   execute_ddl(create)
+                 end
+  end
+
   test "create unique index" do
     create = {:create, index(:posts, [:permalink], unique: true)}
 

--- a/test/ecto/migration_test.exs
+++ b/test/ecto/migration_test.exs
@@ -592,6 +592,12 @@ defmodule Ecto.MigrationTest do
       assert {:create, %Index{}} = last_command()
     end
 
+    test "creates an index with desc_nulls_last" do
+      create index(:posts, desc_nulls_last: :title)
+      flush()
+      assert {:create, %Index{}} = last_command()
+    end
+
     test "creates a check constraint" do
       create constraint(:posts, :price, check: "price > 0")
       flush()


### PR DESCRIPTION
As discussed [on the mailing list], this PR add support for specifying the index direction when creating a new index.

[on the mailing list]:
https://groups.google.com/g/elixir-ecto/c/uYFE2evwsW4/m/2q5QwQH2BAAJ

Most of the changes are pretty straightforward, but in the Tds and Postgres adapters, I did have to split up the old `index_expr/1` into two different functions: one to compute the index expression and one to compute the include expression. Previously they shared the same function, but now that the domains of the functions are different I don't think they should.

I also added two more types to `Ecto.Migration` to make sure the type of the `columns` field is correct.

Finally, I chose to ignore the sorting direction when generating the index name, so that functionality also had to be slightly amended.