### PR TITLE
Add support in migrations for collations in Postgres

### DIFF
--- a/integration_test/myxql/migrations_test.exs
+++ b/integration_test/myxql/migrations_test.exs
@@ -29,6 +29,42 @@ defmodule Ecto.Integration.MigrationsTest do
     end
   end
 
+  text_variants = ~w/tinytext text mediumtext longtext/a
+  @text_variants text_variants
+
+  collation = "utf8mb4_bin"
+  @collation collation
+
+  defmodule CollateMigration do
+    use Ecto.Migration
+
+    @text_variants text_variants
+    @collation collation
+
+    def change do
+      create table(:collate_reference) do
+        add :name, :string, collation: @collation
+      end
+
+      create unique_index(:collate_reference, :name)
+
+      create table(:collate) do
+        add :string, :string, collation: @collation
+        add :varchar, :varchar, size: 255, collation: @collation
+        add :integer, :integer, collation: @collation
+        add :name_string, references(:collate_reference, type: :string, column: :name), collation: @collation
+
+        for type <- @text_variants do
+          add type, type, collation: @collation
+        end
+      end
+
+      alter table(:collate) do
+        modify :string, :string, collation: "utf8mb4_general_ci"
+      end
+    end
+  end
+
   describe "Migrator" do
     @get_lock_command ~s[SELECT GET_LOCK('ecto_Ecto.Integration.PoolRepo', -1)]
     @release_lock_command ~s[SELECT RELEASE_LOCK('ecto_Ecto.Integration.PoolRepo')]
@@ -106,6 +142,31 @@ defmodule Ecto.Integration.MigrationsTest do
         end)
 
       assert log =~ "ALTER TABLE `alter_table` ADD `column2` varchar(255) COMMENT 'second column' AFTER `column1`"
+    end
+
+    test "collation can be set on a column" do
+      num = @base_migration + System.unique_integer([:positive])
+      assert :ok = Ecto.Migrator.up(PoolRepo, num, CollateMigration, log: false)
+      query = fn column -> """
+        SELECT collation_name
+        FROM information_schema.columns
+        WHERE table_name = 'collate' AND column_name = '#{column}';
+      """
+      end
+
+      assert %{
+        rows: [["utf8mb4_general_ci"]]
+      } = Ecto.Adapters.SQL.query!(PoolRepo, query.("string"), [])
+
+      for type <- ~w/text name_string/ ++ @text_variants do
+        assert %{
+          rows: [[@collation]]
+        } = Ecto.Adapters.SQL.query!(PoolRepo, query.(type), [])
+      end
+
+      assert %{
+        rows: [[nil]]
+      } = Ecto.Adapters.SQL.query!(PoolRepo, query.("integer"), [])
     end
   end
 end

--- a/integration_test/myxql/migrations_test.exs
+++ b/integration_test/myxql/migrations_test.exs
@@ -51,7 +51,6 @@ defmodule Ecto.Integration.MigrationsTest do
       create table(:collate) do
         add :string, :string, collation: @collation
         add :varchar, :varchar, size: 255, collation: @collation
-        add :integer, :integer, collation: @collation
         add :name_string, references(:collate_reference, type: :string, column: :name), collation: @collation
 
         for type <- @text_variants do
@@ -163,10 +162,6 @@ defmodule Ecto.Integration.MigrationsTest do
           rows: [[@collation]]
         } = Ecto.Adapters.SQL.query!(PoolRepo, query.(type), [])
       end
-
-      assert %{
-        rows: [[nil]]
-      } = Ecto.Adapters.SQL.query!(PoolRepo, query.("integer"), [])
     end
   end
 end

--- a/integration_test/pg/migrations_test.exs
+++ b/integration_test/pg/migrations_test.exs
@@ -65,7 +65,6 @@ defmodule Ecto.Integration.MigrationsTest do
           add type, type, collation: @collation
         end
 
-        add :integer, :integer, collation: @collation
         add :name_string, references(:collate_reference, type: :string, column: :name),  collation: @collation
       end
 
@@ -202,10 +201,6 @@ defmodule Ecto.Integration.MigrationsTest do
           rows: [[@collation]]
         } = Ecto.Adapters.SQL.query!(PoolRepo, query.(type), [])
       end
