### PR TITLE
Upgrade Ubuntu Runner + MSSQL Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: unittest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       MIX_ENV: test
     strategy:
@@ -47,7 +47,7 @@ jobs:
 
   test-postgres:
     name: postgres integration test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -74,7 +74,7 @@ jobs:
 
   test-mysql:
     name: mysql integration test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -91,15 +91,15 @@ jobs:
 
   test-mssql:
     name: mssql integration test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         elixirbase:
           - "1.14.5-erlang-23.3.4.9-alpine-3.16.9"
         mssql:
-          - "2017"
           - "2019"
+          - "2022"
     steps:
       - uses: earthly/actions-setup@v1
       - uses: actions/checkout@v3


### PR DESCRIPTION
While looking into the Ecto runner errors I saw we are having problems with Ubuntu > 20.04 with SQL Server 2017. When debugging the CI the errors were really low level like the database application was looking for files on the system that did not exist. 

Although the exact reasons are beyond me, I have noticed these kinds of errors in the past when there is an OS incompatibility. And looking at SQL Server 2017 support, it seems it's only up to 18.04: https://learn.microsoft.com/en-us/sql/linux/sql-server-linux-release-notes-2017?view=sql-server-ver16#supported-platforms. So it's just a matter of luck until a breaking change happens. And I guess it happened now.

For this reason I got rid of 2017 from the CI and added 2022 and everything is working nicely.