### PR TITLE
MySQL Load: Combine sql and exit signal in one port command

### DIFF
--- a/lib/ecto/adapters/myxql.ex
+++ b/lib/ecto/adapters/myxql.ex
@@ -589,10 +589,8 @@ defmodule Ecto.Adapters.MyXQL do
     ]
 
     port = Port.open({:spawn_executable, abs_cmd}, port_opts)
-
-    port ! {self(), {:command, contents}}
-    port ! {self(), {:command, ";SELECT '__ECTO_EOF__';\n"}}
-
+    send(port, {self(), {:command, contents}})
+    send(port, {self(), {:command, ";SELECT '__ECTO_EOF__';\n"}})
     collect_output(port, "")
   end
 


### PR DESCRIPTION
This should catch the case where we call `Port.command` the second time after the port has closed. [Our previous fix](https://github.com/elixir-ecto/ecto_sql/pull/723) caught the case where we have an issue with the first `Port.command` call sending data packets after it has been closed