### PR TITLE
Allow configuring stacktrace for logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         elixirbase:
-          - "1.11.4-erlang-23.3.4.9-alpine-3.16.9"
+          - "1.14.5-erlang-23.3.4.9-alpine-3.16.9"
         postgres:
           - "16.2-alpine"
           - "11.11-alpine"
@@ -61,7 +61,7 @@ jobs:
         pool_count:
           - "1"
         include:
-          - elixirbase: "1.11.4-erlang-23.3.4.9-alpine-3.16.9"
+          - elixirbase: "1.14.5-erlang-23.3.4.9-alpine-3.16.9"
             postgres: "16.2-alpine"
             pool_count: "4"
     steps:
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         elixirbase:
-          - "1.11.4-erlang-23.3.4.9-alpine-3.16.9"
+          - "1.14.5-erlang-23.3.4.9-alpine-3.16.9"
         mysql:
           - "5.7"
           - "8.0"
@@ -96,7 +96,7 @@ jobs:
       fail-fast: false
       matrix:
         elixirbase:
-          - "1.11.4-erlang-23.3.4.9-alpine-3.16.9"
+          - "1.14.5-erlang-23.3.4.9-alpine-3.16.9"
         mssql:
           - "2017"
           - "2019"

--- a/integration_test/sql/logging.exs
+++ b/integration_test/sql/logging.exs
@@ -201,6 +201,8 @@ defmodule Ecto.Integration.LoggingTest do
           TestRepo.insert_all(Logging, source_query, log: :info)
         end)
 
+      IO.inspect(log, label: :log)
+
       param_regex = ~r/\[(?<int>.+), \"(?<uuid>.+)\"\]/
       param_logs = Regex.named_captures(param_regex, log)
 

--- a/integration_test/sql/logging.exs
+++ b/integration_test/sql/logging.exs
@@ -147,7 +147,7 @@ defmodule Ecto.Integration.LoggingTest do
       assert out =~ stacktrace_entry(__ENV__.line - 2)
 
       # We are a bit liberal with what we expect as we don't want to tie to internal ExUnit code
-      assert out =~ ~r/  ↳ ExUnit.CaptureLog.*/
+      assert out =~ ~r/  ExUnit.CaptureLog.*/
     end
 
     test "with custom log level" do

--- a/integration_test/sql/logging.exs
+++ b/integration_test/sql/logging.exs
@@ -138,11 +138,9 @@ defmodule Ecto.Integration.LoggingTest do
                :ok
              end) =~ stacktrace_entry(__ENV__.line)
 
-      # Bigger stacktrace size
-      # This fails because we don't receive per-query :stacktrace ecto-sql side,
-      # only the global config from adapter_meta
+      # Requires upstream change in Ecto to pass
       out = capture_log(fn ->
-               TestRepo.all(Post, Keyword.put(@stacktrace_opts, :stacktrace, 2))
+               TestRepo.all(Post, Keyword.put(@stacktrace_opts, :stacktrace, {Ecto.Adapters.SQL, :last_non_ecto, [2]}))
 
                :ok
              end)
@@ -200,8 +198,6 @@ defmodule Ecto.Integration.LoggingTest do
         capture_log(fn ->
           TestRepo.insert_all(Logging, source_query, log: :info)
         end)
-
-      IO.inspect(log, label: :log)
 
       param_regex = ~r/\[(?<int>.+), \"(?<uuid>.+)\"\]/
       param_logs = Regex.named_captures(param_regex, log)

--- a/integration_test/sql/logging.exs
+++ b/integration_test/sql/logging.exs
@@ -137,6 +137,18 @@ defmodule Ecto.Integration.LoggingTest do
 
                :ok
              end) =~ stacktrace_entry(__ENV__.line)
