### PR TITLE
Fix type errors in tests

### DIFF
--- a/test/ecto/adapters/myxql_test.exs
+++ b/test/ecto/adapters/myxql_test.exs
@@ -1011,7 +1011,7 @@ defmodule Ecto.Adapters.MyXQLTest do
 
     assert_raise ArgumentError, ":select is not supported in update_all by MySQL", fn ->
       query = from(e in Schema, where: e.x == 123, select: e.x)
-      update_all(query)
+      update_all(Process.get(:unused, query))
     end
   end
 
@@ -1066,7 +1066,7 @@ defmodule Ecto.Adapters.MyXQLTest do
 
     assert_raise ArgumentError, ":select is not supported in delete_all by MySQL", fn ->
       query = from(e in Schema, where: e.x == 123, select: e.x)
-      delete_all(query)
+      delete_all(Process.get(:unused, query))
     end
   end
 


### PR DESCRIPTION
On 1.20.0-rc.1:

```elixir
warning: incompatible types given to update_all/1:

          update_all(query)

      given types:

          dynamic(%Ecto.Query{
            prefix: nil,
            sources: nil,
            from: %Ecto.Query.FromExpr{
              source: {term(), Ecto.Adapters.MyXQLTest.Schema},
              file: binary(),
              line: integer(),
              as: nil,
              params: empty_list(),
              hints: empty_list()
            },
            joins: empty_list(),
            aliases: empty_map(),
            wheres:
              non_empty_list(%Ecto.Query.BooleanExpr{
                op: :and,
                expr:
                  {:==, empty_list(),
                   non_empty_list(
                     %Ecto.Query.Tagged{tag: nil, type: {integer(), :x}, value: integer()} or
                       {{:., empty_list(),
                         non_empty_list(:x or {:&, empty_list(), non_empty_list(integer())})}, empty_list(),
                        empty_list()}
                   )},
                file: binary(),
                line: integer(),
                params: empty_list(),
                subqueries: empty_list()
              }),
            select: %Ecto.Query.SelectExpr{
              expr:
                {{:., empty_list(), non_empty_list(:x or {:&, empty_list(), non_empty_list(integer())})},
                 empty_list(), empty_list()},
              file: binary(),
              line: integer(),
              fields: nil,
              params: empty_list(),
              take: empty_map(),
              subqueries: empty_list(),
              aliases: empty_map()
            },
            order_bys: empty_list(),
            limit: nil,
            offset: nil,
            group_bys: empty_list(),
            combinations: empty_list(),
            updates: empty_list(),
            havings: empty_list(),
            preloads: empty_list(),
            assocs: empty_list(),
            distinct: nil,
            lock: nil,
            windows: empty_list(),
            with_ctes: nil
          })

      but expected one of:

          %{
            ...,
            from: %{..., source: term()},
            joins: term(),
            select: term(),
            sources: {...},
            wheres: empty_list() or non_empty_list(term(), term()),
            with_ctes: term()
          }

      where "query" was given the type:

          # type: dynamic(%Ecto.Query{
            prefix: nil,
            sources: nil,
            from: %Ecto.Query.FromExpr{
              source: {term(), Ecto.Adapters.MyXQLTest.Schema},
              file: binary(),
              line: integer(),
              as: nil,
              params: empty_list(),
              hints: empty_list()
            },
            joins: empty_list(),
            aliases: empty_map(),
            wheres:
              non_empty_list(%Ecto.Query.BooleanExpr{
                op: :and,
                expr:
                  {:==, empty_list(),
                   non_empty_list(
                     %Ecto.Query.Tagged{tag: nil, type: {integer(), :x}, value: integer()} or
                       {{:., empty_list(),
                         non_empty_list(:x or {:&, empty_list(), non_empty_list(integer())})}, empty_list(),
                        empty_list()}
                   )},
                file: binary(),
                line: integer(),
                params: empty_list(),
                subqueries: empty_list()
              }),
            select: %Ecto.Query.SelectExpr{
              expr:
                {{:., empty_list(), non_empty_list(:x or {:&, empty_list(), non_empty_list(integer())})},
                 empty_list(), empty_list()},
              file: binary(),
              line: integer(),
              fields: nil,
              params: empty_list(),
              take: empty_map(),
              subqueries: empty_list(),
              aliases: empty_map()
            },
            order_bys: empty_list(),
            limit: nil,
            offset: nil,
            group_bys: empty_list(),
            combinations: empty_list(),
            updates: empty_list(),
            havings: empty_list(),
            preloads: empty_list(),
            assocs: empty_list(),
            distinct: nil,
            lock: nil,
            windows: empty_list(),
            with_ctes: nil
          })
          # from: test/ecto/adapters/myxql_test.exs:1013:13
          query = %{
            offset: nil,
            select: %Ecto.Query.SelectExpr{
              ...,
              expr: {{:., [], [{:&, [], [0]}, :x]}, [], []},
              file: "/Users/sabiwara/sabiwara/clones/ecto_sql/test/ecto/adapters/myxql_test.exs",
              line: 1013,
              take: %{},
              aliases: %{}
            },
            sources: nil,
            windows: [],
            prefix: nil,
            aliases: %{},
            lock: nil,
            limit: nil,
            __struct__: Ecto.Query,
            from: %Ecto.Query.FromExpr{
              ...,
              source: {Ecto.Adapters.MyXQLTest.Schema.__schema__(:source), Ecto.Adapters.MyXQLTest.Schema},
              prefix: Ecto.Adapters.MyXQLTest.Schema.__schema__(:prefix),
              file: "/Users/sabiwara/sabiwara/clones/ecto_sql/test/ecto/adapters/myxql_test.exs",
              line: 1013
            },
            updates: [],
            preloads: [],
            assocs: [],
            order_bys: [],
            havings: [],
            group_bys: [],
            distinct: nil,
            combinations: [],
            joins: [],
            wheres: [
              %Ecto.Query.BooleanExpr{
                ...,
                expr:
                  {:==, [],
                   [
                     {{:., [], [{:&, [], [0]}, :x]}, [], []},
                     %Ecto.Query.Tagged{..., value: 123, type: {0, :x}}
                   ]},
                op: :and,
                file: "/Users/sabiwara/sabiwara/clones/ecto_sql/test/ecto/adapters/myxql_test.exs",
                line: 1013
              }
            ],
            with_ctes: nil
          }

      typing violation found at:
      │
 1014 │       update_all(query)
      │       ~
      │
      └─ test/ecto/adapters/myxql_test.exs:1014:7: Ecto.Adapters.MyXQLTest."test update all"/1
```