### PR TITLE
Map postgres :restrict_violation to :foreign_key constraint

### DIFF
--- a/lib/ecto/adapters/postgres/connection.ex
+++ b/lib/ecto/adapters/postgres/connection.ex
@@ -29,6 +29,12 @@ if Code.ensure_loaded?(Postgrex) do
         do: [foreign_key: constraint]
 
     def to_constraints(
+          %Postgrex.Error{postgres: %{code: :restrict_violation, constraint: constraint}},
+          _opts
+        ),
+        do: [foreign_key: constraint]
+
+    def to_constraints(
           %Postgrex.Error{postgres: %{code: :exclusion_violation, constraint: constraint}},
           _opts
         ),


### PR DESCRIPTION
In PostgreSQL 18, this error code is now used for `ON DELETE RESTRICT` constraint violation. The existing `:foreign_key_violation` error code is raised for `ON DELETE NO ACTION`.

The behaviour changed in postgres commit
https://github.com/postgres/postgres/commit/086c84b23d99c2ad268f97508cd840efc1fdfd79

The change is backwards compatible as the error code was not previously raised even though it existed in the postgres documentation. It is now correctly raised for the `ON DELETE RESTRICT` constraint.

Resolves #712 

The example provided in the ISSUE now correctly returns a changeset instead of raising:

```
{:error,
 #Ecto.Changeset<
   action: :delete,
   changes: %{},
   errors: [
     children: {"does not exist",
      [constraint: :foreign, constraint_name: "child_parent_id_fkey"]}
   ],
   data: #Foo.Parent<>,
   valid?: false,
   ...
 >}
```
