### PR TITLE
Only log 'forward' and 'backward' for 'change/0'

### DIFF
--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -21,7 +21,9 @@ defmodule Ecto.Migration.Runner do
     {:ok, runner} = DynamicSupervisor.start_child(Ecto.MigratorSupervisor, {__MODULE__, args})
     metadata(runner, opts)
 
-    log(level, "== Running #{version} #{inspect(module)}.#{operation}/0 #{direction}")
+    direction_msg = if operation == :change, do: " #{direction}", else: nil
+
+    log(level, "== Running #{version} #{inspect(module)}.#{operation}/0#{direction_msg}")
     {time, _} = :timer.tc(fn -> perform_operation(repo, module, operation) end)
     log(level, "== Migrated #{version} in #{inspect(div(time, 100_000) / 10)}s")
   after

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -327,7 +327,7 @@ defmodule Ecto.MigratorTest do
         :ok = up(TestRepo, 12, UpDownMigration)
       end)
 
-    assert output =~ "== Running 12 Ecto.MigratorTest.UpDownMigration.up/0 forward"
+    assert output =~ "== Running 12 Ecto.MigratorTest.UpDownMigration.up/0"
     assert output =~ "alter table posts"
     assert output =~ ~r"== Migrated 12 in \d.\ds"
 
@@ -336,7 +336,7 @@ defmodule Ecto.MigratorTest do
         :ok = down(TestRepo, 12, UpDownMigration)
       end)
 
-    assert output =~ "== Running 12 Ecto.MigratorTest.UpDownMigration.down/0 forward"
+    assert output =~ "== Running 12 Ecto.MigratorTest.UpDownMigration.down/0"
     assert output =~ "execute \"foo\""
     assert output =~ ~r"== Migrated 12 in \d.\ds"
   end


### PR DESCRIPTION
Existing logs like "running down/0 forward" look confusing, IMO. Only `change/0` can be run backward or forward.