### PR TITLE
Allow MyXQL to decode array fields using `:json` columns types in MariaDB.

### DIFF
--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -159,6 +159,7 @@ defmodule Ecto.Adapters.MyXQL do
   ## Custom MySQL types
 
   @impl true
+  def loaders({:array, _}, type), do: [&json_decode/1, type]
   def loaders({:map, _}, type), do: [&json_decode/1, &Ecto.Type.embedded_load(type, &1, :json)]
   def loaders(:map, type), do: [&json_decode/1, type]
   def loaders(:float, type), do: [&float_decode/1, type]


### PR DESCRIPTION
This change allows to use `:json` type columns to store an arrays of elements in MariaDB-backed applications.

For MySQL databases it was already working because that engine supports a `json` column type, but for MariaDB it is created as `longtext` because the engine does not properly support JSON.

That difference avoided `ecto_sql` to be able to load those values from the database, causing an exception.

Closes #667 