-     
-      assert %{
-        rows: [[nil]]
-      } = Ecto.Adapters.SQL.query!(PoolRepo, query.("integer"), [])
     end
   end
 end

--- a/integration_test/pg/migrations_test.exs
+++ b/integration_test/pg/migrations_test.exs
@@ -40,6 +40,41 @@ defmodule Ecto.Integration.MigrationsTest do
     end
   end
 
+  collation = "POSIX"
+  @collation collation
+
+  text_types = ~w/char varchar text/a
+  @text_types text_types
+
+  defmodule CollateMigration do
+    use Ecto.Migration
+
+    @collation collation
+    @text_types text_types
+
+    def change do
+      create table(:collate_reference) do
+        add :name, :string, primary_key: true, collation: @collation
+      end
+
+      create unique_index(:collate_reference, :name)
+
+      create table(:collate) do
+        add :string, :string, collation: @collation
+        for type <- @text_types do
+          add type, type, collation: @collation
+        end
+
+        add :integer, :integer, collation: @collation
+        add :name_string, references(:collate_reference, type: :string, column: :name),  collation: @collation
+      end
+
+      alter table(:collate) do
+        modify :string, :string, collation: "C"
+      end
+    end
+  end
+
   test "logs Postgres notice messages" do
     log =
       capture_log(fn ->
@@ -144,6 +179,33 @@ defmodule Ecto.Integration.MigrationsTest do
       assert down_log =~ @drop_table_log
       refute down_log =~ @version_delete
       refute down_log =~ "commit []"
+    end
+
+    test "collation can be set on a column" do
+      num = @base_migration + System.unique_integer([:positive])
+
+      assert :ok = Ecto.Migrator.up(PoolRepo, num, CollateMigration, log: :info)
+
+      query = fn column -> """
+        SELECT collation_name
+        FROM information_schema.columns
+        WHERE table_name = 'collate' AND column_name = '#{column}';
+      """
+      end
+
+      assert %{
+        rows: [["C"]]
+      } = Ecto.Adapters.SQL.query!(PoolRepo, query.("string"), [])
+
+      for type <- @text_types do
+        assert %{
+          rows: [[@collation]]
+        } = Ecto.Adapters.SQL.query!(PoolRepo, query.(type), [])
+      end
+     
+      assert %{
+        rows: [[nil]]
+      } = Ecto.Adapters.SQL.query!(PoolRepo, query.("integer"), [])
     end
   end
 end

--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -463,7 +463,6 @@ defmodule Ecto.Integration.MigrationTest do
     end
   end
 
-  
   import Ecto.Query, only: [from: 2]
   import Ecto.Migrator, only: [up: 4, down: 4]
 

--- a/integration_test/sql/migration.exs
+++ b/integration_test/sql/migration.exs
@@ -463,6 +463,7 @@ defmodule Ecto.Integration.MigrationTest do
     end
   end
 
+  
   import Ecto.Query, only: [from: 2]
   import Ecto.Migrator, only: [up: 4, down: 4]
 

--- a/integration_test/tds/migrations_test.exs
+++ b/integration_test/tds/migrations_test.exs
@@ -37,7 +37,6 @@ defmodule Ecto.Integration.MigrationsTest do
         add :nvarchar, :nvarchar, size: 255, collation: @collation
         add :text, :text,  collation: @collation
         add :ntext, :ntext, collation: @collation
-        add :integer, :integer, collation: @collation
         add :name_string, references(:collate_reference, type: :string, column: :name), collation: @collation
       end
 
@@ -130,10 +129,6 @@ defmodule Ecto.Integration.MigrationsTest do
           rows: [[@collation]]
         } = Ecto.Adapters.SQL.query!(PoolRepo, query.(type), [])
       end
-
-      assert %{
-        rows: [[nil]]
-      } = Ecto.Adapters.SQL.query!(PoolRepo, query.("integer"), [])
     end
   end
 end

