### PR TITLE
Auto-convert spaces to underscores in migration names

### DIFF
--- a/lib/mix/tasks/ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto.gen.migration.ex
@@ -65,10 +65,11 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
 
     Enum.map(repos, fn repo ->
       case OptionParser.parse!(args, strict: @switches, aliases: @aliases) do
-        {opts, [name]} ->
+        {opts, [name | rest]} ->
           ensure_repo(repo, args)
           path = opts[:migrations_path] || Path.join(source_repo_priv(repo), "migrations")
-          normalized_name = normalize_migration_name(name)
+          full_name = Enum.join([name | rest], " ")
+          normalized_name = normalize_migration_name(full_name)
           base_name = "#{underscore(normalized_name)}.exs"
           file = Path.join(path, "#{timestamp()}_#{base_name}")
           unless File.dir?(path), do: create_directory(path)

--- a/test/mix/tasks/ecto.gen.migration_test.exs
+++ b/test/mix/tasks/ecto.gen.migration_test.exs
@@ -57,7 +57,7 @@ defmodule Mix.Tasks.Ecto.Gen.MigrationTest do
   end
 
   test "converts spaces to underscores in migration name" do
-    [path] = run(["-r", to_string(Repo), "add posts table"])
+    [path] = run(["-r", to_string(Repo), "add", "posts", "table"])
     assert Path.basename(path) =~ ~r/^\d{14}_add_posts_table\.exs$/
 
     assert_file(path, fn file ->
@@ -65,20 +65,30 @@ defmodule Mix.Tasks.Ecto.Gen.MigrationTest do
     end)
   end
 
-  test "handles multiple spaces and edge cases in migration names" do
-    [path1] = run(["-r", to_string(Repo), "  add   posts   table  "])
-    assert Path.basename(path1) =~ ~r/^\d{14}_add_posts_table\.exs$/
+  test "handles multiple arguments as migration name components" do
+    [path1] = run(["-r", to_string(Repo), "add", "posts", "table", "with", "index"])
+    assert Path.basename(path1) =~ ~r/^\d{14}_add_posts_table_with_index\.exs$/
 
-    [path2] = run(["-r", to_string(Repo), "create user accounts"])
+    [path2] = run(["-r", to_string(Repo), "create", "user", "accounts"])
     assert Path.basename(path2) =~ ~r/^\d{14}_create_user_accounts\.exs$/
 
     assert_file(path1, fn file ->
-      assert file =~ "defmodule Mix.Tasks.Ecto.Gen.MigrationTest.Repo.Migrations.AddPostsTable do"
+      assert file =~
+               "defmodule Mix.Tasks.Ecto.Gen.MigrationTest.Repo.Migrations.AddPostsTableWithIndex do"
     end)
 
     assert_file(path2, fn file ->
       assert file =~
                "defmodule Mix.Tasks.Ecto.Gen.MigrationTest.Repo.Migrations.CreateUserAccounts do"
+    end)
+  end
+
+  test "handles edge cases in migration name normalization" do
+    [path] = run(["-r", to_string(Repo), "  add   posts   table  "])
+    assert Path.basename(path) =~ ~r/^\d{14}_add_posts_table\.exs$/
+
+    assert_file(path, fn file ->
+      assert file =~ "defmodule Mix.Tasks.Ecto.Gen.MigrationTest.Repo.Migrations.AddPostsTable do"
     end)
   end
 

--- a/test/mix/tasks/ecto.gen.migration_test.exs
+++ b/test/mix/tasks/ecto.gen.migration_test.exs
@@ -56,6 +56,32 @@ defmodule Mix.Tasks.Ecto.Gen.MigrationTest do
     assert name =~ ~r/^\d{14}_my_migration\.exs$/
   end
 
+  test "converts spaces to underscores in migration name" do
+    [path] = run(["-r", to_string(Repo), "add posts table"])
+    assert Path.basename(path) =~ ~r/^\d{14}_add_posts_table\.exs$/
+
+    assert_file(path, fn file ->
+      assert file =~ "defmodule Mix.Tasks.Ecto.Gen.MigrationTest.Repo.Migrations.AddPostsTable do"
+    end)
+  end
+
+  test "handles multiple spaces and edge cases in migration names" do
+    [path1] = run(["-r", to_string(Repo), "  add   posts   table  "])
+    assert Path.basename(path1) =~ ~r/^\d{14}_add_posts_table\.exs$/
+
+    [path2] = run(["-r", to_string(Repo), "create user accounts"])
+    assert Path.basename(path2) =~ ~r/^\d{14}_create_user_accounts\.exs$/
+
+    assert_file(path1, fn file ->
+      assert file =~ "defmodule Mix.Tasks.Ecto.Gen.MigrationTest.Repo.Migrations.AddPostsTable do"
+    end)
+
+    assert_file(path2, fn file ->
+      assert file =~
+               "defmodule Mix.Tasks.Ecto.Gen.MigrationTest.Repo.Migrations.CreateUserAccounts do"
+    end)
+  end
+
   test "custom migrations_path" do
     dir = Path.join([unquote(tmp_path), "custom_migrations"])
     [path] = run(["-r", to_string(Repo), "--migrations-path", dir, "custom_path"])


### PR DESCRIPTION
## Summary
Auto-converts spaces to underscores in migration names for `mix ecto.gen.migration`, improving user experience by handling common input patterns automatically.

## Changes
- Modified `Mix.Tasks.Ecto.Gen.Migration` to automatically replace spaces with underscores
- Added `normalize_migration_name/1` function to handle the conversion
- Added comprehensive tests for the new functionality
- Maintained backward compatibility and existing validation

## Motivation
Similar to ORMs like Prisma, this provides better UX by automatically handling spaces in migration names instead of showing a validation error. Users can now run:

```bash
# Before (would error)
mix ecto.gen.migration add posts table

# After (works automatically)
mix ecto.gen.migration add posts table
# Generates: 20240628120000_add_posts_table.exs
```

## Testing
- [x] All existing tests pass
- [x] New tests added for space conversion functionality
- [x] Edge cases tested (multiple spaces, leading/trailing spaces)
- [x] Module name generation verified
- [x] Backward compatibility maintained