### PR TITLE
Don't check if DBConnection is loaded.

### DIFF
--- a/lib/ecto/adapters/sql/sandbox.ex
+++ b/lib/ecto/adapters/sql/sandbox.ex
@@ -341,9 +341,7 @@ defmodule Ecto.Adapters.SQL.Sandbox do
 
   defmodule Connection do
     @moduledoc false
-    if Code.ensure_loaded?(DBConnection) do
-      @behaviour DBConnection
-    end
+    @behaviour DBConnection
 
     def connect(_opts) do
       raise "should never be invoked"


### PR DESCRIPTION
AFAICT,

- This check has been present [since the original commit](https://github.com/christhekeele/ecto_sql/blob/c3b56c70f67d51deef0855087cea1876647b3ed8/lib/ecto/adapters/sql/sandbox.ex#L312-L314) to `ecto_sql`
- But `DBConnection` has been a required dependency [since the original commit](https://github.com/christhekeele/ecto_sql/blob/c3b56c70f67d51deef0855087cea1876647b3ed8/mix.exs#L54)
- So this check has always been unnecessary since the repo was public, and is probably a remnant of an original prototype where it was an optional dependency