--- a/lib/ecto/adapters/myxql/connection.ex
+++ b/lib/ecto/adapters/myxql/connection.ex
@@ -1171,13 +1171,13 @@ if Code.ensure_loaded?(MyXQL) do
         quote_name(name),
         ?\s,
         reference_column_type(ref.type, opts),
-        column_options(ref.type, opts),
+        column_options(opts),
         reference_expr(ref, table, name)
       ]
     end
 
     defp column_definition(_table, {:add, name, type, opts}) do
-      [quote_name(name), ?\s, column_type(type, opts), column_options(type, opts)]
+      [quote_name(name), ?\s, column_type(type, opts), column_options(opts)]
     end
 
     defp column_changes(table, columns) do
@@ -1194,13 +1194,13 @@ if Code.ensure_loaded?(MyXQL) do
         quote_name(name),
         ?\s,
         reference_column_type(ref.type, opts),
-        column_options(ref.type, opts),
+        column_options(opts),
         constraint_expr(ref, table, name)
       ]
     end
 
     defp column_change(_table, {:add, name, type, opts}) do
-      ["ADD ", quote_name(name), ?\s, column_type(type, opts), column_options(type, opts)]
+      ["ADD ", quote_name(name), ?\s, column_type(type, opts), column_options(opts)]
     end
 
     defp column_change(table, {:add_if_not_exists, name, %Reference{} = ref, opts}) do
@@ -1209,7 +1209,7 @@ if Code.ensure_loaded?(MyXQL) do
         quote_name(name),
         ?\s,
         reference_column_type(ref.type, opts),
-        column_options(ref.type, opts),
+        column_options(opts),
         constraint_if_not_exists_expr(ref, table, name)
       ]
     end
@@ -1220,7 +1220,7 @@ if Code.ensure_loaded?(MyXQL) do
         quote_name(name),
         ?\s,
         column_type(type, opts),
-        column_options(type, opts)
+        column_options(opts)
       ]
     end
 
@@ -1231,7 +1231,7 @@ if Code.ensure_loaded?(MyXQL) do
         quote_name(name),
         ?\s,
         reference_column_type(ref.type, opts),
-        column_options(ref.type, opts),
+        column_options(opts),
         constraint_expr(ref, table, name)
       ]
     end
@@ -1243,7 +1243,7 @@ if Code.ensure_loaded?(MyXQL) do
         quote_name(name),
         ?\s,
         column_type(type, opts),
-        column_options(type, opts)
+        column_options(opts)
       ]
     end
 
@@ -1265,7 +1265,7 @@ if Code.ensure_loaded?(MyXQL) do
     defp column_change(_table, {:remove_if_exists, name}),
       do: ["DROP IF EXISTS ", quote_name(name)]
 
-    defp column_options(type, opts) do
+    defp column_options(opts) do
       default = Keyword.fetch(opts, :default)
       null = Keyword.get(opts, :null)
       after_column = Keyword.get(opts, :after)
@@ -1274,7 +1274,7 @@ if Code.ensure_loaded?(MyXQL) do
 
       [
         default_expr(default),
-        collation_expr(collation, type),
+        collation_expr(collation),
         null_expr(null),
         comment_expr(comment),
         after_expr(after_column)
@@ -1299,12 +1299,8 @@ if Code.ensure_loaded?(MyXQL) do
     defp null_expr(true), do: " NULL"
     defp null_expr(_), do: []
 
-    defp collation_expr({:ok, collation_name}, text_type)
-         when text_type in ~w/string char varchar text tinytext mediumtext longtext/a do
-      " COLLATE \"#{collation_name}\""
-    end
-
-    defp collation_expr(_, _), do: []
+    defp collation_expr({:ok, collation_name}), do: " COLLATE \"#{collation_name}\""
+    defp collation_expr(_), do: []
 
     defp new_constraint_expr(%Constraint{check: check} = constraint) when is_binary(check) do
       [

--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -1567,7 +1567,7 @@ if Code.ensure_loaded?(Postgrex) do
         reference_expr(ref, table, name),
         modify_null(name, opts),
         modify_default(name, ref.type, opts),
-        collation_expr(collation, ref.type)
+        collation_expr(collation)
       ]
     end
 
@@ -1582,7 +1582,7 @@ if Code.ensure_loaded?(Postgrex) do
         column_type(type, opts),
         modify_null(name, opts),
         modify_default(name, type, opts),
-        collation_expr(collation, type)
+        collation_expr(collation)
       ]
     end
 
