### PR TITLE
Correctly handle generated array columns

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -1750,8 +1750,10 @@ if Code.ensure_loaded?(Postgrex) do
     defp options_expr(options),
       do: [?\s, options]
 
-    defp column_type({:array, type}, opts),
-      do: [column_type(type, opts), "[]"]
+    defp column_type({:array, type}, opts) do
+      [type, opts] = column_type(type, opts)
+      [type, "[]", opts]
+    end
 
     defp column_type(type, opts) when type in ~w(time utc_datetime naive_datetime)a do
       generated = Keyword.get(opts, :generated)

--- a/test/ecto/adapters/postgres_test.exs
+++ b/test/ecto/adapters/postgres_test.exs
@@ -2331,12 +2331,13 @@ defmodule Ecto.Adapters.PostgresTest do
             primary_key: true,
             generated: "ALWAYS AS IDENTITY (MINVALUE  0 START WITH 0 INCREMENT BY 1)"
           ]},
-         {:add, :id_str, :string, [generated: ~s|ALWAYS AS (id) STORED|]}
+         {:add, :id_str, :string, [generated: ~s|ALWAYS AS (id) STORED|]},
+         {:add, :tags, {:array, :text}, [generated: ~s|ALWAYS AS (ARRAY['foo','bar']) STORED|]}
        ]}
 
     assert execute_ddl(create) == [
              """
-             CREATE TABLE "posts" ("id" integer GENERATED ALWAYS AS IDENTITY (MINVALUE  0 START WITH 0 INCREMENT BY 1), "id_str" varchar(255) GENERATED ALWAYS AS (id) STORED, PRIMARY KEY ("id"))
+             CREATE TABLE "posts" ("id" integer GENERATED ALWAYS AS IDENTITY (MINVALUE  0 START WITH 0 INCREMENT BY 1), "id_str" varchar(255) GENERATED ALWAYS AS (id) STORED, \"tags\" text[] GENERATED ALWAYS AS (ARRAY['foo','bar']) STORED, PRIMARY KEY ("id"))
              """
              |> remove_newlines
            ]


### PR DESCRIPTION
Currently, 
```elixir
alter table(:my_table) do
  add :generated_array, {:array, :text}, generated: "always as (existing_array::text[]) stored"
end
```
produces
```sql
ALTER TABLE "my_table" ADD COLUMN "generated_array" text GENERATED always as (existing_array::text[]) stored[]
```
with the `[]` after the GENERATED statement instead of being part of the type definition.

I’m making the assumption that `column_type/2` always returns a two element list (all tests currently pass)