### PR TITLE
Allow explicitly passing a dynamic repo to `Ecto.Adapters.SQL.Sandbox.checkout/1`

### DIFF
--- a/lib/ecto/adapters/sql/sandbox.ex
+++ b/lib/ecto/adapters/sql/sandbox.ex
@@ -646,8 +646,11 @@ defmodule Ecto.Adapters.SQL.Sandbox do
     meta
   end
 
-  defp find_repo(repo) when is_atom(repo), do: repo.get_dynamic_repo()
-  defp find_repo(repo), do: repo
+  defp find_repo(repo) do
+    if is_atom(repo) and Code.ensure_loaded?(repo),
+      do: repo.get_dynamic_repo(),
+      else: repo
+  end
 
   defp post_checkout(conn_mod, conn_state, opts) do
     case conn_mod.handle_begin([mode: :transaction] ++ opts, conn_state) do


### PR DESCRIPTION
As discussed in [this Elixir Forum post](https://elixirforum.com/t/why-do-i-need-to-manually-checkout-the-connection-when-using-a-dynamic-repo-in-tests/72202/5), I encountered issues when testing with a **dynamic repo**.

This PR allows explicitly passing a dynamic repo to both `Ecto.Adapters.SQL.Sandbox.checkout/1` and `Ecto.Adapters.SQL.Sandbox.start_owner!/1`.

With this change, I can change my `DataCase` setup as follows:

```elixir
def setup_sandbox(tags) do
  pid = SQL.Sandbox.start_owner!(Hello.Repo.get_dynamic_repo(), shared: not tags[:async])
  on_exit(fn -> SQL.Sandbox.stop_owner(pid) end)
end
```

This enables proper testing of **dynamic repos** without manual connection management.