@@ -1632,19 +1632,15 @@ if Code.ensure_loaded?(Postgrex) do
       null = Keyword.get(opts, :null)
       collation = Keyword.fetch(opts, :collation)
 
-      [default_expr(default, type), null_expr(null), collation_expr(collation, type)]
+      [default_expr(default, type), null_expr(null), collation_expr(collation)]
     end
 
     defp null_expr(false), do: " NOT NULL"
     defp null_expr(true), do: " NULL"
     defp null_expr(_), do: []
 
-    defp collation_expr({:ok, collation_name}, text_type)
-         when text_type in ~w/string text char varchar/a do
-      " COLLATE \"#{collation_name}\""
-    end
-
-    defp collation_expr(_, _), do: []
+    defp collation_expr({:ok, collation_name}), do: " COLLATE \"#{collation_name}\""
+    defp collation_expr(_), do: []
 
     defp new_constraint_expr(%Constraint{check: check} = constraint) when is_binary(check) do
       [

--- a/lib/ecto/adapters/tds/connection.ex
+++ b/lib/ecto/adapters/tds/connection.ex
@@ -1369,13 +1369,13 @@ if Code.ensure_loaded?(Tds) do
         quote_name(name),
         " ",
         reference_column_type(ref.type, opts),
-        column_options(table, name, ref.type, opts),
+        column_options(table, name, opts),
         reference_expr(ref, table, name)
       ]
     end
 
     defp column_definition(table, {:add, name, type, opts}) do
-      [quote_name(name), " ", column_type(type, opts), column_options(table, name, type, opts)]
+      [quote_name(name), " ", column_type(type, opts), column_options(table, name, opts)]
     end
 
     defp column_changes(statement, table, columns) do
@@ -1396,7 +1396,7 @@ if Code.ensure_loaded?(Tds) do
           quote_name(name),
           " ",
           reference_column_type(ref.type, opts),
-          column_options(table, name, ref.type, opts),
+          column_options(table, name, opts),
           "; "
         ],
         [statement_prefix, "ADD", constraint_expr(ref, table, name), "; "]
@@ -1411,7 +1411,7 @@ if Code.ensure_loaded?(Tds) do
           quote_name(name),
           " ",
           column_type(type, opts),
-          column_options(table, name, type, opts),
+          column_options(table, name, opts),
           "; "
         ]
       ]
@@ -1430,7 +1430,7 @@ if Code.ensure_loaded?(Tds) do
           quote_name(column_name),
           " ",
           column_type(type, opts),
-          column_options(table, column_name, type, opts),
+          column_options(table, column_name, opts),
           "; "
         ]
       ]
@@ -1446,7 +1446,7 @@ if Code.ensure_loaded?(Tds) do
           quote_name(name),
           " ",
           reference_column_type(ref.type, opts),
-          column_options(table, name, ref.type, opts),
+          column_options(table, name, opts),
           "; "
         ],
         [statement_prefix, "ADD", constraint_expr(ref, table, name), "; "],
@@ -1467,7 +1467,7 @@ if Code.ensure_loaded?(Tds) do
           " ",
           column_type(type, opts),
           null_expr(Keyword.get(opts, :null)),
-          collation_expr(collation, type),
+          collation_expr(collation),
           "; "
         ],
         [column_default_value(statement_prefix, table, name, opts)]
@@ -1500,14 +1500,12 @@ if Code.ensure_loaded?(Tds) do
       ]
     end
 
-    defp column_options(table, name, type, opts) do
+    defp column_options(table, name, opts) do
       default = Keyword.fetch(opts, :default)
       null = Keyword.get(opts, :null)
+      collation = Keyword.fetch(opts, :collation)
 
-      collation =
-        Keyword.fetch(opts, :collation)
-
-      [null_expr(null), default_expr(table, name, default), collation_expr(collation, type)]
+      [null_expr(null), default_expr(table, name, default), collation_expr(collation)]
     end
 
     defp column_default_value(statement_prefix, table, name, opts) do