+
+      # Bigger stacktrace size
+      # This fails because we don't receive per-query :stacktrace ecto-sql side,
+      # only the global config from adapter_meta
+      out = capture_log(fn ->
+               TestRepo.all(Post, Keyword.put(@stacktrace_opts, :stacktrace, 2))
+
+               :ok
+             end)
+
+      assert out =~ stacktrace_entry(__ENV__.line - 2)
+      assert out =~ ~r/  ↳ ExUnit.CaptureLog.with_log\/2, at: lib\/ex_unit\/capture_log.ex:113/
     end
 
     test "with custom log level" do

--- a/integration_test/sql/logging.exs
+++ b/integration_test/sql/logging.exs
@@ -145,7 +145,9 @@ defmodule Ecto.Integration.LoggingTest do
              end)
 
       assert out =~ stacktrace_entry(__ENV__.line - 2)
-      assert out =~ ~r/  ↳ ExUnit.CaptureLog.with_log\/2, at: lib\/ex_unit\/capture_log.ex:113/
+
+      # We are a bit liberal with what we expect as we don't want to tie to internal ExUnit code
+      assert out =~ ~r/  ↳ ExUnit.CaptureLog.*/
     end
 
     test "with custom log level" do

--- a/integration_test/sql/logging.exs
+++ b/integration_test/sql/logging.exs
@@ -138,7 +138,6 @@ defmodule Ecto.Integration.LoggingTest do
                :ok
              end) =~ stacktrace_entry(__ENV__.line)
 
-      # Requires upstream change in Ecto to pass
       out = capture_log(fn ->
                TestRepo.all(Post, Keyword.put(@stacktrace_opts, :log_stacktrace_mfa, {Ecto.Adapters.SQL, :last_non_ecto_stacktrace, [2]}))
 

--- a/integration_test/sql/logging.exs
+++ b/integration_test/sql/logging.exs
@@ -139,7 +139,7 @@ defmodule Ecto.Integration.LoggingTest do
              end) =~ stacktrace_entry(__ENV__.line)
 
       out = capture_log(fn ->
-               TestRepo.all(Post, Keyword.put(@stacktrace_opts, :log_stacktrace_mfa, {Ecto.Adapters.SQL, :last_non_ecto_stacktrace, [2]}))
+               TestRepo.all(Post, Keyword.put(@stacktrace_opts, :log_stacktrace_mfa, {Ecto.Adapters.SQL, :first_non_ecto_stacktrace, [2]}))
 
                :ok
              end)

--- a/integration_test/sql/logging.exs
+++ b/integration_test/sql/logging.exs
@@ -140,7 +140,7 @@ defmodule Ecto.Integration.LoggingTest do
 
       # Requires upstream change in Ecto to pass
       out = capture_log(fn ->
-               TestRepo.all(Post, Keyword.put(@stacktrace_opts, :log_stacktrace_mfa, {Ecto.Adapters.SQL, :last_non_ecto, [2]}))
+               TestRepo.all(Post, Keyword.put(@stacktrace_opts, :log_stacktrace_mfa, {Ecto.Adapters.SQL, :last_non_ecto_stacktrace, [2]}))
 
                :ok
              end)

--- a/integration_test/sql/logging.exs
+++ b/integration_test/sql/logging.exs
@@ -140,7 +140,7 @@ defmodule Ecto.Integration.LoggingTest do
 
       # Requires upstream change in Ecto to pass
       out = capture_log(fn ->
-               TestRepo.all(Post, Keyword.put(@stacktrace_opts, :stacktrace, {Ecto.Adapters.SQL, :last_non_ecto, [2]}))
+               TestRepo.all(Post, Keyword.put(@stacktrace_opts, :log_stacktrace_mfa, {Ecto.Adapters.SQL, :last_non_ecto, [2]}))
 
                :ok
              end)

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1355,9 +1355,7 @@ defmodule Ecto.Adapters.SQL do
     end
   end
 
-  defp log_stacktrace([], _, _), do: []
-
-  defp log_stacktrace(stacktrace, repo, size) do
+  defp log_stacktrace([_ | _] = stacktrace, repo, size) do
     for {{module, function, arity, info}, idx} <- Enum.with_index(last_non_ecto(Enum.reverse(stacktrace), repo, size)) do
       [
         ?\n,
@@ -1370,6 +1368,8 @@ defmodule Ecto.Adapters.SQL do
       ]
     end
   end
