### PR TITLE
feat: Commandline switch to generate .ex migration files.

### DIFF
--- a/lib/mix/tasks/ecto.gen.migration.ex
+++ b/lib/mix/tasks/ecto.gen.migration.ex
@@ -17,7 +17,8 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
     repo: [:string, :keep],
     no_compile: :boolean,
     no_deps_check: :boolean,
-    migrations_path: :string
+    migrations_path: :string,
+    generate_ex: :boolean
   ]
 
   @moduledoc """
@@ -48,6 +49,8 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
     * `--no-compile` - does not compile applications before running
     * `--no-deps-check` - does not check dependencies before running
     * `--migrations-path` - the path to run the migrations from, defaults to `priv/repo/migrations`
+    * `--generate-ex` - Whether script files (`.exs`, default migrations) or compiled files
+      (`.ex`, useful for runtime migrations) are generated.
 
   ## Configuration
 
@@ -68,7 +71,8 @@ defmodule Mix.Tasks.Ecto.Gen.Migration do
         {opts, [name]} ->
           ensure_repo(repo, args)
           path = opts[:migrations_path] || Path.join(source_repo_priv(repo), "migrations")
-          base_name = "#{underscore(name)}.exs"
+          extension = if opts[:generate_ex], do: "ex", else: "exs"
+          base_name = "#{underscore(name)}.#{extension}"
           file = Path.join(path, "#{timestamp()}_#{base_name}")
           unless File.dir?(path), do: create_directory(path)
 

--- a/test/mix/tasks/ecto.gen.migration_test.exs
+++ b/test/mix/tasks/ecto.gen.migration_test.exs
@@ -73,4 +73,10 @@ defmodule Mix.Tasks.Ecto.Gen.MigrationTest do
   test "raises when missing file" do
     assert_raise Mix.Error, fn -> run(["-r", to_string(Repo)]) end
   end
+
+  test "generates a new migration with a .ex extension" do
+    [path] = run(["-r", to_string(Repo), "--generate-ex", "my_compiled_migration"])
+    assert Path.dirname(path) == @migrations_path
+    assert Path.basename(path) =~ ~r/^\d{14}_my_compiled_migration\.ex$/
+  end
 end


### PR DESCRIPTION
This PR adds a new migration option `--generate-ex` to generate `.ex` files instead of the default `.exs`. This is useful when running migrations concurrently at runtime, as the Code server does not support compiling the same module concurrently.