@@ -1523,12 +1521,8 @@ if Code.ensure_loaded?(Tds) do
     defp null_expr(true), do: [" NULL"]
     defp null_expr(_), do: []
 
-    defp collation_expr({:ok, collation_name}, text_type)
-         when text_type in ~w/string char varchar nchar nvarchar text ntext/a do
-      " COLLATE #{collation_name}"
-    end
-
-    defp collation_expr(_, _), do: []
+    defp collation_expr({:ok, collation_name}), do: " COLLATE #{collation_name}"
+    defp collation_expr(_), do: []
 
     defp default_expr(_table, _name, {:ok, nil}),
       do: []

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -278,7 +278,7 @@ defmodule Ecto.Migration do
 
   Collations can be set on a column with the option `:collation`. This can be
   useful when relying on ASCII sorting of characters when using a fractional index
-  for example. All supported collations and types that suuport setting a collocation
+  for example. All supported collations and types that support setting a collocation
   are not known by `ecto_sql` and specifying an incorrect collation or a collation on
   an unsupported type might cause a migration to fail. Be sure to match the collation
   on any column that references another column.

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -276,13 +276,12 @@ defmodule Ecto.Migration do
 
   ## Collations
 
-  For columns with a text type, the collation can be set on the column with the
-  option `:collation`. This can be useful when relying on ASCII sorting of
-  characters when using a fractional index for example. All supported collations
-  are not known by `ecto_sql` and specifying an incorrect collation might cause
-  a migration to fail.
-
-  ### N.B. be sure to match the collation on any columns that reference other text columns. See example below
+  Collations can be set on a column with the option `:collation`. This can be
+  useful when relying on ASCII sorting of characters when using a fractional index
+  for example. All supported collations and types that suuport setting a collocation
+  are not known by `ecto_sql` and specifying an incorrect collation or a collation on
+  an unsupported type might cause a migration to fail. Be sure to match the collation
+  on any column that references another column.
 
       def change do
         create table(:collate_reference) do

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -274,6 +274,27 @@ defmodule Ecto.Migration do
 
           config :app, App.Repo, migration_default_prefix: "my_prefix"
 
+  ## Collations
+
+  For columns with a text type, the collation can be set on the column with the
+  option `:collation`. This can be useful when relying on ASCII sorting of
+  characters when using a fractional index for example. All supported collations
+  are not known by `ecto_sql` and specifying an incorrect collation might cause
+  a migration to fail.
+
+  ### N.B. be sure to match the collation on any columns that reference other text columns. See example below
+
+      def change do
+        create table(:collate_reference) do
+          add :name, :string, collation: "POSIX"
+        end
+
+        create table(:collate) do
+          add :string, :string, collation: "POSIX"
+          add :name_ref, references(:collate_reference, type: :string, column: :name), collation: "POSIX"
+        end
+      end
+
   ## Comments
 
   Migrations where you create or alter a table support specifying table
@@ -1166,6 +1187,7 @@ defmodule Ecto.Migration do
       specified.
     * `:scale` - the scale of a numeric type. Defaults to `0`.
     * `:comment` - adds a comment to the added column.
+    * `:collation` - the collation of the text type.
     * `:after` - positions field after the specified one. Only supported on MySQL,
       it is ignored by other databases.
     * `:generated` - a string representing the expression for a generated column. See
@@ -1345,6 +1367,7 @@ defmodule Ecto.Migration do
       specified.
     * `:scale` - the scale of a numeric type. Defaults to `0`.
     * `:comment` - adds a comment to the modified column.
+    * `:collation` - the collation of the text type.
   """
   def modify(column, type, opts \\ []) when is_atom(column) and is_list(opts) do
     validate_precision_opts!(opts, column)


### PR DESCRIPTION
I found this was missing when I added [fractional indexes](https://github.com/varunrau/fractional_index/tree/master?tab=readme-ov-file) in my application. The default en_US-UTF8 collation will sort "Zy" after "a0". After setting the collation on the columns manually to "POSIX" the sorting worked as expected.

If there is interest to pull this into `ecto_sql` I will add documentation and support for MySQL and MSSQL as well.