+
+  defp log_stacktrace(_, _, _), do: []
 
   defp log_stacktrace_info([file: file, line: line] ++ _) do
     [", at: ", file, ?:, Integer.to_string(line)]

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1320,7 +1320,7 @@ defmodule Ecto.Adapters.SQL do
               log_params,
               result,
               stacktrace,
-              stacktrace_mfa(log_stacktrace_mfa, opts)
+              opts[:log_stacktrace_mfa] || log_stacktrace_mfa
             )
           end,
           ansi_color: sql_color(query)
@@ -1338,7 +1338,7 @@ defmodule Ecto.Adapters.SQL do
               log_params,
               result,
               stacktrace,
-              stacktrace_mfa(log_stacktrace_mfa, opts)
+              opts[:log_stacktrace_mfa] || log_stacktrace_mfa
             )
           end,
           ansi_color: sql_color(query)
@@ -1346,16 +1346,6 @@ defmodule Ecto.Adapters.SQL do
     end
 
     :ok
-  end
-
-  defp stacktrace_mfa(log_stacktrace_mfa, opts) do
-    case Keyword.get(opts, :log_stacktrace_mfa) do
-      {_, _, _} = mfa ->
-        mfa
-
-      _ ->
-        log_stacktrace_mfa
-    end
   end
 
   defp log_measurements([{_, nil} | rest], total, acc),

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1357,7 +1357,7 @@ defmodule Ecto.Adapters.SQL do
   defp log_measurements([], total, acc),
     do: Map.new([total_time: total] ++ acc)
 
-  defp log_iodata(measurements, repo, source, query, params, result, stacktrace, stacktrace_size) do
+  defp log_iodata(measurements, repo, source, query, params, result, stacktrace, stacktrace_mfa) do
     [
       "QUERY",
       ?\s,
@@ -1371,7 +1371,7 @@ defmodule Ecto.Adapters.SQL do
       query,
       ?\s,
       inspect(params, charlists: false),
-      log_stacktrace(stacktrace, repo, stacktrace_size)
+      log_stacktrace(stacktrace, repo, stacktrace_mfa)
     ]
   end
 

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1438,19 +1438,21 @@ defmodule Ecto.Adapters.SQL do
         ) :: Exception.stacktrace()
   def first_non_ecto_stacktrace(stacktrace, %{repo: repo}, size) do
     stacktrace
+    |> first_non_ecto_entries(repo, size, size, [])
     |> Enum.reverse()
-    |> last_non_ecto_entries(repo, [])
-    |> Enum.take(size)
   end
 
-  defp last_non_ecto_entries([{mod, _, _, _} | _], repo, acc)
+  defp first_non_ecto_entries([{mod, _, _, _} | rest], repo, size, _, _)
        when mod == repo or mod in @repo_modules,
-       do: acc
+       do: first_non_ecto_entries(rest, repo, size, size, [])
 
-  defp last_non_ecto_entries([entry | rest], repo, acc),
-    do: last_non_ecto_entries(rest, repo, [entry | acc])
+  defp first_non_ecto_entries([_ | rest], repo, size, 0, acc),
+    do: first_non_ecto_entries(rest, repo, size, 0, acc)
 
-  defp last_non_ecto_entries([], _, acc), do: acc
+  defp first_non_ecto_entries([], _, _, _, acc), do: acc
+
+  defp first_non_ecto_entries([entry | rest], repo, size, pending, acc),
+    do: first_non_ecto_entries(rest, repo, size, pending - 1, [entry | acc])
 
   ## Connection helpers
 

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -861,7 +861,7 @@ defmodule Ecto.Adapters.SQL do
     end
 
     log = Keyword.get(config, :log, :debug)
