### PR TITLE
Add `:rollback` option to explain

### DIFF
--- a/integration_test/myxql/explain_test.exs
+++ b/integration_test/myxql/explain_test.exs
@@ -42,5 +42,19 @@ defmodule Ecto.Integration.ExplainTest do
       assert Enum.member?(keys, "select_id")
       assert Enum.member?(keys, "table")
     end
+
+    test "explain without rolling back" do
+      TestRepo.insert!(%Post{})
+      assert [%Post{}] = TestRepo.all(Post)
+
+      {:ok, {:ok, explain}} =
+        TestRepo.transaction(fn ->
+          TestRepo.explain(:delete_all, Post, analyze: true, rollback: false, timeout: 20000)
+        end)
+
+      assert explain =~ "DELETE"
+      assert explain =~ "p0"
+      assert TestRepo.all(Post) == []
+    end
   end
 end

--- a/integration_test/pg/explain_test.exs
+++ b/integration_test/pg/explain_test.exs
@@ -81,4 +81,18 @@ defmodule Ecto.Integration.ExplainTest do
     assert explain =~ ~r/Node Type:/
     assert explain =~ ~r/Relation Name:/
   end
+
+  test "explain without rolling back" do
+    TestRepo.insert!(%Post{})
+    assert [%Post{}] = TestRepo.all(Post)
+
+    {:ok, {:ok, explain}} =
+      TestRepo.transaction(fn ->
+        TestRepo.explain(:delete_all, Post, analyze: true, rollback: false, timeout: 20000)
+      end)
+
+    assert explain =~ "Delete on posts p0"
+    assert explain =~ "cost="
+    assert TestRepo.all(Post) == []
+  end
 end

--- a/integration_test/tds/explain_test.exs
+++ b/integration_test/tds/explain_test.exs
@@ -32,5 +32,19 @@ defmodule Ecto.Integration.ExplainTest do
         TestRepo.explain(:all, from(p in "posts", select: p.invalid, where: p.invalid == "title"))
       end)
     end
+
+    test "explain without rolling back" do
+      TestRepo.insert!(%Post{})
+      assert [%Post{}] = TestRepo.all(Post)
+
+      {:ok, {:ok, explain}} =
+        TestRepo.transaction(fn ->
+          TestRepo.explain(:delete_all, Post, analyze: true, rollback: false, timeout: 20000)
+        end)
+
+      assert explain =~ "DELETE"
+      assert explain =~ "p0"
+      assert TestRepo.all(Post) == []
+    end
   end
 end


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/ecto/issues/4641

There were two options discussed:

1. Add this option
2. Don't rollback when `analyze: false`

I went for the first option for two reasons:

- The transaction code is shared by any non-standard adapter so trying to make less assumptions about what the correct behaviour should be 
- It's more flexible allowing the user to not roll back if they want to use `analyze: true`