-    log_stacktrace_mfa = Keyword.get(config, :log_stacktrace_mfa, {__MODULE__, :last_non_ecto, [1]})
+    log_stacktrace_mfa = Keyword.get(config, :log_stacktrace_mfa, {__MODULE__, :last_non_ecto_stacktrace, [1]})
 
     if log not in @valid_log_levels do
       raise """
@@ -1392,7 +1392,7 @@ defmodule Ecto.Adapters.SQL do
 
   @repo_modules [Ecto.Repo.Queryable, Ecto.Repo.Schema, Ecto.Repo.Transaction]
 
-  def last_non_ecto(size, stacktrace, repo) do
+  def last_non_ecto_stacktrace(size, stacktrace, repo) do
     stacktrace
     |> last_non_ecto_entries(repo, [])
     |> Enum.take(size)

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1405,8 +1405,7 @@ defmodule Ecto.Adapters.SQL do
       [
         ?\n,
         IO.ANSI.light_black(),
-        List.duplicate(?\s, 2 * idx),
-        "↳ ",
+        if(idx == 0, do: "↳ ", else: "  "),
         Exception.format_mfa(module, function, arity),
         log_stacktrace_info(info),
         IO.ANSI.reset()

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1399,7 +1399,7 @@ defmodule Ecto.Adapters.SQL do
   end
 
   defp log_stacktrace([_ | _] = stacktrace, repo, {module, function, args}) do
-    entries = apply(module, function, [stacktrace, repo | args])
+    entries = apply(module, function, [stacktrace, %{repo: repo} | args])
 
     Enum.with_index(entries, fn {module, function, arity, info}, idx ->
       [
@@ -1431,9 +1431,12 @@ defmodule Ecto.Adapters.SQL do
   This function is used by default in the `:log_stacktrace_mfa` config, with
   a size of 1.
   """
-  @spec first_non_ecto_stacktrace(Exception.stacktrace(), Ecto.Repo.t(), non_neg_integer()) ::
-          Exception.stacktrace()
-  def first_non_ecto_stacktrace(stacktrace, repo, size) do
+  @spec first_non_ecto_stacktrace(
+          Exception.stacktrace(),
+          %{repo: Ecto.Repo.t()},
+          non_neg_integer()
+        ) :: Exception.stacktrace()
+  def first_non_ecto_stacktrace(stacktrace, %{repo: repo}, size) do
     stacktrace
     |> Enum.reverse()
     |> last_non_ecto_entries(repo, [])

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -658,9 +658,15 @@ defmodule Ecto.Adapters.SQL do
     sql_call(adapter_meta, :query_many, [sql], params, opts)
   end
 
-
   defp sql_call(adapter_meta, callback, args, params, opts) do
-    %{pid: pool, telemetry: telemetry, sql: sql, opts: default_opts, log_stacktrace_mfa: log_stacktrace_mfa} = adapter_meta
+    %{
+      pid: pool,
+      telemetry: telemetry,
+      sql: sql,
+      opts: default_opts,
+      log_stacktrace_mfa: log_stacktrace_mfa
+    } = adapter_meta
+
     conn = get_conn_or_pool(pool, adapter_meta)
     opts = with_log(telemetry, log_stacktrace_mfa, params, opts ++ default_opts)
     args = args ++ [params, opts]
@@ -861,7 +867,9 @@ defmodule Ecto.Adapters.SQL do
     end
 
     log = Keyword.get(config, :log, :debug)
-    log_stacktrace_mfa = Keyword.get(config, :log_stacktrace_mfa, {__MODULE__, :last_non_ecto_stacktrace, [1]})
+
+    log_stacktrace_mfa =
+      Keyword.get(config, :log_stacktrace_mfa, {__MODULE__, :last_non_ecto_stacktrace, [1]})
 
     if log not in @valid_log_levels do
       raise """
@@ -1100,7 +1108,14 @@ defmodule Ecto.Adapters.SQL do
 
   @doc false
   def reduce(adapter_meta, statement, params, opts, acc, fun) do
-    %{pid: pool, telemetry: telemetry, sql: sql, log_stacktrace_mfa: log_stacktrace_mfa, opts: default_opts} = adapter_meta
+    %{
+      pid: pool,
+      telemetry: telemetry,
+      sql: sql,
+      log_stacktrace_mfa: log_stacktrace_mfa,
+      opts: default_opts
+    } = adapter_meta
+
     opts = with_log(telemetry, log_stacktrace_mfa, params, opts ++ default_opts)
 
     case get_conn(pool) do
@@ -1116,7 +1131,14 @@ defmodule Ecto.Adapters.SQL do
 
   @doc false
   def into(adapter_meta, statement, params, opts) do
-    %{pid: pool, telemetry: telemetry, sql: sql, opts: default_opts, log_stacktrace_mfa: log_stacktrace_mfa} = adapter_meta
+    %{
+      pid: pool,
+      telemetry: telemetry,
+      sql: sql,
+      opts: default_opts,
+      log_stacktrace_mfa: log_stacktrace_mfa
+    } = adapter_meta
+
     opts = with_log(telemetry, log_stacktrace_mfa, params, opts ++ default_opts)
 
     case get_conn(pool) do
@@ -1289,14 +1311,36 @@ defmodule Ecto.Adapters.SQL do
       {true, level} ->
         Logger.log(
           level,
-          fn -> log_iodata(measurements, repo, source, query, log_params, result, stacktrace, stacktrace_mfa(log_stacktrace_mfa, opts)) end,
+          fn ->
+            log_iodata(
+              measurements,
+              repo,
+              source,
+              query,
+              log_params,
+              result,
+              stacktrace,
+              stacktrace_mfa(log_stacktrace_mfa, opts)
+            )
+          end,
           ansi_color: sql_color(query)
         )
 
       {opts_level, args_level} ->
         Logger.log(
           opts_level || args_level,
-          fn -> log_iodata(measurements, repo, source, query, log_params, result, stacktrace, stacktrace_mfa(log_stacktrace_mfa, opts)) end,
+          fn ->
+            log_iodata(
+              measurements,
+              repo,
+              source,
+              query,
+              log_params,
+              result,
+              stacktrace,
+              stacktrace_mfa(log_stacktrace_mfa, opts)
+            )
+          end,
           ansi_color: sql_color(query)
         )
     end
@@ -1398,14 +1442,21 @@ defmodule Ecto.Adapters.SQL do
     |> Enum.take(size)
   end
 
-  defp last_non_ecto_entries([{mod, _, _, _} | _], repo, acc) when mod == repo or mod in @repo_modules, do: acc
-  defp last_non_ecto_entries([entry | rest], repo, acc), do: last_non_ecto_entries(rest, repo, [entry | acc])
+  defp last_non_ecto_entries([{mod, _, _, _} | _], repo, acc)
+       when mod == repo or mod in @repo_modules,
+       do: acc
+
+  defp last_non_ecto_entries([entry | rest], repo, acc),
+    do: last_non_ecto_entries(rest, repo, [entry | acc])
+
   defp last_non_ecto_entries([], _, acc), do: acc
 
   ## Connection helpers
 
   defp checkout_or_transaction(fun, adapter_meta, opts, callback) do
-    %{pid: pool, telemetry: telemetry, opts: default_opts, log_stacktrace_mfa: log_stacktrace_mfa} = adapter_meta
+    %{pid: pool, telemetry: telemetry, opts: default_opts, log_stacktrace_mfa: log_stacktrace_mfa} =
+      adapter_meta
+
     opts = with_log(telemetry, log_stacktrace_mfa, [], opts ++ default_opts)
 
     callback = fn conn ->

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1428,7 +1428,7 @@ defmodule Ecto.Adapters.SQL do
   @doc """
   Receives a stacktrace, and return the first N items before Ecto entries
 
-  This function is used by default in the `:log_stacktrace_info` config, with
+  This function is used by default in the `:log_stacktrace_mfa` config, with
   a size of 1.
   """
   @spec first_non_ecto_stacktrace(Exception.stacktrace(), Ecto.Repo.t(), non_neg_integer()) ::

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1438,21 +1438,19 @@ defmodule Ecto.Adapters.SQL do
         ) :: Exception.stacktrace()
   def first_non_ecto_stacktrace(stacktrace, %{repo: repo}, size) do
     stacktrace
-    |> first_non_ecto_entries(repo, size, size, [])
     |> Enum.reverse()
+    |> last_non_ecto_entries(repo, [])
+    |> Enum.take(size)
   end
 
-  defp first_non_ecto_entries([{mod, _, _, _} | rest], repo, size, _, _)
+  defp last_non_ecto_entries([{mod, _, _, _} | _], repo, acc)
        when mod == repo or mod in @repo_modules,
-       do: first_non_ecto_entries(rest, repo, size, size, [])
+       do: acc
 
-  defp first_non_ecto_entries([_ | rest], repo, size, 0, acc),
-    do: first_non_ecto_entries(rest, repo, size, 0, acc)
+  defp last_non_ecto_entries([entry | rest], repo, acc),
+    do: last_non_ecto_entries(rest, repo, [entry | acc])
 
-  defp first_non_ecto_entries([], _, _, _, acc), do: acc
-
-  defp first_non_ecto_entries([entry | rest], repo, size, pending, acc),
-    do: first_non_ecto_entries(rest, repo, size, pending - 1, [entry | acc])
+  defp last_non_ecto_entries([], _, acc), do: acc
 
   ## Connection helpers
 

--- a/lib/ecto/adapters/sql.ex
+++ b/lib/ecto/adapters/sql.ex
@@ -1425,6 +1425,14 @@ defmodule Ecto.Adapters.SQL do
 
   @repo_modules [Ecto.Repo.Queryable, Ecto.Repo.Schema, Ecto.Repo.Transaction]
 
+  @doc """
+  Receives a stacktrace, and return the first N items before Ecto entries
+
+  This function is used by default in the `:log_stacktrace_info` config, with
+  a size of 1.
+  """
+  @spec first_non_ecto_stacktrace(Exception.stacktrace(), Ecto.Repo.t(), non_neg_integer()) ::
+          Exception.stacktrace()
   def first_non_ecto_stacktrace(stacktrace, repo, size) do
     stacktrace
     |> Enum.reverse()

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule EctoSQL.MixProject do
     [
       app: :ecto_sql,
       version: @version,
-      elixir: "~> 1.11",
+      elixir: "~> 1.14",
       deps: deps(),
       test_paths: test_paths(System.get_env("ECTO_ADAPTER")),
       xref: [


### PR DESCRIPTION
<details>
   <summary>Click to expand old description</summary>
A lot of times, more stack items can be helpful in identifying the source of a query.

This PR demonstrates how we can support it. But the API has problems:

1. the `:stacktrace` option is used not only by logging but also for general telemetry events. Making it an integer doesn't make sense for telemetry (as the full stacktrace is published there anyway).

2. the `:stacktrace` option is overriden Ecto-side, so Ecto.SQL can't accept integers on a per-query basis, only on global configuration.
</details>

Adds a new option `:log_stacktrace_mfa` that can be used at configuration level or query level (like `:log`, or `:stacktrace`). This config allows filtering/prepping the stacktrace-derived data displayed in the logs. For example, one may want to filter other modules other than those that Ecto.SQL filters by default, or maybe just include more stack items. 

Sample usage:

```elixir
# Using a custom function
config :my_app, MyApp.Repo, stacktrace: true, log_stacktrace_mfa: {MyApp.Utils, :prepare_ecto_stacktrace, []}

# Using the default one, with an increased stacktrace size to 3
config :my_app, MyApp.Repo, stacktrace: true, log_stacktrace_mfa: {Ecto.Adapters.SQL, :first_non_ecto_stacktrace, [3]}
```